### PR TITLE
chore: migrate description links from old format to rqidLink

### DIFF
--- a/src/assets/compendiums/rune-descriptions.db/rune-condition-descriptions.yaml
+++ b/src/assets/compendiums/rune-descriptions.db/rune-condition-descriptions.yaml
@@ -10,7 +10,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-mastery
+      id: je..mastery-condition
       lang: en
       priority: 0
 
@@ -25,7 +25,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-magic
+      id: je..magic-condition
       lang: en
       priority: 0
 ---
@@ -39,7 +39,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-infinity
+      id: je..infinity-condition
       lang: en
       priority: 0
 
@@ -54,7 +54,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-luck
+      id: je..luck-condition
       lang: en
       priority: 0
 
@@ -69,7 +69,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-fate
+      id: je..fate-condition
       lang: en
       priority: 0
 
@@ -82,6 +82,6 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-law
+      id: je..law-condition
       lang: en
       priority: 0

--- a/src/assets/compendiums/rune-descriptions.db/rune-element-descriptions.yaml
+++ b/src/assets/compendiums/rune-descriptions.db/rune-element-descriptions.yaml
@@ -22,7 +22,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-air
+      id: je..air-element
       lang: en
       priority: 0
 
@@ -49,7 +49,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-water
+      id: je..water-element
       lang: en
       priority: 0
 
@@ -79,7 +79,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-earth
+      id: je..earth-element
       lang: en
       priority: 0
 ---
@@ -108,7 +108,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-darkness
+      id: je..darkness-element
       lang: en
       priority: 0
 ---
@@ -137,7 +137,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-fire-sky
+      id: je..fire-sky-element
       lang: en
       priority: 0
 ---
@@ -166,6 +166,6 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-moon
+      id: je..moon-element
       lang: en
       priority: 0

--- a/src/assets/compendiums/rune-descriptions.db/rune-form-descriptions.yaml
+++ b/src/assets/compendiums/rune-descriptions.db/rune-form-descriptions.yaml
@@ -11,7 +11,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-beast
+      id: je..beast-form
       lang: en
       priority: 0
 ---
@@ -24,7 +24,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-chaos
+      id: je..chaos-form
       lang: en
       priority: 0
 
@@ -39,7 +39,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-plant
+      id: je..plant-form
       lang: en
       priority: 0
 
@@ -52,7 +52,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-spirit
+      id: je..spirit-form
       lang: en
       priority: 0
 
@@ -66,7 +66,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-dragonewt
+      id: je..dragonewt-form
       lang: en
       priority: 0
 
@@ -83,6 +83,6 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-man
+      id: je..man-form
       lang: en
       priority: 0

--- a/src/assets/compendiums/rune-descriptions.db/rune-power-descriptions.yaml
+++ b/src/assets/compendiums/rune-descriptions.db/rune-power-descriptions.yaml
@@ -10,7 +10,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-movement
+      id: je..movement-power
       lang: en
       priority: 0
 
@@ -28,7 +28,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-harmony
+      id: je..harmony-power
       lang: en
       priority: 0
 
@@ -44,7 +44,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-fertility
+      id: je..fertility-power
       lang: en
       priority: 0
 
@@ -62,7 +62,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-truth
+      id: je..truth-power
       lang: en
       priority: 0
 
@@ -78,7 +78,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-stasis
+      id: je..stasis-power
       lang: en
       priority: 0
 
@@ -96,7 +96,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-illusion
+      id: je..illusion-power
       lang: en
       priority: 0
 
@@ -113,7 +113,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-death
+      id: je..death-power
       lang: en
       priority: 0
 
@@ -129,6 +129,6 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-disorder
+      id: je..disorder-power
       lang: en
       priority: 0

--- a/src/assets/compendiums/rune-descriptions.db/rune-technique-descriptions.yaml
+++ b/src/assets/compendiums/rune-descriptions.db/rune-technique-descriptions.yaml
@@ -7,7 +7,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-combine
+      id: je..combine-technique
       lang: en
       priority: 0
 
@@ -23,7 +23,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-tap
+      id: je..tap-technique
       lang: en
       priority: 0
 
@@ -38,7 +38,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-dispel
+      id: je..dispel-technique
       lang: en
       priority: 0
 
@@ -53,7 +53,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-separate
+      id: je..separate-technique
       lang: en
       priority: 0
 
@@ -68,7 +68,7 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-summon
+      id: je..summon-technique
       lang: en
       priority: 0
 
@@ -84,6 +84,6 @@ content: >
 flags:
   rqg:
     documentRqidFlags:
-      id: je..runedescription-command
+      id: je..command-technique
       lang: en
       priority: 0

--- a/src/system/migrations/migrateWorld.ts
+++ b/src/system/migrations/migrateWorld.ts
@@ -7,6 +7,7 @@ import { moveRuneIcons } from "./migrations-item/moveRuneIcon";
 import { renameSkillIcons } from "./migrations-item/renameSkillIcons";
 import { systemId } from "../config";
 import { renameDragonewt } from "./migrations-item/renameDragonewt";
+import { useRqidDescriptionLinks } from "./migrations-item/migrateDescriptionLinks";
 
 /**
  * Perform a system migration for the entire World, applying migrations for what is in it
@@ -44,6 +45,7 @@ export async function applyDefaultWorldMigrations(): Promise<void> {
     moveRuneIcons,
     renameSkillIcons,
     renameDragonewt,
+    useRqidDescriptionLinks,
   ];
   const worldActorMigrations: ActorMigration[] = [migrateActorDummy];
 

--- a/src/system/migrations/migrations-item/migrateDescriptionLinks.ts
+++ b/src/system/migrations/migrations-item/migrateDescriptionLinks.ts
@@ -1,0 +1,137 @@
+import { ItemData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs";
+import { ItemUpdate } from "../applyMigrations";
+import { getGame, toKebabCase } from "../../util";
+import { Rqid } from "../../api/rqidApi";
+
+const logPrefix = "RQG | Migrate Descr. Link |";
+
+export async function useRqidDescriptionLinks(itemData: ItemData): Promise<ItemUpdate> {
+  const updateData: ItemUpdate = {};
+  updateData.data = updateData.data ?? {};
+
+  if (hasProperty(itemData.data, "journalId")) {
+    const previousRqidLink = (itemData as any).data?.descriptionRqidLink?.id;
+    // Already has a rqidLink - don't update
+    if (previousRqidLink) {
+      return updateData;
+    }
+    // Follow & use old style link
+    const previousLinkUpdate = await getUpdateViaPreviousLink(itemData);
+    if (previousLinkUpdate) {
+      updateData.data = previousLinkUpdate as any;
+      console.log(
+        logPrefix,
+        "Followed old style description link and found JE with rqid - updated item with descriptionRqidLink",
+        updateData,
+        itemData
+      );
+    } else {
+      // No previous link -try if there exists a journal entry with a standard rqid name that matches the item name.
+      // This will fix all (unlinked) rune description links since they now have a provided compendium
+      const testRqidLink = `je..${toKebabCase(itemData.name)}`;
+      const foundJournal = await Rqid.fromRqid(testRqidLink, "en", true); // Only supports lang "en"
+
+      if (foundJournal) {
+        // Set the new values
+        updateData.data = {
+          descriptionRqidLink: {
+            name: foundJournal.name ?? "",
+            rqid: testRqidLink,
+          },
+        };
+        console.log(
+          logPrefix,
+          // @ts-expect-errors journalId & journalPack
+          `Didn't find a JE from previous link id [${itemData.data?.journalId}], pack [${itemData.data?.journalPack}] but found a link to a standard named JE [${testRqidLink}] - updated item`,
+
+          updateData,
+          itemData
+        );
+      } else {
+        console.debug(
+          logPrefix,
+          // @ts-expect-errors journalId & journalPack
+          `Didn't find a JE from previous link id [${itemData.data?.journalId}], pack [${itemData.data?.journalPack}] or from default rqid link [${testRqidLink}] - no update`,
+          itemData
+        );
+      }
+    }
+    // Remove old description link
+    (updateData as any).data["-=journalId"] = null;
+    (updateData as any).data["-=journalPack"] = null;
+    (updateData as any).data["-=journalName"] = null;
+  }
+  return updateData;
+}
+
+async function getUpdateViaPreviousLink(itemData: ItemData): Promise<ItemUpdate | undefined> {
+  // Follow the old link and get its values
+  const oldJournalId: string | undefined = (itemData.data as any).journalId;
+  if (!oldJournalId) {
+    // no previous id - will check if there is a match with default rqid as well...
+    return undefined;
+  }
+
+  const oldJournalPack: string | undefined = (itemData.data as any).journalPack;
+  const updateData = oldJournalPack
+    ? await getUpdateFromCompendium(oldJournalId, oldJournalPack)
+    : getUpdateFromWorld(oldJournalId);
+
+  if (!updateData) {
+    const msg = `Can't find linked description id [${oldJournalId}] in compendium [${oldJournalPack}]. Misconfiguration in existing description link - No migration done.`;
+    console.warn(logPrefix, msg, itemData);
+    return undefined;
+  }
+  return updateData;
+}
+
+async function getUpdateFromCompendium(
+  oldJournalId: string,
+  oldJournalPack: string
+): Promise<ItemUpdate | undefined> {
+  // Get the old journal entry
+  const pack = getGame().packs.get(oldJournalPack);
+  if (!pack) {
+    const msg = `Can't find linked description compendium: [${oldJournalPack}]. Is the compendium active? - No migration done.`;
+    console.warn(logPrefix, msg, oldJournalId, oldJournalPack);
+    // TODO give opportunity to relink?
+    return undefined;
+  }
+  // @ts-expect-error indexed
+  if (!pack.indexed) {
+    await pack.getIndex();
+  }
+
+  // @ts-expect-error key
+  const indexData = pack.index.find((d) => d._id === oldJournalId);
+  if (!indexData) {
+    const msg = `Can't get indexData for id [${oldJournalId}] in compendium [${pack.metadata.name}]. - No migration done.`;
+    console.warn(logPrefix, msg, oldJournalId, oldJournalPack);
+    return undefined;
+  }
+
+  return {
+    descriptionRqidLink: {
+      // @ts-expect-error name
+      name: indexData?.name ?? "",
+      // @ts-expect-error flags
+      rqid: indexData?.flags?.rqg?.documentRqidFlags?.id ?? "",
+    },
+  };
+}
+
+function getUpdateFromWorld(oldJournalId: string): ItemUpdate | undefined {
+  const journal = getGame().journal?.find((j) => j.id === oldJournalId);
+  if (!journal) {
+    const msg = `Can't find journalEntry in world, id: [${oldJournalId}]. No migration done.`;
+    console.warn(logPrefix, msg, oldJournalId);
+    return;
+  }
+
+  return {
+    descriptionRqidLink: {
+      name: journal.name ?? "",
+      rqid: journal.data?.flags?.rqg?.documentRqidFlags?.id ?? "",
+    },
+  };
+}


### PR DESCRIPTION
Migrate the old style description journal entry links (journalId, journalPack) to the new style (descriptionRqidLink: {rqid, name})

also update the rqid for the provided rune descriptions to match the default naming, and update the rqid count to be a bit more flexible