### PR TITLE
Issue77-drag-items-between-actors

### DIFF
--- a/src/actors/item-specific/runeMagic.ts
+++ b/src/actors/item-specific/runeMagic.ts
@@ -23,9 +23,14 @@ export class RuneMagic extends AbstractEmbeddedItem {
     if (item.data.data.cultId) {
       const runeMagicCult = actor.items.get(item.data.data.cultId);
       if (!runeMagicCult || runeMagicCult.data.type !== ItemTypeEnum.Cult) {
-        const msg = localize("RQG.Item.Notification.ActorDoesNotHaveCultOnRuneMagicWarning");
-        ui.notifications?.warn(msg);
-        console.warn(msg, item, actor);
+        // This warning can happen when drag-dropping a rune spell from one Actor to another,
+        // but the notification happens a lot of times and doesn't really matter since the system immediately,
+        // displays the "Which cult provides this Rune Magic?" dialog allowing the player to fix it.
+
+        // const msg = localize("RQG.Item.Notification.ActorDoesNotHaveCultOnRuneMagicWarning");
+        // ui.notifications?.warn(msg);
+        // console.warn(msg, item, actor);
+
         item.data.data.cultId = ""; // remove the mismatched link to make it appear in the GUI
       }
       if (runeMagicCult && runeMagicCult.data.type === ItemTypeEnum.Cult) {
@@ -49,7 +54,9 @@ export class RuneMagic extends AbstractEmbeddedItem {
         (i) =>
           i.type === ItemTypeEnum.Rune &&
           (runeMagicRuneNames.includes(i.name ?? "") ||
-            (runeMagicRuneNames.includes(getGame().settings.get("rqg", "magicRuneName") as string) &&
+            (runeMagicRuneNames.includes(
+              getGame().settings.get("rqg", "magicRuneName") as string
+            ) &&
               cultRuneNames.includes(i.name ?? "")))
       )
       // @ts-ignore r is a runeItem TODO rewrite as reduce

--- a/src/actors/rqgActorSheet.ts
+++ b/src/actors/rqgActorSheet.ts
@@ -1195,7 +1195,9 @@ export class RqgActorSheet extends ActorSheet<
       // removed from the giver's inventory
       await this.confirmTransferPhysicalItem(itemData, sourceActor);
     } else {
-      // Prompt to ensure copy
+      // Prompt to ensure copy of non-physical items
+      // TODO: create dialog
+      // TODO: maybe a setting to enable/disable copying non-physical items?
       return this._onDropItemCreate(itemData);
     }
   }

--- a/src/actors/sheet-parts/combat.hbs
+++ b/src/actors/sheet-parts/combat.hbs
@@ -2,7 +2,7 @@
 <div class="flex-row flex-align-center">
   <label data-damage-roll="{{characterData.attributes.damageBonus}}">{{localize "RQG.Actor.Combat.DamageBonus"}} {{characterData.attributes.damageBonus}}</label>
 </div>
-<div class="grid combat">
+<div class="grid combat item-list">
   <div class="headings"></div>
   <div class="head1"></div>
   <div class="head2">{{localize "RQG.Actor.Combat.Weapon"}}</div>
@@ -14,8 +14,8 @@
   {{#each ownedItems.weapon}}
     {{#if (eq data.data.equippedStatus "equipped")}}
       {{#unless data.data.isNatural}}
-        <div data-item-id="{{data._id}}" class="combat contextmenu"><img class="item" src="{{img}}"></div>
-        <div data-item-id="{{data._id}}" class="combat contextmenu">{{name}}
+        <div data-item-id="{{data._id}}" class="combat contextmenu item"><img class="item" src="{{img}}"></div>
+        <div data-item-id="{{data._id}}" class="combat contextmenu item">{{name}}
           {{#if data.data.isProjectileWeapon}}
             ({{quantity data.data.projectileId @root.data._id @root.tokenId}})
           {{else if data.data.isThrownWeapon}}
@@ -24,7 +24,7 @@
             [{{data.data.quantity}}]
           {{/if}}
         </div>
-        <div data-item-id="{{data._id}}" class="combat contextmenu">
+        <div data-item-id="{{data._id}}" class="combat contextmenu item">
           {{#if data.data.hitPointLocation}}
             {{data.data.hitPointLocation}}
           {{else}}
@@ -32,7 +32,7 @@
                         value="{{data.data.hitPoints.value}}"> / {{data.data.hitPoints.max}}</label>
           {{/if}}
         </div>
-        <div>
+        <div class="item">
           <span class="flex-column text-right">
             {{#each data.data.usage}}
               {{#if skillId}}
@@ -46,7 +46,7 @@
             {{/each}}
           </span>
         </div>
-        <div>
+        <div class="item">
           <span class="flex-column">
             {{#each data.data.usage}}
               {{#if skillId}}
@@ -57,7 +57,7 @@
             {{/each}}
           </span>
         </div>
-        <div>
+        <div class="item">
           <span class="flex-column">
             {{#each data.data.usage}}
               {{#if skillId}}

--- a/src/actors/sheet-parts/condition.hbs
+++ b/src/actors/sheet-parts/condition.hbs
@@ -1,12 +1,12 @@
 {{#if ownedItems.rune.condition}}
-<div class="grid rune">
+<div class="grid rune item-list">
   <h2 class="fullrow">{{localize "RQG.Actor.Rune.Condition"}}</h2>
   {{#each ownedItems.rune.condition}}
-    <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{data.data.chance}}%</span>
     </div>
   {{/each}}

--- a/src/actors/sheet-parts/elemental.hbs
+++ b/src/actors/sheet-parts/elemental.hbs
@@ -1,12 +1,12 @@
-<div class="grid rune">
+<div class="grid rune item-list">
   <h2 class="fullrow">{{localize "RQG.Actor.Rune.Elemental"}}</h2>
   {{#each ownedItems.rune.element}}
-    <div data-item-id="{{id}}" class="rune contextmenu"
+    <div data-item-id="{{id}}" class="rune contextmenu item"
       {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{data.data.chance}}%</span>
     </div>
   {{/each}}

--- a/src/actors/sheet-parts/form.hbs
+++ b/src/actors/sheet-parts/form.hbs
@@ -1,22 +1,22 @@
-<div class="grid opposed-rune">
+<div class="grid opposed-rune item-list">
   <h2 class="fullrow">{{localize "RQG.Actor.Rune.Form"}}</h2>
 
   {{#with ownedItems.rune.form.Man}}
-    <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{data.data.chance}}%</span>
     </div>
   {{/with}}
   <i class="fas fa-arrows-alt-h"></i>
   {{#with ownedItems.rune.form.Beast}}
-    <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{data.data.chance}}%</span>
     </div>
   {{/with}}
@@ -25,11 +25,11 @@
   {{#unless (eq @key "Man")}}
   {{#unless (eq @key "Beast")}}
     {{#with this}}
-      <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+      <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
         <img class="rune" src="{{img}}">
       </div>
-      <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-      <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+      <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+      <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
         <span class="text-right">{{data.data.chance}}%</span>
       </div>
       <div></div>

--- a/src/actors/sheet-parts/gear-tab.hbs
+++ b/src/actors/sheet-parts/gear-tab.hbs
@@ -18,7 +18,7 @@
         <div class="head3"></div>
         <div class="head4" style="width:85px">{{localize "RQG.Actor.Gear.Location"}}</div>
       </div>
-      <ul class="location virtual">
+      <ul class="location virtual item-list">
         {{#each itemLocationTree.contains}}
         {{> "systems/rqg/actors/sheet-parts/physical-item-location.hbs"}}
         {{/each}}
@@ -31,7 +31,7 @@
       <!--Gear-->
       <article class="flex-1">
         <h2>{{localize "RQG.Actor.Gear.Gear"}}</h2>
-        <div class="grid gear">
+        <div class="grid gear item-list">
           <div class="headings"></div>
           <div class="head1"></div>
           <div class="head2">{{localize "RQG.Actor.Gear.Name"}}</div>
@@ -42,20 +42,20 @@
           <div class="head7">{{localize "RQG.Actor.Gear.Location"}}</div>
           {{#each ownedItems.gear}}
           {{#if (eq data.data.physicalItemType "unique")}}
-          <div data-item-id="{{id}}" class="gear contextmenu"><img class="item" src="{{img}}"></div>
-          <div data-item-id="{{id}}" class="gear contextmenu">{{name}}</div>
-          <div data-item-id="{{id}}" class="gear contextmenu">{{!-- TODO REMOVE QUANTITY --}}</div>
-          <div data-item-id="{{id}}" class="gear contextmenu">
+          <div data-item-id="{{id}}" class="gear contextmenu item"><img class="item" src="{{img}}"></div>
+          <div data-item-id="{{id}}" class="gear contextmenu item">{{name}}</div>
+          <div data-item-id="{{id}}" class="gear contextmenu item">{{!-- TODO REMOVE QUANTITY --}}</div>
+          <div data-item-id="{{id}}" class="gear contextmenu item">
             <span class="text-right">{{#if data.data.price.estimated}}{{currency data.data.price.estimated 'L'}}{{/if}}</span>
           </div>
-          <div data-item-id="{{id}}" class="gear contextmenu">
+          <div data-item-id="{{id}}" class="gear contextmenu item">
             <span class="text-right">{{multiply data.data.quantity data.data.encumbrance}}</span>
           </div>
-          <div data-item-id="{{id}}" data-item-equipped-toggle class="gear contextmenu">
+          <div data-item-id="{{id}}" data-item-equipped-toggle class="gear contextmenu item">
             <img class="equipped-status text-center" title="{{localize (concat "RQG.Item.EquippedStatus." data.data.equippedStatus)}}"
                  src="{{equippedIcon data.data.equippedStatus}}">
           </div>
-          <div data-item-id="{{id}}" class="gear contextmenu">
+          <div data-item-id="{{id}}" class="gear contextmenu item">
             <input type="text" list="locations" data-item-edit-value="data.location" value="{{data.data.location}}"
                    size="10">
           </div>
@@ -68,7 +68,7 @@
       <div class="flex-1">
         <article>
           <h2>{{localize "RQG.Actor.Gear.Currency"}}</h2>
-          <div class="grid gear">
+          <div class="grid gear item-list">
             <div class="headings"></div>
             <div class="head1"></div>
             <div class="head2">{{localize "RQG.Actor.Gear.Name"}}</div>
@@ -79,22 +79,22 @@
             <div class="head6"></div>
             <div class="head7">{{localize "RQG.Actor.Gear.Location"}}</div>
             {{#each ownedItems.currency}}
-            <div data-item-id="{{id}}" class="gear contextmenu"><img class="item" src="{{img}}"></div>
-            <div data-item-id="{{id}}" class="gear contextmenu" title="{{data.data.price.conversion}}">{{name}}</div>
-            <div data-item-id="{{id}}" class="gear contextmenu">
+            <div data-item-id="{{id}}" class="gear contextmenu item"><img class="item" src="{{img}}"></div>
+            <div data-item-id="{{id}}" class="gear contextmenu item" title="{{data.data.price.conversion}}">{{name}}</div>
+            <div data-item-id="{{id}}" class="gear contextmenu item">
               <span class="text-right"><input type="number" min="0" max="999999" data-item-edit-value="data.quantity" value="{{data.data.quantity}}"></span>
             </div>
-            <div data-item-id="{{id}}" class="gear contextmenu">
+            <div data-item-id="{{id}}" class="gear contextmenu item">
               <span class="text-right">{{#if data.data.price.estimated}}{{multiplyfixed2 data.data.quantity data.data.price.estimated}}&thinsp;L{{/if}}</span>
             </div>
-            <div data-item-id="{{id}}" class="gear contextmenu pad-left">
+            <div data-item-id="{{id}}" class="gear contextmenu pad-left item">
               <span class="text-right">{{multiplyfixed2 data.data.quantity data.data.encumbrance}}</span>
             </div>
-            <div data-item-id="{{id}}" data-item-equipped-toggle class="gear contextmenu">
+            <div data-item-id="{{id}}" data-item-equipped-toggle class="gear contextmenu item">
               <img class="equipped-status text-center" title="{{localize (concat "RQG.Item.EquippedStatus." data.data.equippedStatus)}}"
                    src="{{equippedIcon data.data.equippedStatus}}">
             </div>
-            <div data-item-id="{{id}}" class="gear contextmenu">
+            <div data-item-id="{{id}}" class="gear contextmenu item">
               <input type="text" list="locations" data-item-edit-value="data.location" value="{{data.data.location}}"
                      size="10">
             </div>
@@ -113,7 +113,7 @@
         <!--Consumables-->
         <article>
           <h2>{{localize "RQG.Actor.Gear.Consumables"}}</h2>
-          <div class="grid gear">
+          <div class="grid gear item-list">
             <div class="headings"></div>
             <div class="head1"></div>
             <div class="head2">{{localize "RQG.Actor.Gear.Name"}}</div>
@@ -124,22 +124,22 @@
             <div class="head7">{{localize "RQG.Actor.Gear.Location"}}</div>
             {{#each ownedItems.gear}}
             {{#if (eq data.data.physicalItemType "consumable")}}
-            <div data-item-id="{{id}}" class="gear contextmenu"><img class="item" src="{{img}}"></div>
-            <div data-item-id="{{id}}" class="gear contextmenu">{{name}}</div>
-            <div data-item-id="{{id}}" class="gear contextmenu">
+            <div data-item-id="{{id}}" class="gear contextmenu item"><img class="item" src="{{img}}"></div>
+            <div data-item-id="{{id}}" class="gear contextmenu item">{{name}}</div>
+            <div data-item-id="{{id}}" class="gear contextmenu item">
               <span class="text-right"><input type="number" min="0" max="999999" data-item-edit-value="data.quantity" value="{{data.data.quantity}}"></span>
             </div>
-            <div data-item-id="{{id}}" class="gear contextmenu">
+            <div data-item-id="{{id}}" class="gear contextmenu item">
               <span class="text-right">{{#if data.data.price.estimated}}{{currency data.data.price.estimated 'L'}}{{/if}}</span>
             </div>
-            <div data-item-id="{{id}}" class="gear contextmenu">
+            <div data-item-id="{{id}}" class="gear contextmenu item">
               <span class="text-right">{{multiply data.data.quantity data.data.encumbrance}}</span>
             </div>
-            <div data-item-id="{{id}}" data-item-equipped-toggle class="gear contextmenu">
+            <div data-item-id="{{id}}" data-item-equipped-toggle class="gear contextmenu item">
               <img class="equipped-status text-center" title="{{localize (concat "RQG.Item.EquippedStatus." data.data.equippedStatus)}}"
                    src="{{equippedIcon data.data.equippedStatus}}">
             </div>
-            <div data-item-id="{{id}}" class="gear contextmenu">
+            <div data-item-id="{{id}}" class="gear contextmenu item">
               <input type="text" list="locations" data-item-edit-value="data.location" value="{{data.data.location}}"
                      size="10">
             </div>
@@ -153,7 +153,7 @@
     <!-- Weapons & Shields-->
     <article>
       <h2>{{localize "RQG.Actor.Gear.WeaponsAndShields"}}</h2>
-      <div class="grid weapon">
+      <div class="grid weapon item-list">
         <div class="headings"></div>
         <div class="head1"></div>
         <div class="head2">{{localize "RQG.Actor.Gear.Name"}}</div>
@@ -169,11 +169,11 @@
 
         {{#each ownedItems.weapon}}
           {{#unless data.data.isNatural}}
-            <div data-item-id="{{id}}" class="gear contextmenu"><img class="item" src="{{img}}"></div>
-            <div data-item-id="{{id}}" class="gear contextmenu">{{name}}
+            <div data-item-id="{{id}}" class="gear contextmenu item"><img class="item" src="{{img}}"></div>
+            <div data-item-id="{{id}}" class="gear contextmenu item">{{name}}
               {{#if (eq data.data.physicalItemType "consumable")}} ({{data.data.quantity}}){{/if}}
             </div>
-            <div data-item-id="{{id}}" class="gear usagecontainer contextmenu nowrap">
+            <div data-item-id="{{id}}" class="gear usagecontainer contextmenu nowrap item">
               {{#each data.data.usage}}
                 {{#if skillId}}
                 <div class="usagecell {{#if unusable}} warning{{/if}}" {{#if unusable}}title="{{localize "RQG.Actor.Combat.StrDexMinsNotMetTip"}}"{{/if}}>
@@ -182,7 +182,7 @@
                 {{/if}}
               {{/each}}
             </div>
-            <div data-item-id="{{id}}" class="gear usagecontainer contextmenu">
+            <div data-item-id="{{id}}" class="gear usagecontainer contextmenu item">
               <span class="text-center">
               {{#each data.data.usage}}
                 {{#if skillId}}
@@ -193,7 +193,7 @@
               {{/each}}
               </span>
             </div>
-            <div data-item-id="{{id}}" class="gear usagecontainer contextmenu"><span class="text-right">
+            <div data-item-id="{{id}}" class="gear usagecontainer contextmenu item"><span class="text-right">
               {{#each data.data.usage}}
                 {{#if skillId}}
                   <div class="usagecell {{#if underMinSTR}} warning{{/if}}" {{#if underMinSTR}}title="{{localize "RQG.Actor.Combat.StrMinNotMetTip"}}"{{/if}}>
@@ -203,7 +203,7 @@
               {{/each}}
             </span>
             </div>
-            <div data-item-id="{{id}}" class="gear usagecontainer contextmenu">
+            <div data-item-id="{{id}}" class="gear usagecontainer contextmenu item">
               <span class="text-right">
               {{#each data.data.usage}}
                 {{#if skillId}}
@@ -214,19 +214,19 @@
               {{/each}}
               </span>
             </div>
-            <div data-item-id="{{id}}" class="gear contextmenu"><span
+            <div data-item-id="{{id}}" class="gear contextmenu item"><span
               class="text-right">{{data.data.hitPoints.value}}</span>
             </div>
-            <div data-item-id="{{id}}" class="gear contextmenu">
+            <div data-item-id="{{id}}" class="gear contextmenu item">
               <span class="text-right">{{#if data.data.price.estimated}}{{currency data.data.price.estimated 'L'}}{{/if}}</span>
             </div>
-            <div data-item-id="{{id}}" class="gear contextmenu"><span class="text-right">{{multiply data.data.quantity data.data.encumbrance}}</span>
+            <div data-item-id="{{id}}" class="gear contextmenu item"><span class="text-right">{{multiply data.data.quantity data.data.encumbrance}}</span>
             </div>
-            <div data-item-id="{{id}}" data-item-equipped-toggle class="gear contextmenu">
+            <div data-item-id="{{id}}" data-item-equipped-toggle class="gear contextmenu item">
               <img class="equipped-status text-center" title="{{localize (concat "RQG.Item.EquippedStatus." data.data.equippedStatus)}}"
                    src="{{equippedIcon data.data.equippedStatus}}">
             </div>
-            <div data-item-id="{{id}}" class="gear contextmenu">
+            <div data-item-id="{{id}}" class="gear contextmenu item">
               <input type="text" list="locations" data-item-edit-value="data.location" value="{{data.data.location}}"
                      size="10">
             </div>
@@ -238,7 +238,7 @@
     <!--Armor-->
     <article>
       <h2>{{localize "RQG.Actor.Gear.Armor"}}</h2>
-      <div class="grid armor">
+      <div class="grid armor item-list">
         <div class="headings"></div>
         <div class="head1"></div>
         <div class="head2">{{localize "RQG.Actor.Gear.Name"}}</div>
@@ -250,31 +250,31 @@
         <div class="head8"></div>
         <div class="head9">{{localize "RQG.Actor.Gear.Location"}}</div>
         {{#each ownedItems.armor}}
-          <div data-item-id="{{id}}" class="gear contextmenu"><img class="item" src="{{img}}"></div>
-          <div data-item-id="{{id}}" class="gear contextmenu">{{name}}</div>
-          <div data-item-id="{{id}}" class="gear contextmenu">
+          <div data-item-id="{{id}}" class="gear contextmenu item"><img class="item" src="{{img}}"></div>
+          <div data-item-id="{{id}}" class="gear contextmenu item">{{name}}</div>
+          <div data-item-id="{{id}}" class="gear contextmenu item">
             <span class="text-right">{{data.data.absorbs}}</span>
           </div>
-          <div data-item-id="{{id}}" class="gear contextmenu">[
+          <div data-item-id="{{id}}" class="gear contextmenu item">[
             {{#each data.data.hitLocations}}
               {{this}},
             {{/each}}
             ]
           </div>
-          <div data-item-id="{{id}}" class="gear contextmenu">
+          <div data-item-id="{{id}}" class="gear contextmenu item">
             <span class="text-right">{{data.data.moveQuietlyPenalty}}</span>
           </div>
-          <div data-item-id="{{id}}" class="gear contextmenu">
+          <div data-item-id="{{id}}" class="gear contextmenu item">
             <span class="text-right">{{#if data.data.price.estimated}}{{currency data.data.price.estimated 'L'}}{{/if}}</span>
           </div>
-          <div data-item-id="{{id}}" class="gear contextmenu">
+          <div data-item-id="{{id}}" class="gear contextmenu item">
             <span class="text-right">{{data.data.encumbrance}}</span>
           </div>
-          <div data-item-id="{{id}}" data-item-equipped-toggle class="gear contextmenu">
+          <div data-item-id="{{id}}" data-item-equipped-toggle class="gear contextmenu item">
             <img class="equipped-status text-center" title="{{localize (concat "RQG.Item.EquippedStatus." data.data.equippedStatus)}}"
                  src="{{equippedIcon data.data.equippedStatus}}">
           </div>
-          <div data-item-id="{{id}}" class="gear contextmenu">
+          <div data-item-id="{{id}}" class="gear contextmenu item">
             <input type="text" list="locations" data-item-edit-value="data.location" value="{{data.data.location}}"
                    size="10">
           </div>

--- a/src/actors/sheet-parts/health.hbs
+++ b/src/actors/sheet-parts/health.hbs
@@ -12,25 +12,25 @@
     </label>
     <label class="text-right">{{localize "RQG.Actor.Health.HealingRatePerWeek" healingRate=characterData.attributes.healingRate }}</label>
   </div>
-  <div class="grid hit-location">
+  <div class="grid hit-location item-list">
     <div class="headings"></div>
     <div class="head1-4">{{localize "RQG.Actor.Health.HitLocation"}}</div>
     <div class="head5"><span class="text-center">{{localize "RQG.Actor.Health.HitPointsAbbr"}}</span></div>
     <div class="head6"><span class="text-right">{{localize "RQG.Actor.Health.ArmorPointsAbbr"}}</span></div>
     <div class="head7">{{localize "RQG.Actor.Health.Wounds"}}</div>
     {{#each ownedItems.hitLocation}}
-      <div {{#if @root.isGM}}class="hit-location contextmenu"{{/if}}  data-item-id="{{id}}"><span class="text-right">{{data.data.dieFrom}}</span></div>
-      <div {{#if @root.isGM}}class="hit-location contextmenu"{{/if}} data-item-id="{{id}}">-</div>
-      <div {{#if @root.isGM}}class="hit-location contextmenu"{{/if}} data-item-id="{{id}}"><span class="text-right">{{data.data.dieTo}}</span></div>
-      <div {{#if @root.isGM}}class="hit-location contextmenu"{{/if}} data-item-id="{{id}}">
+      <div {{#if @root.isGM}}class="hit-location contextmenu item"{{/if}}  data-item-id="{{id}}"><span class="text-right">{{data.data.dieFrom}}</span></div>
+      <div {{#if @root.isGM}}class="hit-location contextmenu item"{{/if}} data-item-id="{{id}}">-</div>
+      <div {{#if @root.isGM}}class="hit-location contextmenu item"{{/if}} data-item-id="{{id}}"><span class="text-right">{{data.data.dieTo}}</span></div>
+      <div {{#if @root.isGM}}class="hit-location contextmenu item"{{/if}} data-item-id="{{id}}">
         {{name}}
         {{#unless (eq data.data.hitLocationHealthState "healthy")}}
           <i>&nbsp;{{toLowerCase (localize (concat "RQG.Item.HitLocation.HealthStatusEnum." data.data.hitLocationHealthState))}}</i>
         {{/unless}}
       </div>
-      <div {{#if @root.isGM}}class="hit-location contextmenu"{{/if}} data-item-id="{{id}}"><span class="text-right nowrap">{{data.data.hitPoints.value}} / {{this.data.data.hitPoints.max}}</span></div>
-      <div {{#if @root.isGM}}class="hit-location contextmenu"{{/if}} data-item-id="{{id}}"><span class="text-right">{{data.data.armorPoints}}</span></div>
-      <div {{#if @root.isGM}}class="hit-location contextmenu"{{/if}} data-item-id="{{id}}">
+      <div {{#if @root.isGM}}class="hit-location contextmenu item"{{/if}} data-item-id="{{id}}"><span class="text-right nowrap">{{data.data.hitPoints.value}} / {{this.data.data.hitPoints.max}}</span></div>
+      <div {{#if @root.isGM}}class="hit-location contextmenu item"{{/if}} data-item-id="{{id}}"><span class="text-right">{{data.data.armorPoints}}</span></div>
+      <div {{#if @root.isGM}}class="hit-location contextmenu item"{{/if}} data-item-id="{{id}}">
         <div data-item-heal-wound title="{{localize "RQG.Actor.Health.HealWound"}}" class="text-right nowrap">
           {{#each data.data.wounds}}
           <i class="fas fa-notes-medical"></i> {{this}}

--- a/src/actors/sheet-parts/passions-tab.hbs
+++ b/src/actors/sheet-parts/passions-tab.hbs
@@ -1,11 +1,11 @@
 <h2 class="flex-row">{{localize "RQG.Actor.Passion.Passions"}}</h2>
-<div class="grid passions">
+<div class="grid passions item-list">
   {{#each ownedItems.passion}}
-  <div class="grid passion">
-    <div data-item-id="{{id}}" data-item-roll class="passion contextmenu img" title="{{localize "RQG.Game.RollTitle"}}"><img src="{{img}}"></div>
-    <div data-item-id="{{id}}" data-item-roll class="passion contextmenu" title="{{localize "RQG.Game.RollTitle"}}">{{name}}</div>
-    <div data-item-id="{{id}}" data-item-roll class="passion contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" title="{{localize "RQG.Game.RollTitle"}}">{{this.data.data.chance}}%</div>
-    <details data-item-id="{{id}}" class="description passion contextmenu"><summary>{{localize "RQG.Actor.Passion.BackStory"}}</summary>{{{enrichHtml this.data.data.description}}}</details>
+  <div class="grid passion item">
+    <div data-item-id="{{id}}" data-item-roll class="passion contextmenu img item" title="{{localize "RQG.Game.RollTitle"}}"><img src="{{img}}"></div>
+    <div data-item-id="{{id}}" data-item-roll class="passion contextmenu item" title="{{localize "RQG.Game.RollTitle"}}">{{name}}</div>
+    <div data-item-id="{{id}}" data-item-roll class="passion contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" title="{{localize "RQG.Game.RollTitle"}}">{{this.data.data.chance}}%</div>
+    <details data-item-id="{{id}}" class="description passion contextmenu item"><summary>{{localize "RQG.Actor.Passion.BackStory"}}</summary>{{{enrichHtml this.data.data.description}}}</details>
   </div>
     {{/each}}
 </div>

--- a/src/actors/sheet-parts/physical-item-location.hbs
+++ b/src/actors/sheet-parts/physical-item-location.hbs
@@ -1,4 +1,4 @@
-<li class="{{#if id}}gear contextmenu{{else}}virtual{{/if}}" data-item-id="{{id}}">
+<li class="{{#if id}}gear contextmenu{{else}}virtual{{/if}} item" data-item-id="{{id}}">
   <div class="grid location-row">
     <div>
       {{#if contains}}<i class="fas fa-folder-open"> </i>{{/if}}

--- a/src/actors/sheet-parts/power.hbs
+++ b/src/actors/sheet-parts/power.hbs
@@ -1,82 +1,82 @@
-<div class="grid opposed-rune">
+<div class="grid opposed-rune item-list">
   <h2 class="fullrow">{{localize "RQG.Actor.Rune.Power"}}</h2>
 
   {{#with ownedItems.rune.power.Fertility}}
-    <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
         <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{this.data.data.chance}}%</span>
     </div>
   {{/with}}
   <i class="fas fa-arrows-alt-h"></i>
   {{#with ownedItems.rune.power.Death}}
-    <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{this.data.data.chance}}%</span>
     </div>
   {{/with}}
 
   {{#with ownedItems.rune.power.Harmony}}
-    <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{this.data.data.chance}}%</span>
     </div>
   {{/with}}
   <i class="fas fa-arrows-alt-h"></i>
   {{#with ownedItems.rune.power.Disorder}}
-    <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{this.data.data.chance}}%</span>
     </div>
   {{/with}}
 
   {{#with ownedItems.rune.power.Truth}}
-    <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{this.data.data.chance}}%</span>
     </div>
   {{/with}}
   <i class="fas fa-arrows-alt-h"></i>
   {{#with ownedItems.rune.power.Illusion}}
-    <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{this.data.data.chance}}%</span>
     </div>
   {{/with}}
 
   {{#with ownedItems.rune.power.Stasis}}
-    <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{this.data.data.chance}}%</span>
     </div>
   {{/with}}
   <i class="fas fa-arrows-alt-h"></i>
   {{#with ownedItems.rune.power.Movement}}
-    <div data-item-id="{{id}}" class="rune contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="rune contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="rune" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="rune contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
-    <div data-item-id="{{id}}" class="rune contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+    <div data-item-id="{{id}}" class="rune contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">{{data.data.rune}}</div>
+    <div data-item-id="{{id}}" class="rune contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
       <span class="text-right">{{this.data.data.chance}}%</span>
     </div>
   {{/with}}

--- a/src/actors/sheet-parts/rune-magic-tab.hbs
+++ b/src/actors/sheet-parts/rune-magic-tab.hbs
@@ -6,9 +6,9 @@
 </div>
 {{/unless}}
 {{/each}}
-
+<div class="item-list">
 {{#each ownedItems.cult}}
-<div style="margin-bottom: 1.5rem" data-item-id="{{id}}">
+<div class="item" style="margin-bottom: 1.5rem" data-item-id="{{id}}">
   <h2 class="cult contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
     {{name}}
     {{#each data.data.runes}}
@@ -32,7 +32,7 @@
       <span><b>{{localize "RQG.Actor.RuneMagic.SubCults"}}</b>{{{enrichHtml data.data.subCults}}}</span>
     {{/if}}
   </div>
-  <div class="grid rune-magic">
+  <div class="grid rune-magic item-list">
     <div class="headings"></div>
     <div class="head1"></div>
     <div class="head2">{{localize "RQG.Actor.RuneMagic.RuneSpell"}}</div>
@@ -46,42 +46,44 @@
     <div class="head10">{{localize "RQG.Actor.RuneMagic.Chance"}}</div>
     {{#each @root.ownedItems.runeMagic}}
     {{#if (eq ../id data.data.cultId)}}
-      <div data-item-id="{{id}}" class="rune-magic contextmenu"
+      <div data-item-id="{{id}}" class="rune-magic contextmenu item"
            {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
         <img class="item" src="{{img}}">
       </div>
-      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu" title="{{localize "RQG.Game.RollTitle"}}">
+      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu item" title="{{localize "RQG.Game.RollTitle"}}">
         {{name}}&nbsp;
         {{#each data.data.runes}}
           <img class="rune" src="{{runeImg this}}" title="{{this}}">
         {{/each}}
       </div>
-      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu" title="{{localize "RQG.Game.RollTitle"}}">
+      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu item" title="{{localize "RQG.Game.RollTitle"}}">
         <span class="text-center">{{data.data.points}}</span>
       </div>
-      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu" title="{{localize "RQG.Game.RollTitle"}}">
+      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu item" title="{{localize "RQG.Game.RollTitle"}}">
         {{#unless data.data.isRitual}}<span class="text-center">{{localize (concat "RQG.Item.Spell.RangeEnum." data.data.castingRange)}}</span>{{/unless}}
       </div>
-      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu" title="{{localize "RQG.Game.RollTitle"}}">
+      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu item" title="{{localize "RQG.Game.RollTitle"}}">
         {{#unless data.data.isRitual}}<span class="text-center">{{localize (concat "RQG.Item.Spell.DurationEnum." data.data.duration)}}</span>{{/unless}}
       </div>
-      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu" title="{{localize "RQG.Game.RollTitle"}}">
+      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu item" title="{{localize "RQG.Game.RollTitle"}}">
         <span class="text-center">{{yes-no data.data.isRitual}}</span>
       </div>
-      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu" title="Roll">
+      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu item" title="Roll">
         <span class="text-center">{{yes-no data.data.isEnchantment}}</span>
       </div>
-      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu" title="{{localize "RQG.Game.RollTitle"}}">
+      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu item" title="{{localize "RQG.Game.RollTitle"}}">
         <span class="text-center">{{yes-no data.data.isStackable}}</span>
       </div>
-      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu" title="{{localize "RQG.Game.RollTitle"}}">
+      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu item" title="{{localize "RQG.Game.RollTitle"}}">
         <span class="text-center">{{yes-no data.data.isOneUse}}</span>
       </div>
-      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu" title="{{localize "RQG.Game.RollTitle"}}">
+      <div data-item-id="{{id}}" data-rune-magic-roll class="rune-magic contextmenu item" title="{{localize "RQG.Game.RollTitle"}}">
         <span class="text-right">{{data.data.chance}}%</span>
       </div>
     {{/if}}
     {{/each}}
   </div>
 </div>
-{{/each}}
+{{/each}}  
+</div>
+

--- a/src/actors/sheet-parts/skills-tab.hbs
+++ b/src/actors/sheet-parts/skills-tab.hbs
@@ -3,20 +3,20 @@
   {{#if this}}
   <div class="masonry-item">
     <h2>{{localize (concat 'RQG.Actor.Skill.SkillCategory.' @key)}} ({{#with @root.characterData.skillCategoryModifiers}}{{lookup this @key}}{{/with}})</h2>
-    <div class="grid skill">
+    <div class="grid skill item-list">
       {{#each this}}
         {{#unless data.data.runes}}
-        <div data-item-id="{{id}}" title="{{localize "RQG.Actor.Skill.SkillDescriptionTitle" }}" class="skill contextmenu"
+        <div data-item-id="{{id}}" title="{{localize "RQG.Actor.Skill.SkillDescriptionTitle" }}" class="skill contextmenu item"
           {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
           <img class="item" src="{{img}}">
         </div>
-        <div data-item-id="{{id}}" class="skill contextmenu" data-item-roll title="{{localize "RQG.Game.RollTitle"}}" title="{{localize "RQG.Game.RollTitle"}}">
+        <div data-item-id="{{id}}" class="skill contextmenu item" data-item-roll title="{{localize "RQG.Game.RollTitle"}}" title="{{localize "RQG.Game.RollTitle"}}">
           {{data.data.skillName}}{{#if data.data.specialization}} ({{data.data.specialization}}){{/if}}
           {{#each data.data.runes}}
             <img class="rune" src="{{runeImg this}}" title="{{this}}">
           {{/each}}
         </div>
-      <div data-item-id="{{id}}" class="skill contextmenu {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
+      <div data-item-id="{{id}}" class="skill contextmenu item {{#if data.data.hasExperience}}experienced{{/if}}" data-item-roll title="{{localize "RQG.Game.RollTitle"}}">
         <span class="text-right nowrap">{{data.data.chance}}%</span>
       </div>
         {{/unless}}

--- a/src/actors/sheet-parts/spirit-magic-tab.hbs
+++ b/src/actors/sheet-parts/spirit-magic-tab.hbs
@@ -2,7 +2,7 @@
   {{localize "RQG.Actor.SpiritMagic.SpiritMagic"}}
   <span class="small-size">{{localize "RQG.Actor.SpiritMagic.CHALimitFormula" points=spiritMagicPointSum CHALimit=data.data.characteristics.charisma.value}}</span>
 </h2>
-<div class="grid spiritmagic">
+<div class="grid spiritmagic item-list">
   <div class="headings"></div>
   <div class="head1"></div>
   <div class="head2">{{localize "RQG.Actor.SpiritMagic.Name"}}</div>
@@ -14,31 +14,31 @@
   <div class="head8">{{localize "RQG.Actor.SpiritMagic.Ritual"}}</div>
   <div class="head9">{{localize "RQG.Actor.SpiritMagic.Enchantment"}}</div>
   {{#each ownedItems.spiritMagic}}
-    <div data-item-id="{{id}}" class="spirit-magic contextmenu" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
+    <div data-item-id="{{id}}" class="spirit-magic contextmenu item" {{#if data.data.journalId}} data-journal-pack="{{data.data.journalPack}}" data-journal-id="{{data.data.journalId}}"{{/if}}>
       <img class="item" src="{{img}}">
     </div>
-    <div data-item-id="{{id}}" class="spirit-magic contextmenu" data-spirit-magic-roll>
+    <div data-item-id="{{id}}" class="spirit-magic contextmenu item" data-spirit-magic-roll>
       {{name}}{{#if data.data.isMatrix}} {{localize "RQG.Item.SpiritMagic.MatrixIndicator"}}{{/if}}
     </div>
-    <div data-item-id="{{id}}" class="spirit-magic contextmenu" data-spirit-magic-roll>
+    <div data-item-id="{{id}}" class="spirit-magic contextmenu item" data-spirit-magic-roll>
       <span class="text-center">{{data.data.points}}</span>
     </div>
-    <div data-item-id="{{id}}" class="spirit-magic contextmenu" data-spirit-magic-roll>
+    <div data-item-id="{{id}}" class="spirit-magic contextmenu item" data-spirit-magic-roll>
       <span class="text-center">{{yes-no this.data.data.isVariable}}</span>
     </div>
-    <div data-item-id="{{id}}" class="spirit-magic contextmenu" data-spirit-magic-roll>
+    <div data-item-id="{{id}}" class="spirit-magic contextmenu item" data-spirit-magic-roll>
       <span class="text-center">{{localize (concat "RQG.Item.Spell.RangeEnum." data.data.castingRange)}}</span>
     </div>
-    <div data-item-id="{{id}}" class="spirit-magic contextmenu" data-spirit-magic-roll>
+    <div data-item-id="{{id}}" class="spirit-magic contextmenu item" data-spirit-magic-roll>
       <span class="text-center">{{localize (concat "RQG.Item.Spell.DurationEnum." data.data.duration)}}</span>
     </div>
-    <div data-item-id="{{id}}" class="spirit-magic contextmenu" data-spirit-magic-roll>
+    <div data-item-id="{{id}}" class="spirit-magic contextmenu item" data-spirit-magic-roll>
       <span class="text-center">{{localize (concat "RQG.Item.Spell.ConcentrationEnum." data.data.concentration)}}</span>
     </div>
-    <div data-item-id="{{id}}" class="spirit-magic contextmenu" data-spirit-magic-roll>
+    <div data-item-id="{{id}}" class="spirit-magic contextmenu item" data-spirit-magic-roll>
       <span class="text-center">{{yes-no this.data.data.isRitual}}</span>
     </div>
-    <div data-item-id="{{id}}" class="spirit-magic contextmenu" data-spirit-magic-roll>
+    <div data-item-id="{{id}}" class="spirit-magic contextmenu item" data-spirit-magic-roll>
       <span class="text-center">{{yes-no this.data.data.isEnchantment}}</span>
     </div>
   {{/each}}

--- a/src/dialog/confirmCopyIntangibleItem.hbs
+++ b/src/dialog/confirmCopyIntangibleItem.hbs
@@ -1,0 +1,28 @@
+<form>
+  <h1>
+    {{#if adapter.incomingItemDataSource.img}}
+      <img
+        class="item"
+        src="{{adapter.incomingItemDataSource.img}}"
+        title="{{adapter.incomingItemDataSource.name}}"
+        style="padding-right: 10px;"
+      />
+    {{/if}}
+    {{localize
+      "RQG.Dialog.confirmCopyIntangibleItem.header"
+      itemName=adapter.incomingItemDataSource.name
+      targetActor=adapter.targetActor.name
+    }}
+  </h1>
+  <div>
+
+    <p>{{localize
+        "RQG.Dialog.confirmCopyIntangibleItem.ReallyCopyIntangibleItem"
+        itemName=adapter.incomingItemDataSource.name
+        targetActor=adapter.targetActor.name
+        sourceActor=adapter.sourceActor.name
+      }}
+    </p>
+  </div>
+
+</form>

--- a/src/dialog/confirmTransferPhysicalItem.hbs
+++ b/src/dialog/confirmTransferPhysicalItem.hbs
@@ -1,34 +1,52 @@
 <form>
-    <h1>
-        {{#if adapter.incomingItemDataSource.img}}
-        <img class="item" src="{{adapter.incomingItemDataSource.img}}" title="{{adapter.incomingItemDataSource.name}}" style="padding-right: 10px;" />
-        {{/if}}
-        {{localize "RQG.Dialog.confirmTransferPhysicalItem.header" 
-                itemName=adapter.incomingItemDataSource.name
-                targetActor=adapter.targetActor.name}}
-    </h1>
-    <div>
-        
+  <h1>
+    {{#if adapter.incomingItemDataSource.img}}
+      <img
+        class="item"
+        src="{{adapter.incomingItemDataSource.img}}"
+        title="{{adapter.incomingItemDataSource.name}}"
+        style="padding-right: 10px;"
+      />
+    {{/if}}
+    {{localize
+      "RQG.Dialog.confirmTransferPhysicalItem.header"
+      itemName=adapter.incomingItemDataSource.name
+      targetActor=adapter.targetActor.name
+    }}
+  </h1>
+  <div>
 
-        {{#if adapter.showQuantity}}
-        <p>{{localize "RQG.Dialog.confirmTransferPhysicalItem.ReallyGiveItemQuantity" 
-                itemName=adapter.incomingItemDataSource.name
-                targetActor=adapter.targetActor.name
-                sourceActor=adapter.sourceActor.name}}
-        </p>
-        <p>{{localize "RQG.Dialog.confirmTransferPhysicalItem.GiveHowMany" 
-                itemName=adapter.incomingItemDataSource.name
-                targetActor=adapter.targetActor.name
-                sourceActor=adapter.sourceActor.name
-                maxQty=adapter.incomingItemDataSource.data.quantity}}</p>
-        <input name="numtotransfer" type="number" min="0" max="{{adapter.incomingItemDataSource.data.quantity}}" value="{{adapter.incomingItemDataSource.data.quantity}}">
-        {{else}}
-        <p>{{localize "RQG.Dialog.confirmTransferPhysicalItem.ReallyGiveItemSingle" 
-                itemName=adapter.incomingItemDataSource.name
-                targetActor=adapter.targetActor.name
-                sourceActor=adapter.sourceActor.name}}
-        </p>
-        {{/if}}
-    </div>
+    {{#if adapter.showQuantity}}
+      <p>{{localize
+          "RQG.Dialog.confirmTransferPhysicalItem.ReallyGiveItemQuantity"
+          itemName=adapter.incomingItemDataSource.name
+          targetActor=adapter.targetActor.name
+          sourceActor=adapter.sourceActor.name
+        }}
+      </p>
+      <p>{{localize
+          "RQG.Dialog.confirmTransferPhysicalItem.GiveHowMany"
+          itemName=adapter.incomingItemDataSource.name
+          targetActor=adapter.targetActor.name
+          sourceActor=adapter.sourceActor.name
+          maxQty=adapter.incomingItemDataSource.data.quantity
+        }}</p>
+      <input
+        name="numtotransfer"
+        type="number"
+        min="0"
+        max="{{adapter.incomingItemDataSource.data.quantity}}"
+        value="{{adapter.incomingItemDataSource.data.quantity}}"
+      />
+    {{else}}
+      <p>{{localize
+          "RQG.Dialog.confirmTransferPhysicalItem.ReallyGiveItemSingle"
+          itemName=adapter.incomingItemDataSource.name
+          targetActor=adapter.targetActor.name
+          sourceActor=adapter.sourceActor.name
+        }}
+      </p>
+    {{/if}}
+  </div>
 
 </form>

--- a/src/dialog/confirmTransferPhysicalItem.hbs
+++ b/src/dialog/confirmTransferPhysicalItem.hbs
@@ -1,0 +1,34 @@
+<form>
+    <h1>
+        {{#if adapter.incomingItemDataSource.img}}
+        <img class="item" src="{{adapter.incomingItemDataSource.img}}" title="{{adapter.incomingItemDataSource.name}}" style="padding-right: 10px;" />
+        {{/if}}
+        {{localize "RQG.Dialog.confirmTransferPhysicalItem.header" 
+                itemName=adapter.incomingItemDataSource.name
+                targetActor=adapter.targetActor.name}}
+    </h1>
+    <div>
+        
+
+        {{#if adapter.showQuantity}}
+        <p>{{localize "RQG.Dialog.confirmTransferPhysicalItem.ReallyGiveItemQuantity" 
+                itemName=adapter.incomingItemDataSource.name
+                targetActor=adapter.targetActor.name
+                sourceActor=adapter.sourceActor.name}}
+        </p>
+        <p>{{localize "RQG.Dialog.confirmTransferPhysicalItem.GiveHowMany" 
+                itemName=adapter.incomingItemDataSource.name
+                targetActor=adapter.targetActor.name
+                sourceActor=adapter.sourceActor.name
+                maxQty=adapter.incomingItemDataSource.data.quantity}}</p>
+        <input name="numtotransfer" type="number" min="0" max="{{adapter.incomingItemDataSource.data.quantity}}" value="{{adapter.incomingItemDataSource.data.quantity}}">
+        {{else}}
+        <p>{{localize "RQG.Dialog.confirmTransferPhysicalItem.ReallyGiveItemSingle" 
+                itemName=adapter.incomingItemDataSource.name
+                targetActor=adapter.targetActor.name
+                sourceActor=adapter.sourceActor.name}}
+        </p>
+        {{/if}}
+    </div>
+
+</form>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -321,6 +321,8 @@
       "Common": {
         "yes": "yes",
         "no": "no",
+        "btnYes": "Yes",
+        "btnNo": "No",
         "btnCancel": "Cancel",
         "btnConfirm": "Confirm",
         "OtherModifiers": "Other Modifiers:",
@@ -333,6 +335,13 @@
         "CardFlavor": "Characteristic: {name} ({value})",
         "RollFlavor": "{difficulty} {name} Check",
         "RollFlavorModifier": "<br/>With {modifier} other modifiers"
+      },
+      "confirmTransferPhysicalItem": {
+        "title": "Really give {itemName} to {targetActor}?",
+        "header": "Really give {itemName} to {targetActor}?",
+        "ReallyGiveItemSingle": "Really give {itemName} to {targetActor}?  It will be removed from {sourceActor}'s inventory.",
+        "ReallyGiveItemQuantity": "Really give {itemName} to {targetActor}?  It will be removed from {sourceActor}'s inventory, or {sourceActor}'s inventory quantity will be reduced.",
+        "GiveHowMany": "Give how many {itemName} to {targetActor}?  {sourceActor}'s inventory of this item will be reduced by the amount chosen, or the item will be deleted if you choose to give the maximum amount of {maxQty}."
       },
       "itemCard": {
         "RollFlavor": "{name} Check",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -336,9 +336,16 @@
         "RollFlavor": "{difficulty} {name} Check",
         "RollFlavorModifier": "<br/>With {modifier} other modifiers"
       },
+      "confirmCopyIntangibleItem": {
+        "title": "Really give {itemName} to {targetActor}?",
+        "header": "Really give {itemName} to {targetActor}?",
+        "btnCopy": "Copy",
+        "ReallyCopyIntangibleItem": "Really copy {itemName} from {sourceActor} to {targetActor}?"
+      },
       "confirmTransferPhysicalItem": {
         "title": "Really give {itemName} to {targetActor}?",
         "header": "Really give {itemName} to {targetActor}?",
+        "btnGive": "Give",
         "ReallyGiveItemSingle": "Really give {itemName} to {targetActor}?  It will be removed from {sourceActor}'s inventory.",
         "ReallyGiveItemQuantity": "Really give {itemName} to {targetActor}?  It will be removed from {sourceActor}'s inventory, or {sourceActor}'s inventory quantity will be reduced.",
         "GiveHowMany": "Give how many {itemName} to {targetActor}?  {sourceActor}'s inventory of this item will be reduced by the amount chosen, or the item will be deleted if you choose to give the maximum amount of {maxQty}."

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -204,6 +204,15 @@
         "Background": "Background",
         "ActiveEffects": "AE 🧪"
       },
+      "Notification": {
+        "NotActorOwnerWarn": "You are not the owner of {actorName}, and cannot drop this item onto this actor sheet",
+        "DraggedItemNotFoundError": "Dragged item not found from source!",
+        "CantMakeItemDataSourceError": "Unable to make ItemDataSource from dragged item from item with id [{itemId}]",
+        "NoIncomingItemDataSourceError": "No incoming Item Data Source!",
+        "IncomingItemDataSourceNotPhysicalItemError": "Incoming Item Data Source does not represent a physical item with a quantity!",
+        "CantTransferLessThanOneItemError": "Can't transfer less than one item!",
+        "CantTransferMoreThanSourceOwnsError": "Cannot transfer more {itemName} than ${sourceActorName} has in inventory."
+      },
       "Passion": {
         "Passions": "Passions",
         "BackStory": "Back Story"


### PR DESCRIPTION
Handles _onDropItem in RqgActorSheet and allows for copying intangible items or transfering (giving) physical items (ie those with quantity).  If the quantity is greater than one allows transferring an arbitrary amount, "splitting the stack".

Note that a player cannot transfer items from an Actor Sheet they own to one that they do not, even if they have "limited" or "observer" permissions on it.  I've asked about this on the Foundry Discord, but no answer as of now.  The workaround may be for the party to have a "Party Loot Sheet" that they all have "owner" permissions to and copy items to and from there to exchange them.

 If the ability to drag intangible items (like runes or passions) is annoying to some we could make a setting that governs whether or not to express the "item-list" on the top level list element to enable or disable that behavior.