### PR TITLE
Remove linked RuneMagic when a Cult is deleted

### DIFF
--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -18,8 +18,8 @@ export default {
   optimize: {
     entrypoints: ["rqg.js", "template.js"],
     splitting: false,
-    // bundle: true,
-    // minify: true,
+    bundle: true,
+    minify: true,
     target: "es2020",
   },
   packageOptions: {},

--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -18,8 +18,8 @@ export default {
   optimize: {
     entrypoints: ["rqg.js", "template.js"],
     splitting: false,
-    bundle: true,
-    minify: true,
+    // bundle: true,
+    // minify: true,
     target: "es2020",
   },
   packageOptions: {},

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -250,9 +250,18 @@
       "CurrencyConversionTipOver1": "One {name} is worth {value} Lunars.",
       "CurrencyConversionTipLunar": "Lunars are the standard basis of currency.",
       "CurrencyConversionTipUnder1": "One Lunar is worth {value} {name}s."
+    },
+    "confirmItemDeleteDialog": {
+      "title": "Delete {itemType}: {itemName}",
+      "content": "Are you sure you want to delete the {itemType} named {itemName}?",
+      "contentCult": "Are you sure you want to delete the {itemType} named {itemName}? This will also delete all of the {runeMagicSpell} items associated with this {itemType}."
     }
   },
   "DIALOG": {
+    "Common": {
+      "btnCancel": "Cancel",
+      "btnConfirm": "Confirm"
+    },
     "improveAbilityDialog": {
       "title": "Improvement for {typeLocName} \"{name}\"",
       "titleChar": "Improvement for Characteristic \"{name}\"",

--- a/src/items/rqgItem.ts
+++ b/src/items/rqgItem.ts
@@ -121,22 +121,26 @@ export class RqgItem extends Item {
     const { parent, pack, ...options } = context;
     if (parent?.documentName === "Actor") {
       updates.forEach((u) => {
-        const document = parent.items.get(u._id);
-        if (!document || document.documentName !== "Item") {
-          const msg = "couldn't find item document from result";
-          ui.notifications?.error(msg);
-          throw new RqgError(msg, updates);
+        if (u && u.length > 0) {
+          const document = parent.items.get(u._id);
+          if (!document || document.documentName !== "Item") {
+            const msg = "couldn't find item document from result";
+            ui.notifications?.error(msg);
+            throw new RqgError(msg, updates);
+          }
+          // Will update "updates" as a side effect
+          ResponsibleItemClass.get(document.data.type)?.preUpdateItem(
+            parent,
+            document,
+            updates,
+            options
+          );
         }
-        // Will update "updates" as a side effect
-        ResponsibleItemClass.get(document.data.type)?.preUpdateItem(
-          parent,
-          document,
-          updates,
-          options
-        );
       });
     }
-    return super.updateDocuments(updates, context);
+    if (updates[0].length > 0) {
+      return super.updateDocuments(updates, context);
+    }
   }
 
   // Validate that embedded items are unique (name + type),
@@ -159,5 +163,11 @@ export class RqgItem extends Item {
     );
     const okToAdd = !isRuneMagic || !(isRuneMagic && !actorHasCult);
     return !okToAdd;
+  }
+
+  //** Localizes Item Type Name using ITEM localization used by Foundry.
+  //** See also  */
+  public static localizeItemTypeName(itemType: ItemTypeEnum): string {
+    return getGame().i18n.localize("ITEM.Type" + itemType.titleCase());
   }
 }

--- a/src/items/rqgItem.ts
+++ b/src/items/rqgItem.ts
@@ -138,7 +138,10 @@ export class RqgItem extends Item {
         }
       });
     }
-    if (updates[0].length > 0) {
+    
+    // updates[0] will be an empty array when deleting the cult
+    // and will have a "data" property if there are real updates
+    if ( updates[0].data !== undefined) {
       return super.updateDocuments(updates, context);
     }
   }

--- a/src/items/rqgItem.ts
+++ b/src/items/rqgItem.ts
@@ -169,7 +169,6 @@ export class RqgItem extends Item {
   }
 
   //** Localizes Item Type Name using ITEM localization used by Foundry.
-  //** See also  */
   public static localizeItemTypeName(itemType: ItemTypeEnum): string {
     return getGame().i18n.localize("ITEM.Type" + itemType.titleCase());
   }

--- a/src/system/registerHandlebarsHelpers.ts
+++ b/src/system/registerHandlebarsHelpers.ts
@@ -26,7 +26,7 @@ export const registerHandlebarsHelpers = function () {
   });
 
   Handlebars.registerHelper("localizeitemtype", (typeName) => {
-    const itemType: ItemTypeEnum = <ItemTypeEnum>typeName;
+    const itemType: ItemTypeEnum = typeName;
     return RqgItem.localizeItemTypeName(itemType);
   });
 

--- a/src/system/registerHandlebarsHelpers.ts
+++ b/src/system/registerHandlebarsHelpers.ts
@@ -1,6 +1,7 @@
 import { EquippedStatus } from "../data-model/item-data/IPhysicalItem";
 import { getActorFromIds, getAllRunesIndex, getGame, hasOwnProperty, RqgError } from "./util";
 import { ItemTypeEnum } from "../data-model/item-data/itemTypes";
+import { RqgItem } from "../items/rqgItem";
 
 export const registerHandlebarsHelpers = function () {
   Handlebars.registerHelper("concat", (...strs) =>
@@ -25,7 +26,8 @@ export const registerHandlebarsHelpers = function () {
   });
 
   Handlebars.registerHelper("localizeitemtype", (typeName) => {
-    return getGame().i18n.localize("ITEM.Type" + typeName.titleCase());
+    const itemType: ItemTypeEnum = <ItemTypeEnum>typeName;
+    return RqgItem.localizeItemTypeName(itemType);
   });
 
   Handlebars.registerHelper("skillname", (itemId, actorId, tokenId) => {


### PR DESCRIPTION
Fixes #128

- rqgActorSheet.confirmItemDelete now checks if the item is a Cult and if so displays a different message and if accepted deletes associated Rune Magic Spells.
- localization
- !!! rqgItem.updateDocuments required changes to ignore empty updates.  Is this going to affect other things?
- rqgItem.localizeItemTypeName now handles localizing values from ItemTypeEnum
- the "localizeitemtype" handlebars helper now uses rqgItem.localizeItemTypeName