### PR TITLE
Rename Rune experience to hasExperience

### DIFF
--- a/src/actors/rqgActorSheet.ts
+++ b/src/actors/rqgActorSheet.ts
@@ -1002,11 +1002,13 @@ export class RqgActorSheet extends ActorSheet<
                 console.log("CULT", item);
                 const cultId = item.id;
                 //@ts-ignore cultId
-                const runeMagicSpells = actor.items.filter(i => i.type === ItemTypeEnum.RuneMagic && i.data.data.cultId === cultId);
-                runeMagicSpells.forEach(s => {
-                  idsToDelete.push((s.id));
-                })
-              };
+                const runeMagicSpells = actor.items.filter(
+                  (i) => i.data.type === ItemTypeEnum.RuneMagic && i.data.data.cultId === cultId
+                );
+                runeMagicSpells.forEach((s) => {
+                  idsToDelete.push(s.id);
+                });
+              }
 
               idsToDelete.push(itemId);
 

--- a/src/data-model/item-data/runeData.ts
+++ b/src/data-model/item-data/runeData.ts
@@ -15,7 +15,6 @@ export interface RuneDataSourceData extends IAbility, JournalEntryLink {
   rune: string;
   runeType: RuneTypeEnum;
   chance: number;
-  experience: boolean;
   /** For Power Runes (+ Form: Man & Beast) ex: "Beast (form)" */
   opposingRune: string;
   /** For Sorcery - Elemental Runes & Techniques ex ["Air (elemental)", "Fire (elemental)"] */
@@ -41,7 +40,7 @@ export const emptyRune: RuneDataSourceData = {
   rune: "",
   chance: 0,
   canGetExperience: true,
-  experience: false,
+  hasExperience: false,
   runeType: RuneTypeEnum.Form,
   opposingRune: "",
   minorRunes: [],

--- a/src/items/rqgItem.ts
+++ b/src/items/rqgItem.ts
@@ -142,7 +142,7 @@ export class RqgItem extends Item {
     }
 
     // updates[0] will be an empty array when deleting the cult
-    // and will have a "data" property if there are real updates
+    // and an object if there are real updates
     if (Object.keys(updates[0]).length > 0) {
       return super.updateDocuments(updates, context);
     }

--- a/src/items/rqgItem.ts
+++ b/src/items/rqgItem.ts
@@ -140,10 +140,10 @@ export class RqgItem extends Item {
         }
       });
     }
-    
+
     // updates[0] will be an empty array when deleting the cult
     // and will have a "data" property if there are real updates
-    if ( updates[0].data !== undefined) {
+    if (Object.entries(updates[0]).length > 0) {
       return super.updateDocuments(updates, context);
     }
   }

--- a/src/items/rqgItem.ts
+++ b/src/items/rqgItem.ts
@@ -143,7 +143,7 @@ export class RqgItem extends Item {
 
     // updates[0] will be an empty array when deleting the cult
     // and will have a "data" property if there are real updates
-    if (Object.entries(updates[0]).length > 0) {
+    if (Object.keys(updates[0]).length > 0) {
       return super.updateDocuments(updates, context);
     }
   }

--- a/src/system/migrations/migrateWorld.ts
+++ b/src/system/migrations/migrateWorld.ts
@@ -1,7 +1,7 @@
-import { migrateItemDummy } from "./migrations-item/migrateItemDummy";
 import { getGame } from "../util";
 import { migrateActorDummy } from "./migrations-actor/migrateActorDummy";
 import { ActorMigration, applyMigrations, ItemMigration } from "./applyMigrations";
+import { changeRuneExperienceFieldName } from "./migrations-item/changeRuneExperienceFieldName";
 
 /**
  * Perform a system migration for the entire World, applying migrations for what is in it
@@ -31,7 +31,7 @@ export async function migrateWorld(): Promise<void> {
 }
 
 export async function applyDefaultWorldMigrations(): Promise<void> {
-  const worldItemMigrations: ItemMigration[] = [migrateItemDummy];
+  const worldItemMigrations: ItemMigration[] = [changeRuneExperienceFieldName];
   const worldActorMigrations: ActorMigration[] = [migrateActorDummy];
 
   await applyMigrations(worldItemMigrations, worldActorMigrations);

--- a/src/system/migrations/migrations-item/changeRuneExperienceFieldName.ts
+++ b/src/system/migrations/migrations-item/changeRuneExperienceFieldName.ts
@@ -1,0 +1,18 @@
+import { ItemTypeEnum } from "../../../data-model/item-data/itemTypes";
+import { ItemData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs";
+import { ItemUpdate } from "../applyMigrations";
+import { deleteKeyPrefix } from "../../util";
+
+// Change data.experience to data.hasExperience
+export async function changeRuneExperienceFieldName(itemData: ItemData): Promise<ItemUpdate> {
+  const updateData: ItemUpdate = {};
+  if (itemData.type === ItemTypeEnum.Rune) {
+    // Always remove "experience" from runes
+    updateData.data = { [`${deleteKeyPrefix}experience`]: null };
+    if (itemData.data.hasExperience == null) {
+      // @ts-ignore experience
+      updateData.data.hasExperience = itemData.experience ?? false;
+    }
+  }
+  return updateData;
+}


### PR DESCRIPTION
I've manually gone through all starter-set runes and changed it there. This migration should go through all world compendiums, world items, items embedded in actors both in world and in scenes.

Normally this will be run when there is a new release, to force run the migration you can run `game.system.api.migrate()` in the console (alternatively lower the current version setting to force a migration to start)