### PR TITLE
Characteristics Context Menu background not wide enough

### DIFF
--- a/src/rqg.scss
+++ b/src/rqg.scss
@@ -549,6 +549,7 @@
   }
 
   #context-menu {
+    width: fit-content;
     font-size: 14px;
     cursor: default;
     text-align: left;


### PR DESCRIPTION
Fixes #91
Just changed the width of the context menu to "fit-content".  All of the context menus were actually affected by this, but most of them didn't have items that were wide enough for it to be noticeable.