### PR TITLE
Move weapon usage selection to chat message

### DIFF
--- a/src/actors/context-menus/combat-context-menu.ts
+++ b/src/actors/context-menus/combat-context-menu.ts
@@ -19,16 +19,7 @@ export const combatMenuOptions = (actor: RqgActor): ContextMenu.Item[] => [
     callback: async (el: JQuery) => {
       const weaponItemId = getRequiredDomDataset(el, "item-id");
       const weapon = actor.getEmbeddedDocument("Item", weaponItemId) as RqgItem | undefined;
-      if (!weapon) {
-        const msg = localize("RQG.ContextMenu.Notification.CantShowWeaponChatError", {
-          skillItemId: "****", // TODO Change translation!!!!
-          weaponItemId: weaponItemId,
-          actorName: actor.name,
-        });
-        ui.notifications?.error(msg);
-        throw new RqgError(msg);
-      }
-      await weapon.toChat();
+      await weapon?.toChat();
     },
   },
   {

--- a/src/actors/context-menus/combat-context-menu.ts
+++ b/src/actors/context-menus/combat-context-menu.ts
@@ -1,5 +1,4 @@
 import { RqgActorSheet } from "../rqgActorSheet";
-import { WeaponChatHandler } from "../../chat/weaponChatHandler";
 import { RqgActor } from "../rqgActor";
 import {
   getDomDataset,
@@ -11,31 +10,25 @@ import {
 import { ContextMenuRunes } from "./contextMenuRunes";
 import { RqgItem } from "../../items/rqgItem";
 import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
-import { UsageType } from "../../data-model/item-data/weaponData";
 
-export const combatMenuOptions = (
-  actor: RqgActor,
-  token: TokenDocument | undefined
-): ContextMenu.Item[] => [
+export const combatMenuOptions = (actor: RqgActor): ContextMenu.Item[] => [
   {
     name: localize("RQG.Game.RollChat"),
     icon: ContextMenuRunes.RollViaChat,
-    condition: (el) => !!getDomDataset(el, "weapon-usage-type"),
+    condition: (el: JQuery) => !!getDomDataset(el, "item-id"),
     callback: async (el: JQuery) => {
-      const skillItemId = getDomDataset(el, "skill-id");
-      const weaponItemId = getDomDataset(el, "item-id");
-      const usage = getRequiredDomDataset(el, "weapon-usage-type") as UsageType;
-      if (skillItemId && weaponItemId) {
-        await WeaponChatHandler.show(weaponItemId, usage, actor, token);
-      } else {
+      const weaponItemId = getRequiredDomDataset(el, "item-id");
+      const weapon = actor.getEmbeddedDocument("Item", weaponItemId) as RqgItem | undefined;
+      if (!weapon) {
         const msg = localize("RQG.ContextMenu.Notification.CantShowWeaponChatError", {
-          skillItemId: skillItemId,
+          skillItemId: "****", // TODO Change translation!!!!
           weaponItemId: weaponItemId,
           actorName: actor.name,
         });
         ui.notifications?.error(msg);
         throw new RqgError(msg);
       }
+      await weapon.toChat();
     },
   },
   {

--- a/src/actors/context-menus/passion-context-menu.ts
+++ b/src/actors/context-menus/passion-context-menu.ts
@@ -1,4 +1,3 @@
-import { Ability } from "../../data-model/shared/ability";
 import { RqgActorSheet } from "../rqgActorSheet";
 import { RqgActor } from "../rqgActor";
 import {
@@ -8,7 +7,6 @@ import {
   localize,
   RqgError,
 } from "../../system/util";
-import { ItemChatHandler } from "../../chat/itemChatHandler";
 import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
 import { showImproveAbilityDialog } from "../../dialog/improveAbilityDialog";
 import { ContextMenuRunes } from "./contextMenuRunes";
@@ -44,12 +42,7 @@ export const passionMenuOptions = (
         ui.notifications?.error(msg);
         throw new RqgError(msg);
       }
-      await Ability.roll(
-        item.name ?? "",
-        item.data.data.chance,
-        0,
-        ChatMessage.getSpeaker({ actor: actor, token: token })
-      );
+      await item?.abilityRoll();
     },
   },
   {

--- a/src/actors/context-menus/passion-context-menu.ts
+++ b/src/actors/context-menus/passion-context-menu.ts
@@ -24,7 +24,8 @@ export const passionMenuOptions = (
     condition: () => true,
     callback: async (el: JQuery) => {
       const itemId = getRequiredDomDataset(el, "item-id");
-      await ItemChatHandler.show(itemId, actor, token);
+      const item = actor.items.get(itemId);
+      await item?.toChat();
     },
   },
   {

--- a/src/actors/context-menus/rune-context-menu.ts
+++ b/src/actors/context-menus/rune-context-menu.ts
@@ -2,7 +2,6 @@ import { Ability } from "../../data-model/shared/ability";
 import { RqgActorSheet } from "../rqgActorSheet";
 import { RqgActor } from "../rqgActor";
 import {
-  activateChatTab,
   assertItemType,
   getDomDatasetAmongSiblings,
   getGame,
@@ -10,7 +9,6 @@ import {
   localize,
   RqgError,
 } from "../../system/util";
-import { ItemChatHandler } from "../../chat/itemChatHandler";
 import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
 import { showImproveAbilityDialog } from "../../dialog/improveAbilityDialog";
 import { ContextMenuRunes } from "./contextMenuRunes";
@@ -27,8 +25,8 @@ export const runeMenuOptions = (
     condition: () => true,
     callback: async (el: JQuery) => {
       const itemId = getRequiredDomDataset(el, "item-id");
-      await ItemChatHandler.show(itemId, actor, token);
-      activateChatTab();
+      const item = actor.items.get(itemId);
+      await item?.toChat();
     },
   },
   {

--- a/src/actors/context-menus/rune-context-menu.ts
+++ b/src/actors/context-menus/rune-context-menu.ts
@@ -1,4 +1,3 @@
-import { Ability } from "../../data-model/shared/ability";
 import { RqgActorSheet } from "../rqgActorSheet";
 import { RqgActor } from "../rqgActor";
 import {
@@ -37,13 +36,7 @@ export const runeMenuOptions = (
       const itemId = getRequiredDomDataset(el, "item-id");
       const item = actor.items.get(itemId);
       assertItemType(item?.data.type, ItemTypeEnum.Rune);
-      const itemChance = item.data.data.chance;
-      await Ability.roll(
-        item.name ?? "",
-        itemChance,
-        0,
-        ChatMessage.getSpeaker({ actor: actor, token: token })
-      );
+      await item?.abilityRoll();
     },
   },
   {

--- a/src/actors/context-menus/rune-magic-context-menu.ts
+++ b/src/actors/context-menus/rune-magic-context-menu.ts
@@ -24,7 +24,8 @@ export const runeMagicMenuOptions = (
     condition: () => true,
     callback: async (el: JQuery) => {
       const itemId = getRequiredDomDataset(el, "item-id");
-      await RuneMagicChatHandler.show(itemId, actor, token);
+      const item = actor.items.get(itemId);
+      await item?.toChat();
     },
   },
   {

--- a/src/actors/context-menus/rune-magic-context-menu.ts
+++ b/src/actors/context-menus/rune-magic-context-menu.ts
@@ -9,15 +9,11 @@ import {
   RqgError,
 } from "../../system/util";
 import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
-import { RuneMagicChatHandler } from "../../chat/runeMagicChatHandler";
 import { ContextMenuRunes } from "./contextMenuRunes";
 import { RqgItem } from "../../items/rqgItem";
 import { Rqid } from "../../system/api/rqidApi";
 
-export const runeMagicMenuOptions = (
-  actor: RqgActor,
-  token: TokenDocument | undefined
-): ContextMenu.Item[] => [
+export const runeMagicMenuOptions = (actor: RqgActor): ContextMenu.Item[] => [
   {
     name: localize("RQG.Game.RollChat"),
     icon: ContextMenuRunes.RollViaChat,
@@ -36,16 +32,7 @@ export const runeMagicMenuOptions = (
       const itemId = getRequiredDomDataset(el, "item-id");
       const item = actor.items.get(itemId);
       assertItemType(item?.data.type, ItemTypeEnum.RuneMagic);
-      await RuneMagicChatHandler.roll(
-        item,
-        item?.data.data.points,
-        0,
-        0,
-        0,
-        0,
-        actor,
-        ChatMessage.getSpeaker({ actor: actor, token: token })
-      );
+      item.abilityRoll();
     },
   },
   {

--- a/src/actors/context-menus/skill-context-menu.ts
+++ b/src/actors/context-menus/skill-context-menu.ts
@@ -1,5 +1,4 @@
 import { RqgActorSheet } from "../rqgActorSheet";
-import { ItemChatHandler } from "../../chat/itemChatHandler";
 import { RqgActor } from "../rqgActor";
 import {
   assertItemType,
@@ -62,12 +61,7 @@ export const skillMenuOptions = (
         ui.notifications?.error(msg);
         throw new RqgError(msg, el);
       }
-      await ItemChatHandler.roll(
-        item,
-        0,
-        actor,
-        ChatMessage.getSpeaker({ actor: actor, token: token })
-      );
+      await item?.abilityRoll();
     },
   },
   {

--- a/src/actors/context-menus/skill-context-menu.ts
+++ b/src/actors/context-menus/skill-context-menu.ts
@@ -34,7 +34,8 @@ export const skillMenuOptions = (
     },
     callback: async (el: JQuery) => {
       const itemId = getRequiredDomDataset(el, "item-id");
-      await ItemChatHandler.show(itemId, actor, token);
+      const item = actor.items.get(itemId);
+      await item?.toChat();
     },
   },
   {

--- a/src/actors/context-menus/spirit-magic-context-menu.ts
+++ b/src/actors/context-menus/spirit-magic-context-menu.ts
@@ -27,7 +27,7 @@ export const spiritMagicMenuOptions = (
       const itemId = getDomDataset(el, "item-id");
       const item = (itemId && actor.items.get(itemId)) || undefined;
       assertItemType(item?.data.type, ItemTypeEnum.SpiritMagic);
-      item.id && (await SpiritMagicChatHandler.show(item.id, actor, token));
+      await item?.toChat();
     },
   },
   {
@@ -39,7 +39,7 @@ export const spiritMagicMenuOptions = (
       const item = (itemId && actor.items.get(itemId)) || undefined;
       assertItemType(item?.data.type, ItemTypeEnum.SpiritMagic);
       if (item.data.data.isVariable && item.data.data.points > 1) {
-        item.id && (await SpiritMagicChatHandler.show(item.id, actor, token));
+        await item.toChat();
       } else {
         await SpiritMagicChatHandler.roll(
           item,

--- a/src/actors/context-menus/spirit-magic-context-menu.ts
+++ b/src/actors/context-menus/spirit-magic-context-menu.ts
@@ -1,5 +1,4 @@
 import { RqgActorSheet } from "../rqgActorSheet";
-import { SpiritMagicChatHandler } from "../../chat/spiritMagicChatHandler";
 import { RqgActor } from "../rqgActor";
 import {
   assertItemType,
@@ -15,10 +14,7 @@ import { ContextMenuRunes } from "./contextMenuRunes";
 import { RqgItem } from "../../items/rqgItem";
 import { Rqid } from "../../system/api/rqidApi";
 
-export const spiritMagicMenuOptions = (
-  actor: RqgActor,
-  token: TokenDocument | undefined
-): ContextMenu.Item[] => [
+export const spiritMagicMenuOptions = (actor: RqgActor): ContextMenu.Item[] => [
   {
     name: localize("RQG.Game.RollChat"),
     icon: ContextMenuRunes.RollViaChat,
@@ -41,13 +37,7 @@ export const spiritMagicMenuOptions = (
       if (item.data.data.isVariable && item.data.data.points > 1) {
         await item.toChat();
       } else {
-        await SpiritMagicChatHandler.roll(
-          item,
-          item.data.data.points,
-          0,
-          actor,
-          ChatMessage.getSpeaker({ actor: actor, token: token })
-        );
+        await item?.abilityRoll();
       }
     },
   },

--- a/src/actors/item-specific/abstractEmbeddedItem.ts
+++ b/src/actors/item-specific/abstractEmbeddedItem.ts
@@ -1,5 +1,6 @@
 import { RqgItem } from "../../items/rqgItem";
 import { RqgActor } from "../rqgActor";
+import { RqgError } from "../../system/util";
 
 /**
  * Separate item specific actions that should be done on embedded items when actor _onCreateEmbeddedDocuments etc. is called.
@@ -7,6 +8,11 @@ import { RqgActor } from "../rqgActor";
 export abstract class AbstractEmbeddedItem {
   // TODO ***
   // public static init() {}
+
+  static toChat(item: RqgItem): void {}
+
+  static async rollFromChat(): Promise<void> {}
+  static async roll(): Promise<void> {}
 
   static preEmbedItem(actor: RqgActor, item: RqgItem, options: object[], userId: string): void {}
 

--- a/src/actors/item-specific/abstractEmbeddedItem.ts
+++ b/src/actors/item-specific/abstractEmbeddedItem.ts
@@ -1,6 +1,6 @@
 import { RqgItem } from "../../items/rqgItem";
 import { RqgActor } from "../rqgActor";
-import { RqgError } from "../../system/util";
+import { ResultEnum } from "../../data-model/shared/ability";
 
 /**
  * Separate item specific actions that should be done on embedded items when actor _onCreateEmbeddedDocuments etc. is called.
@@ -9,10 +9,17 @@ export abstract class AbstractEmbeddedItem {
   // TODO ***
   // public static init() {}
 
-  static toChat(item: RqgItem): void {}
+  /**
+   * Send this item to a chat message to select option before doing a roll against it.
+   */
+  static async toChat(item: RqgItem): Promise<void> {}
 
-  static async rollFromChat(): Promise<void> {}
-  static async roll(): Promise<void> {}
+  /**
+   * Do a roll immediately with specified options.
+   */
+  static async abilityRoll(item: RqgItem, options: {}): Promise<ResultEnum | undefined> {
+    return;
+  }
 
   static preEmbedItem(actor: RqgActor, item: RqgItem, options: object[], userId: string): void {}
 

--- a/src/actors/item-specific/passion.ts
+++ b/src/actors/item-specific/passion.ts
@@ -1,4 +1,8 @@
 import { AbstractEmbeddedItem } from "./abstractEmbeddedItem";
+import { RqgItem } from "../../items/rqgItem";
+import { ItemChatFlags } from "../../data-model/shared/rqgDocumentFlags";
+import { ItemChatHandler } from "../../chat/itemChatHandler";
+import { activateChatTab } from "../../system/util";
 
 export class Passion extends AbstractEmbeddedItem {
   // public static init() {
@@ -7,4 +11,20 @@ export class Passion extends AbstractEmbeddedItem {
   //     makeDefault: true,
   //   });
   // }
+
+  static async toChat(passion: RqgItem): Promise<void> {
+    const flags: ItemChatFlags = {
+      type: "itemChat",
+      chat: {
+        actorUuid: passion.actor!.uuid,
+        tokenUuid: passion.actor!.token?.uuid,
+        chatImage: passion.img ?? "",
+        itemUuid: passion.uuid,
+      },
+      formData: {
+        modifier: "",
+      },
+    };
+    await ChatMessage.create(await ItemChatHandler.renderContent(flags));
+  }
 }

--- a/src/actors/item-specific/passion.ts
+++ b/src/actors/item-specific/passion.ts
@@ -2,7 +2,9 @@ import { AbstractEmbeddedItem } from "./abstractEmbeddedItem";
 import { RqgItem } from "../../items/rqgItem";
 import { ItemChatFlags } from "../../data-model/shared/rqgDocumentFlags";
 import { ItemChatHandler } from "../../chat/itemChatHandler";
-import { activateChatTab } from "../../system/util";
+import { assertItemType, formatModifier, localize } from "../../system/util";
+import { ResultEnum } from "../../data-model/shared/ability";
+import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
 
 export class Passion extends AbstractEmbeddedItem {
   // public static init() {
@@ -26,5 +28,20 @@ export class Passion extends AbstractEmbeddedItem {
       },
     };
     await ChatMessage.create(await ItemChatHandler.renderContent(flags));
+  }
+
+  public static async abilityRoll(passion: RqgItem, options: any): Promise<ResultEnum> {
+    assertItemType(passion?.data.type, ItemTypeEnum.Passion);
+    const chance: number = Number(passion.data.data.chance) || 0;
+    let flavor = localize("RQG.Dialog.itemChat.RollFlavor", { name: passion.name });
+    if (options.modifier && options.modifier !== 0) {
+      flavor += localize("RQG.Dialog.itemChat.RollFlavorModifier", {
+        modifier: formatModifier(options.modifier),
+      });
+    }
+    const speaker = ChatMessage.getSpeaker({ actor: passion.actor ?? undefined });
+    const result = await passion._roll(flavor, chance, options.modifier, speaker);
+    await passion.checkExperience(result);
+    return result;
   }
 }

--- a/src/actors/item-specific/rune.ts
+++ b/src/actors/item-specific/rune.ts
@@ -2,9 +2,10 @@ import { AbstractEmbeddedItem } from "./abstractEmbeddedItem";
 import { RqgActor } from "../rqgActor";
 import { RqgItem } from "../../items/rqgItem";
 import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
-import { activateChatTab, localize } from "../../system/util";
+import { assertItemType, formatModifier, localize } from "../../system/util";
 import { ItemChatFlags } from "../../data-model/shared/rqgDocumentFlags";
 import { ItemChatHandler } from "../../chat/itemChatHandler";
+import { ResultEnum } from "../../data-model/shared/ability";
 
 export class Rune extends AbstractEmbeddedItem {
   // public static init() {
@@ -30,6 +31,23 @@ export class Rune extends AbstractEmbeddedItem {
     await ChatMessage.create(await ItemChatHandler.renderContent(flags));
   }
 
+  static async abilityRoll(
+    runeItem: RqgItem,
+    options: { modifier: number }
+  ): Promise<ResultEnum | undefined> {
+    const chance: number = Number((runeItem?.data.data as any).chance) || 0;
+    let flavor = localize("RQG.Dialog.itemChat.RollFlavor", { name: runeItem.name });
+    if (options.modifier && options.modifier !== 0) {
+      flavor += localize("RQG.Dialog.itemChat.RollFlavorModifier", {
+        modifier: formatModifier(options.modifier),
+      });
+    }
+    const speaker = ChatMessage.getSpeaker({ actor: runeItem.actor ?? undefined });
+    const result = await runeItem._roll(flavor, chance, options.modifier, speaker);
+    await runeItem.checkExperience(result);
+    return result;
+  }
+
   static preUpdateItem(actor: RqgActor, rune: RqgItem, updates: any[], options: any): void {
     if (rune.data.type === ItemTypeEnum.Rune) {
       const chanceResult = updates.find((r) => r["data.chance"] != null);
@@ -38,29 +56,17 @@ export class Rune extends AbstractEmbeddedItem {
       }
       if (rune.data.data.opposingRune) {
         const opposingRune = actor.items.getName(rune.data.data.opposingRune);
-        this.adjustOpposingRuneChance(
-          opposingRune,
-          rune,
-          actor,
-          chanceResult["data.chance"],
-          updates
-        );
+        this.adjustOpposingRuneChance(opposingRune, chanceResult["data.chance"], updates);
       }
     }
   }
 
   private static adjustOpposingRuneChance(
     opposingRune: RqgItem | undefined,
-    item: RqgItem,
-    actor: RqgActor,
     newChance: number,
     updates: object[]
   ) {
-    if (!opposingRune || opposingRune.data.type !== ItemTypeEnum.Rune) {
-      const msg = localize("RQG.Item.Notification.OpposingRuneDoesNotExistWarning");
-      ui.notifications?.warn(msg);
-      return;
-    }
+    assertItemType(opposingRune?.data.type, ItemTypeEnum.Rune);
     const opposingRuneChance = opposingRune.data.data.chance;
     if (newChance + opposingRuneChance !== 100) {
       updates.push({

--- a/src/actors/item-specific/rune.ts
+++ b/src/actors/item-specific/rune.ts
@@ -2,7 +2,9 @@ import { AbstractEmbeddedItem } from "./abstractEmbeddedItem";
 import { RqgActor } from "../rqgActor";
 import { RqgItem } from "../../items/rqgItem";
 import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
-import { localize } from "../../system/util";
+import { activateChatTab, localize } from "../../system/util";
+import { ItemChatFlags } from "../../data-model/shared/rqgDocumentFlags";
+import { ItemChatHandler } from "../../chat/itemChatHandler";
 
 export class Rune extends AbstractEmbeddedItem {
   // public static init() {
@@ -11,6 +13,23 @@ export class Rune extends AbstractEmbeddedItem {
   //     makeDefault: true,
   //   });
   // }
+
+  static async toChat(rune: RqgItem): Promise<void> {
+    const flags: ItemChatFlags = {
+      type: "itemChat",
+      chat: {
+        actorUuid: rune.actor!.uuid,
+        tokenUuid: rune.actor!.token?.uuid,
+        chatImage: rune.img ?? "",
+        itemUuid: rune.uuid,
+      },
+      formData: {
+        modifier: "",
+      },
+    };
+    await ChatMessage.create(await ItemChatHandler.renderContent(flags));
+  }
+
   static preUpdateItem(actor: RqgActor, rune: RqgItem, updates: any[], options: any): void {
     if (rune.data.type === ItemTypeEnum.Rune) {
       const chanceResult = updates.find((r) => r["data.chance"] != null);

--- a/src/actors/item-specific/runeMagic.ts
+++ b/src/actors/item-specific/runeMagic.ts
@@ -2,12 +2,14 @@ import { AbstractEmbeddedItem } from "./abstractEmbeddedItem";
 import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
 import { RqgActor } from "../rqgActor";
 import { RqgItem } from "../../items/rqgItem";
-import { activateChatTab, assertItemType, getGame, localize, RqgError } from "../../system/util";
+import { assertActorType, assertItemType, getGame, localize, RqgError } from "../../system/util";
 import { ItemDataSource } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/itemData";
 import { systemId } from "../../system/config";
-import { ItemChatFlags, RuneMagicChatFlags } from "../../data-model/shared/rqgDocumentFlags";
-import { ItemChatHandler } from "../../chat/itemChatHandler";
+import { RuneMagicChatFlags } from "../../data-model/shared/rqgDocumentFlags";
 import { RuneMagicChatHandler } from "../../chat/runeMagicChatHandler";
+import { ResultEnum, ResultMessage } from "../../data-model/shared/ability";
+import { ActorTypeEnum } from "../../data-model/actor-data/rqgActorData";
+import { RuneDataPropertiesData } from "../../data-model/item-data/runeData";
 
 export class RuneMagic extends AbstractEmbeddedItem {
   // public static init() {
@@ -18,8 +20,8 @@ export class RuneMagic extends AbstractEmbeddedItem {
   // }
 
   static async toChat(runeMagic: RqgItem): Promise<void> {
-    const eligibleRunes = RuneMagicChatHandler.getEligibleRunes(runeMagic, runeMagic.actor!);
-    const defaultRuneId = RuneMagicChatHandler.getStrongestRune(eligibleRunes)?.id;
+    const eligibleRunes = RuneMagic.getEligibleRunes(runeMagic);
+    const defaultRuneId = RuneMagic.getStrongestRune(eligibleRunes)?.id;
     assertItemType(runeMagic.data.type, ItemTypeEnum.RuneMagic);
     const flags: RuneMagicChatFlags = {
       type: "runeMagicChat",
@@ -40,6 +42,91 @@ export class RuneMagic extends AbstractEmbeddedItem {
     };
 
     await ChatMessage.create(await RuneMagicChatHandler.renderContent(flags));
+  }
+
+  static async abilityRoll(
+    runeMagicItem: RqgItem,
+    options: {
+      runePointsCost: number;
+      magicPointBoost: number;
+      ritualOrMeditation: number;
+      skillAugmentation: number;
+      otherModifiers: number;
+      selectedRuneId?: string;
+    }
+  ): Promise<ResultEnum | undefined> {
+    assertItemType(runeMagicItem.data.type, ItemTypeEnum.RuneMagic);
+    const runeMagicCultId = runeMagicItem?.data.data.cultId;
+    const cult = runeMagicItem.actor?.items.get(runeMagicCultId);
+    assertItemType(cult?.data.type, ItemTypeEnum.Cult);
+    if (!options.selectedRuneId) {
+      const eligibleRunes = RuneMagic.getEligibleRunes(runeMagicItem);
+      options.selectedRuneId = RuneMagic.getStrongestRune(eligibleRunes)?.id ?? "";
+    }
+    const runeItem = runeMagicItem.actor?.items.get(options.selectedRuneId);
+    assertItemType(runeItem?.data.type, ItemTypeEnum.Rune);
+
+    const validationError = RuneMagic.validateData(
+      cult,
+      options.runePointsCost,
+      options.magicPointBoost
+    );
+    if (validationError) {
+      ui.notifications?.warn(validationError);
+      return;
+    }
+
+    const resultMessages: ResultMessage[] = [
+      {
+        result: ResultEnum.Critical,
+        html: localize("RQG.Dialog.runeMagicChat.resultMessageCritical", {
+          magicPointBoost: options.magicPointBoost,
+        }),
+      },
+      {
+        result: ResultEnum.Special,
+        html: localize("RQG.Dialog.runeMagicChat.resultMessageSpecial", {
+          runePointCost: options.runePointsCost,
+          magicPointBoost: options.magicPointBoost,
+        }),
+      },
+      {
+        result: ResultEnum.Success,
+        html: localize("RQG.Dialog.runeMagicChat.resultMessageSuccess", {
+          runePointCost: options.runePointsCost,
+          magicPointBoost: options.magicPointBoost,
+        }),
+      },
+      {
+        result: ResultEnum.Failure,
+        html: localize("RQG.Dialog.runeMagicChat.resultMessageFailure"),
+      },
+      {
+        result: ResultEnum.Fumble,
+        html: localize("RQG.Dialog.runeMagicChat.resultMessageFumble", {
+          runePointCost: options.runePointsCost,
+        }),
+      },
+    ];
+
+    const speaker = ChatMessage.getSpeaker({ actor: runeMagicItem.actor ?? undefined });
+    const result = await runeMagicItem._roll(
+      localize("RQG.Dialog.runeMagicChat.Cast", { spellName: runeMagicItem.name }),
+      Number(runeItem.data.data.chance),
+      options.ritualOrMeditation + options.skillAugmentation + options.otherModifiers,
+      speaker,
+      resultMessages
+    );
+
+    await RuneMagic.handleRollResult(
+      result,
+      options.runePointsCost,
+      options.magicPointBoost,
+      runeItem,
+      runeMagicItem
+    );
+
+    return result;
   }
 
   static onActorPrepareEmbeddedEntities(item: RqgItem): RqgItem {
@@ -167,5 +254,178 @@ export class RuneMagic extends AbstractEmbeddedItem {
       });
       await dialog.render(true);
     });
+  }
+
+  public static validateData(
+    cultItem: RqgItem,
+    runePointsUsed: number,
+    magicPointsBoost: number
+  ): string {
+    assertItemType(cultItem?.data.type, ItemTypeEnum.Cult);
+    if (runePointsUsed > (Number(cultItem.data.data.runePoints.value) || 0)) {
+      return getGame().i18n.format("RQG.Dialog.runeMagicChat.validationNotEnoughRunePoints");
+    } else if (
+      magicPointsBoost > (Number(cultItem.actor?.data.data.attributes?.magicPoints?.value) || 0)
+    ) {
+      return localize("RQG.Dialog.runeMagicChat.validationNotEnoughMagicPoints");
+    } else {
+      return "";
+    }
+  }
+
+  /**
+   * Given a rune spell and an actor, returns the runes that are possible to use for casting that spell.
+   */
+  static getEligibleRunes(runeMagicItem: RqgItem): RqgItem[] {
+    assertItemType(runeMagicItem.data.type, ItemTypeEnum.RuneMagic);
+
+    // The cult from where the spell was learned
+    const cult = runeMagicItem.actor?.items.get(runeMagicItem.data.data.cultId);
+    assertItemType(cult?.data.type, ItemTypeEnum.Cult);
+
+    // Get the name of the "magic" rune.
+    const magicRuneName = getGame().settings.get(systemId, "magicRuneName");
+
+    let usableRuneNames: string[];
+    if (runeMagicItem.data.data.runes.includes(magicRuneName)) {
+      // Actor can use any of the cult's runes to cast
+      // And some cults have the same rune more than once, so de-dupe them
+      usableRuneNames = [...new Set(cult.data.data.runes)];
+    } else {
+      // Actor can use any of the Rune Magic Spell's runes to cast
+      usableRuneNames = [...new Set(runeMagicItem.data.data.runes)];
+    }
+
+    let runesForCasting: RqgItem[] = [];
+    // Get the actor's versions of the runes, which will have their "chance"
+    usableRuneNames.forEach((runeName: string) => {
+      const actorRune = runeMagicItem.actor?.items.getName(runeName);
+      assertItemType(actorRune?.data.type, ItemTypeEnum.Rune);
+      runesForCasting.push(actorRune);
+    });
+
+    return runesForCasting;
+  }
+
+  static getStrongestRune(runeMagicItems: RqgItem[]): RqgItem | undefined {
+    if (runeMagicItems.length === 0) {
+      return undefined;
+    }
+    return runeMagicItems.reduce((strongest: RqgItem, current: RqgItem) => {
+      const strongestRuneChance = (strongest.data.data as RuneDataPropertiesData).chance ?? 0;
+      const currentRuneChance = (current.data.data as RuneDataPropertiesData).chance ?? 0;
+      return strongestRuneChance > currentRuneChance ? strongest : current;
+    });
+  }
+
+  private static async handleRollResult(
+    result: ResultEnum,
+    runePointsUsed: number,
+    magicPointsUsed: number,
+    runeItem: RqgItem,
+    runeMagicItem: RqgItem
+  ): Promise<void> {
+    assertItemType(runeItem.data.type, ItemTypeEnum.Rune);
+    assertItemType(runeMagicItem.data.type, ItemTypeEnum.RuneMagic);
+    const cult = runeMagicItem.actor?.items.get(runeMagicItem.data.data.cultId ?? "");
+    assertItemType(cult?.data.type, ItemTypeEnum.Cult);
+    const isOneUse = runeMagicItem.data.data.isOneUse;
+
+    switch (result) {
+      case ResultEnum.Critical:
+      case ResultEnum.SpecialCritical:
+      case ResultEnum.HyperCritical:
+        // spell takes effect, Rune Points NOT spent, Rune gets xp check, boosting Magic Points spent
+        await RuneMagic.SpendRuneAndMagicPoints(
+          0,
+          magicPointsUsed,
+          runeMagicItem.actor ?? undefined,
+          cult,
+          isOneUse
+        );
+        await runeItem.awardExperience();
+        break;
+
+      case ResultEnum.Success:
+      case ResultEnum.Special:
+        // spell takes effect, Rune Points spent, Rune gets xp check, boosting Magic Points spent
+        await RuneMagic.SpendRuneAndMagicPoints(
+          runePointsUsed,
+          magicPointsUsed,
+          runeMagicItem.actor ?? undefined,
+          cult,
+          isOneUse
+        );
+        await runeItem.awardExperience();
+        break;
+
+      case ResultEnum.Failure:
+        {
+          // spell fails, no Rune Point Loss, if Magic Point boosted, lose 1 Magic Point if boosted
+          const boosted = magicPointsUsed >= 1 ? 1 : 0;
+          await RuneMagic.SpendRuneAndMagicPoints(
+            0,
+            boosted,
+            runeMagicItem.actor ?? undefined,
+            cult,
+            isOneUse
+          );
+        }
+        break;
+
+      case ResultEnum.Fumble:
+        // spell fails, lose Rune Points, if Magic Point boosted, lose 1 Magic Point if boosted
+        const boosted = magicPointsUsed >= 1 ? 1 : 0;
+        await RuneMagic.SpendRuneAndMagicPoints(
+          runePointsUsed,
+          boosted,
+          runeMagicItem.actor ?? undefined,
+          cult,
+          isOneUse
+        );
+        break;
+
+      default:
+        const msg = "Got unexpected result from roll in runeMagicChat";
+        ui.notifications?.error(msg);
+        throw new RqgError(msg);
+    }
+  }
+
+  private static async SpendRuneAndMagicPoints(
+    runePoints: number,
+    magicPoints: number,
+    actor: RqgActor | undefined,
+    cult: RqgItem,
+    isOneUse: boolean
+  ) {
+    assertItemType(cult.data.type, ItemTypeEnum.Cult);
+    assertActorType(actor?.data.type, ActorTypeEnum.Character);
+    // At this point if the current Rune Points or Magic Points are zero
+    // it's too late. That validation happened earlier.
+    const newRunePointTotal = (cult.data.data.runePoints.value || 0) - runePoints;
+    const newMagicPointTotal = (actor?.data.data.attributes.magicPoints.value || 0) - magicPoints;
+    let newRunePointMaxTotal = cult.data.data.runePoints.max || 0;
+    if (isOneUse) {
+      newRunePointMaxTotal -= runePoints;
+      if (newRunePointMaxTotal < (cult.data.data.runePoints.max || 0)) {
+        ui.notifications?.info(
+          localize("RQG.Dialog.runeMagicChat.SpentOneUseRunePoints", {
+            actorName: actor?.name,
+            runePoints: runePoints,
+            cultName: cult.name,
+          })
+        );
+      }
+    }
+    const updateCultItemRunePoints: DeepPartial<ItemDataSource> = {
+      _id: cult?.id,
+      data: { runePoints: { value: newRunePointTotal, max: newRunePointMaxTotal } },
+    };
+    await actor?.updateEmbeddedDocuments("Item", [updateCultItemRunePoints]);
+    const updateActorMagicPoints = {
+      data: { attributes: { magicPoints: { value: newMagicPointTotal } } },
+    };
+    await actor?.update(updateActorMagicPoints);
   }
 }

--- a/src/actors/item-specific/runeMagic.ts
+++ b/src/actors/item-specific/runeMagic.ts
@@ -47,7 +47,7 @@ export class RuneMagic extends AbstractEmbeddedItem {
   static async abilityRoll(
     runeMagicItem: RqgItem,
     options: {
-      runePointsCost: number;
+      runePointCost: number;
       magicPointBoost: number;
       ritualOrMeditation: number;
       skillAugmentation: number;
@@ -68,7 +68,7 @@ export class RuneMagic extends AbstractEmbeddedItem {
 
     const validationError = RuneMagic.validateData(
       cult,
-      options.runePointsCost,
+      options.runePointCost,
       options.magicPointBoost
     );
     if (validationError) {
@@ -86,14 +86,14 @@ export class RuneMagic extends AbstractEmbeddedItem {
       {
         result: ResultEnum.Special,
         html: localize("RQG.Dialog.runeMagicChat.resultMessageSpecial", {
-          runePointCost: options.runePointsCost,
+          runePointCost: options.runePointCost,
           magicPointBoost: options.magicPointBoost,
         }),
       },
       {
         result: ResultEnum.Success,
         html: localize("RQG.Dialog.runeMagicChat.resultMessageSuccess", {
-          runePointCost: options.runePointsCost,
+          runePointCost: options.runePointCost,
           magicPointBoost: options.magicPointBoost,
         }),
       },
@@ -104,7 +104,7 @@ export class RuneMagic extends AbstractEmbeddedItem {
       {
         result: ResultEnum.Fumble,
         html: localize("RQG.Dialog.runeMagicChat.resultMessageFumble", {
-          runePointCost: options.runePointsCost,
+          runePointCost: options.runePointCost,
         }),
       },
     ];
@@ -120,7 +120,7 @@ export class RuneMagic extends AbstractEmbeddedItem {
 
     await RuneMagic.handleRollResult(
       result,
-      options.runePointsCost,
+      options.runePointCost,
       options.magicPointBoost,
       runeItem,
       runeMagicItem
@@ -258,11 +258,11 @@ export class RuneMagic extends AbstractEmbeddedItem {
 
   public static validateData(
     cultItem: RqgItem,
-    runePointsUsed: number,
+    runePointCost: number,
     magicPointsBoost: number
   ): string {
     assertItemType(cultItem?.data.type, ItemTypeEnum.Cult);
-    if (runePointsUsed > (Number(cultItem.data.data.runePoints.value) || 0)) {
+    if (runePointCost > (Number(cultItem.data.data.runePoints.value) || 0)) {
       return getGame().i18n.format("RQG.Dialog.runeMagicChat.validationNotEnoughRunePoints");
     } else if (
       magicPointsBoost > (Number(cultItem.actor?.data.data.attributes?.magicPoints?.value) || 0)
@@ -320,7 +320,7 @@ export class RuneMagic extends AbstractEmbeddedItem {
 
   private static async handleRollResult(
     result: ResultEnum,
-    runePointsUsed: number,
+    runePointCost: number,
     magicPointsUsed: number,
     runeItem: RqgItem,
     runeMagicItem: RqgItem
@@ -350,7 +350,7 @@ export class RuneMagic extends AbstractEmbeddedItem {
       case ResultEnum.Special:
         // spell takes effect, Rune Points spent, Rune gets xp check, boosting Magic Points spent
         await RuneMagic.SpendRuneAndMagicPoints(
-          runePointsUsed,
+          runePointCost,
           magicPointsUsed,
           runeMagicItem.actor ?? undefined,
           cult,
@@ -377,7 +377,7 @@ export class RuneMagic extends AbstractEmbeddedItem {
         // spell fails, lose Rune Points, if Magic Point boosted, lose 1 Magic Point if boosted
         const boosted = magicPointsUsed >= 1 ? 1 : 0;
         await RuneMagic.SpendRuneAndMagicPoints(
-          runePointsUsed,
+          runePointCost,
           boosted,
           runeMagicItem.actor ?? undefined,
           cult,

--- a/src/actors/item-specific/skill.ts
+++ b/src/actors/item-specific/skill.ts
@@ -1,9 +1,11 @@
 import { AbstractEmbeddedItem } from "./abstractEmbeddedItem";
 import { RqgItem } from "../../items/rqgItem";
 import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
-import { localize, RqgError } from "../../system/util";
+import { activateChatTab, localize, RqgError } from "../../system/util";
 import { ActorTypeEnum } from "../../data-model/actor-data/rqgActorData";
 import { SkillDataPropertiesData } from "../../data-model/item-data/skillData";
+import { ItemChatFlags } from "../../data-model/shared/rqgDocumentFlags";
+import { ItemChatHandler } from "../../chat/itemChatHandler";
 
 export class Skill extends AbstractEmbeddedItem {
   // public static init() {
@@ -12,6 +14,22 @@ export class Skill extends AbstractEmbeddedItem {
   //     makeDefault: true,
   //   });
   // }
+
+  static async toChat(skill: RqgItem): Promise<void> {
+    const flags: ItemChatFlags = {
+      type: "itemChat",
+      chat: {
+        actorUuid: skill.actor!.uuid,
+        tokenUuid: skill.actor!.token?.uuid,
+        chatImage: skill.img ?? "",
+        itemUuid: skill.uuid,
+      },
+      formData: {
+        modifier: "",
+      },
+    };
+    await ChatMessage.create(await ItemChatHandler.renderContent(flags));
+  }
 
   public static onActorPrepareDerivedData(skillItem: RqgItem): RqgItem {
     if (skillItem.data.type !== ItemTypeEnum.Skill) {

--- a/src/actors/item-specific/spiritMagic.ts
+++ b/src/actors/item-specific/spiritMagic.ts
@@ -1,4 +1,9 @@
 import { AbstractEmbeddedItem } from "./abstractEmbeddedItem";
+import { activateChatTab, assertItemType } from "../../system/util";
+import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
+import { SpiritMagicChatFlags } from "../../data-model/shared/rqgDocumentFlags";
+import { SpiritMagicChatHandler } from "../../chat/spiritMagicChatHandler";
+import { RqgItem } from "../../items/rqgItem";
 
 export class SpiritMagic extends AbstractEmbeddedItem {
   // public static init() {
@@ -7,4 +12,24 @@ export class SpiritMagic extends AbstractEmbeddedItem {
   //     makeDefault: true,
   //   });
   // }
+
+  static async toChat(spiritMagic: RqgItem): Promise<void> {
+    assertItemType(spiritMagic.data.type, ItemTypeEnum.SpiritMagic);
+
+    const flags: SpiritMagicChatFlags = {
+      type: "spiritMagicChat",
+      chat: {
+        actorUuid: spiritMagic.actor!.uuid,
+        tokenUuid: spiritMagic.actor!.token?.uuid,
+        chatImage: spiritMagic.img ?? "",
+        itemUuid: spiritMagic.uuid,
+      },
+      formData: {
+        level: spiritMagic.data.data.points.toString(),
+        boost: "",
+      },
+    };
+
+    await ChatMessage.create(await SpiritMagicChatHandler.renderContent(flags));
+  }
 }

--- a/src/actors/item-specific/spiritMagic.ts
+++ b/src/actors/item-specific/spiritMagic.ts
@@ -1,9 +1,10 @@
 import { AbstractEmbeddedItem } from "./abstractEmbeddedItem";
-import { activateChatTab, assertItemType } from "../../system/util";
+import { assertItemType, localize } from "../../system/util";
 import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
 import { SpiritMagicChatFlags } from "../../data-model/shared/rqgDocumentFlags";
 import { SpiritMagicChatHandler } from "../../chat/spiritMagicChatHandler";
 import { RqgItem } from "../../items/rqgItem";
+import { ResultEnum } from "../../data-model/shared/ability";
 
 export class SpiritMagic extends AbstractEmbeddedItem {
   // public static init() {
@@ -31,5 +32,47 @@ export class SpiritMagic extends AbstractEmbeddedItem {
     };
 
     await ChatMessage.create(await SpiritMagicChatHandler.renderContent(flags));
+  }
+
+  static async abilityRoll(
+    spiritMagicItem: RqgItem,
+    options: { level: number; boost: number }
+  ): Promise<ResultEnum | undefined> {
+    const validationError = SpiritMagic.validateRollData(
+      spiritMagicItem,
+      options.level,
+      options.boost
+    );
+    if (validationError) {
+      ui.notifications?.warn(validationError);
+      return;
+    }
+    const mpCost = options.level + options.boost;
+    const result = await spiritMagicItem._roll(
+      localize("RQG.Dialog.spiritMagicChat.Cast", { spellName: spiritMagicItem.name }),
+      (spiritMagicItem.actor?.data.data.characteristics.power.value ?? 0) * 5,
+      0,
+      ChatMessage.getSpeaker({ actor: spiritMagicItem.actor ?? undefined })
+    );
+    await spiritMagicItem.actor?.drawMagicPoints(mpCost, result);
+    return result;
+  }
+
+  public static validateRollData(
+    spiritMagicItem: RqgItem,
+    level: number,
+    boost: number
+  ): string | undefined {
+    assertItemType(spiritMagicItem.data.type, ItemTypeEnum.SpiritMagic);
+    if (level > spiritMagicItem.data.data.points) {
+      return localize("RQG.Dialog.spiritMagicChat.CantCastSpellAboveLearnedLevel");
+    } else if (
+      level + boost >
+      (spiritMagicItem.actor?.data.data.attributes.magicPoints.value || 0)
+    ) {
+      return localize("RQG.Dialog.spiritMagicChat.NotEnoughMagicPoints");
+    } else {
+      return;
+    }
   }
 }

--- a/src/actors/item-specific/weapon.ts
+++ b/src/actors/item-specific/weapon.ts
@@ -1,11 +1,31 @@
 import { AbstractEmbeddedItem } from "./abstractEmbeddedItem";
 import { RqgItem } from "../../items/rqgItem";
 import { RqgActor } from "../rqgActor";
-import { assertItemType, localize, logMisconfiguration } from "../../system/util";
+import {
+  assertChatMessageFlagType,
+  assertItemType,
+  convertFormValueToString,
+  getGame,
+  getGameUser,
+  hasOwnProperty,
+  localize,
+  logMisconfiguration,
+  requireValue,
+  RqgError,
+  usersIdsThatOwnActor,
+} from "../../system/util";
 import { ItemTypeEnum } from "../../data-model/item-data/itemTypes";
 import { getSameLocationUpdates } from "./shared/physicalItemUtil";
-import { WeaponChatHandler } from "../../chat/weaponChatHandler";
+import { DamageRollTypeEnum, WeaponChatHandler } from "../../chat/weaponChatHandler";
 import { WeaponChatFlags } from "../../data-model/shared/rqgDocumentFlags";
+import { ResultEnum } from "../../data-model/shared/ability";
+import { CombatManeuver, DamageType, UsageType } from "../../data-model/item-data/weaponData";
+import { RqgChatMessage } from "src/chat/RqgChatMessage";
+import { ChatSpeakerDataProperties } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatSpeakerData";
+import { DeepPartial } from "snowpack";
+import { ItemDataSource } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/itemData";
+import { systemId } from "../../system/config";
+import { ChatMessageDataConstructorData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatMessageData";
 
 export class Weapon extends AbstractEmbeddedItem {
   // public static init() {
@@ -17,7 +37,7 @@ export class Weapon extends AbstractEmbeddedItem {
 
   static async toChat(weapon: RqgItem): Promise<void> {
     assertItemType(weapon.data.type, ItemTypeEnum.Weapon);
-    const usage = WeaponChatHandler.getDefaultUsage(weapon);
+    const usage = Weapon.getDefaultUsage(weapon);
     if (!usage) {
       return; // There is no way to use this weapon - it could be arrows for example
     }
@@ -41,6 +61,71 @@ export class Weapon extends AbstractEmbeddedItem {
     };
 
     await ChatMessage.create(await WeaponChatHandler.renderContent(flags));
+  }
+  // All rolls in one for now, differentiate with actionName
+  static async abilityRoll(
+    weaponItem: RqgItem,
+    options: {
+      actionName: string;
+      actionValue: string;
+      otherModifiers: number;
+      usageType: UsageType;
+      chatMessage: RqgChatMessage;
+    }
+  ): Promise<ResultEnum | undefined> {
+    assertItemType(weaponItem.data.type, ItemTypeEnum.Weapon);
+    requireValue(weaponItem.actor, "Called weapon abilityRoll with a not embedded weapon item");
+    const speaker = ChatMessage.getSpeaker({ actor: weaponItem.actor ?? undefined });
+
+    switch (options.actionName) {
+      case "combatManeuverRoll":
+        const weaponUsage = weaponItem.data.data.usage[options.usageType];
+        const combatManeuver = weaponUsage.combatManeuvers.find(
+          (m) => m.name === options.actionValue
+        );
+        requireValue(
+          combatManeuver,
+          `Couldn't find combatmaneuver [${options.actionName}] and usage type [${options.usageType}] on weapon [${weaponItem.name}]`,
+          weaponItem
+        );
+        await Weapon.combatManeuverRoll(
+          weaponItem,
+          options.usageType,
+          combatManeuver,
+          options.chatMessage,
+          options.otherModifiers,
+          speaker
+        );
+        return;
+
+      case "damageRoll":
+        assertChatMessageFlagType(options.chatMessage.data.flags.rqg?.type, "weaponChat");
+        const damageRollType = options.actionValue as DamageRollTypeEnum; // TODO improve typing
+        await Weapon.damageRoll(
+          weaponItem,
+          options.usageType,
+          convertFormValueToString(options.chatMessage.data.flags.rqg?.formData.combatManeuverName),
+
+          damageRollType,
+          speaker
+        );
+        return;
+
+      case "hitLocationRoll":
+        await Weapon.hitLocationRoll(speaker);
+        return;
+
+      case "fumbleRoll":
+        await Weapon.fumbleRoll(weaponItem.actor);
+        return;
+
+      default:
+        const msg = localize("RQG.Dialog.weaponChat.UnknownButtonInChatError", {
+          actionButton: options.actionName,
+        });
+        ui.notifications?.error(msg);
+        throw new RqgError(msg, options.actionName);
+    }
   }
 
   static preUpdateItem(actor: RqgActor, weapon: RqgItem, updates: object[], options: any): void {
@@ -149,5 +234,294 @@ export class Weapon extends AbstractEmbeddedItem {
       }
     }
     return embeddedSkillId;
+  }
+
+  static getDefaultUsage(weapon: RqgItem): UsageType {
+    assertItemType(weapon.data.type, ItemTypeEnum.Weapon);
+    const defaultUsage = weapon.data.data.defaultUsage;
+    if (defaultUsage) {
+      return defaultUsage;
+    }
+    const options = WeaponChatHandler.getUsageTypeOptions(weapon);
+    // Fallback to picking the first available
+    return Object.keys(options)[0] as UsageType;
+  }
+
+  private static async combatManeuverRoll(
+    weaponItem: RqgItem,
+    usage: UsageType,
+    combatManeuver: CombatManeuver,
+    chatMessage: RqgChatMessage,
+    otherModifiers: number,
+    speaker: ChatSpeakerDataProperties
+  ): Promise<void> {
+    assertItemType(weaponItem.data.type, ItemTypeEnum.Weapon);
+    requireValue(chatMessage, "No chat message provided for combarManeuverRoll");
+    const damageType = combatManeuver?.damageType;
+    const specialDamageTypeDescription =
+      damageType === "special" ? combatManeuver?.description || undefined : undefined;
+    const flags = chatMessage.data.flags.rqg;
+    assertChatMessageFlagType(flags?.type, "weaponChat");
+
+    flags.chat.specialDamageTypeText =
+      specialDamageTypeDescription ??
+      CONFIG.RQG.combatManeuvers.get(combatManeuver?.name ?? "")?.specialDescriptionHtml;
+
+    const projectileItemData = weaponItem.data.data.isProjectileWeapon
+      ? weaponItem.actor?.items.get(weaponItem.data.data.projectileId)?.data
+      : weaponItem.data; // Thrown (or melee)
+
+    let originalAmmoQty: number = 0;
+
+    // Decrease quantity of linked projectile if shooting
+    if (
+      projectileItemData?.type === ItemTypeEnum.Weapon &&
+      projectileItemData.data.quantity &&
+      projectileItemData.data.quantity > 0 &&
+      usage === "missile" &&
+      !["parry", "special"].includes(damageType ?? "")
+    ) {
+      originalAmmoQty = projectileItemData.data.quantity;
+      const updateData: DeepPartial<ItemDataSource> = {
+        _id: projectileItemData._id,
+        data: { quantity: --projectileItemData.data.quantity },
+      };
+      await weaponItem.actor?.updateEmbeddedDocuments("Item", [updateData]);
+    }
+
+    if (usage === "missile" && !projectileItemData) {
+      ui.notifications?.warn(
+        localize("RQG.Dialog.weaponChat.OutOfAmmoWarn", {
+          projectileName: "---",
+          combatManeuverName: combatManeuver?.name,
+        })
+      );
+      return;
+    }
+
+    // Prevent using weapons with projectile quantity 0
+    if (
+      projectileItemData?.type === ItemTypeEnum.Weapon &&
+      projectileItemData.data.quantity != null &&
+      projectileItemData.data.quantity <= 0
+    ) {
+      if (originalAmmoQty > 0) {
+        ui.notifications?.warn(
+          localize("RQG.Dialog.weaponChat.UsedLastOfAmmoWarn", {
+            projectileName: projectileItemData.name,
+          })
+        );
+      } else {
+        ui.notifications?.warn(
+          localize("RQG.Dialog.weaponChat.OutOfAmmoWarn", {
+            projectileName: projectileItemData.name,
+            combatManeuverName: combatManeuver?.name,
+          })
+        );
+        return;
+      }
+    }
+
+    const skillItem = Weapon.getUsedSkillItem(weaponItem, usage);
+    assertItemType(skillItem?.data.type, ItemTypeEnum.Skill);
+
+    const chance: number = Number(skillItem.data.data.chance) || 0;
+
+    flags.chat.result = await skillItem._roll(
+      skillItem.name + " " + Weapon.getDamageTypeString(damageType, [combatManeuver]),
+      chance,
+      otherModifiers,
+      speaker
+    );
+    await skillItem?.checkExperience(flags.chat.result);
+    const data = await WeaponChatHandler.renderContent(flags);
+    await chatMessage.update(data);
+  }
+
+  private static async damageRoll(
+    weaponItem: RqgItem,
+    usageType: UsageType,
+    combatManeuverName: string | undefined,
+    damageRollType: DamageRollTypeEnum,
+    speaker: ChatSpeakerDataProperties
+  ): Promise<void> {
+    requireValue(
+      combatManeuverName,
+      localize("RQG.Dialog.weaponChat.NoCombatManeuverInDamageRollError")
+    );
+    assertItemType(weaponItem.data.type, ItemTypeEnum.Weapon);
+    let damageBonusFormula: string =
+      weaponItem.actor?.data.data.attributes.damageBonus !== "0"
+        ? `${weaponItem.actor?.data.data.attributes.damageBonus}`
+        : "";
+
+    const weaponUsage = weaponItem.data.data.usage[usageType];
+    const weaponDamageTag = localize("RQG.Dialog.weaponChat.WeaponDamageTag");
+    const weaponDamage = hasOwnProperty(weaponUsage, "damage")
+      ? Roll.parse(`(${weaponUsage.damage})[${weaponDamageTag}]`, {})
+      : [];
+
+    if (usageType === "missile") {
+      if (weaponItem.data.data.isThrownWeapon) {
+        damageBonusFormula =
+          "ceil(" + (weaponItem.actor?.data.data.attributes.damageBonus || 0) + "/2)";
+      } else {
+        damageBonusFormula = "";
+      }
+    }
+
+    const damageRollTerms =
+      hasOwnProperty(weaponUsage, "damage") && weaponUsage.damage ? weaponDamage : []; // Don't add 0 damage rollTerm
+
+    const damageType = weaponUsage.combatManeuvers.find(
+      (m) => m.name === combatManeuverName
+    )?.damageType;
+    requireValue(
+      damageType,
+      localize("RQG.Dialog.weaponChat.WeaponDoesNotHaveCombatManeuverError")
+    );
+
+    if ([DamageRollTypeEnum.Special, DamageRollTypeEnum.MaxSpecial].includes(damageRollType)) {
+      if (["slash", "impale"].includes(damageType)) {
+        damageRollTerms.push(...Weapon.slashImpaleSpecialDamage(weaponUsage.damage));
+      } else if (damageType === "crush") {
+        damageRollTerms.push(...(await Weapon.crushSpecialDamage(damageBonusFormula)));
+      } else if (damageType === "parry") {
+        // Parry will use crush if existing or slash/impale if not, will work unless some weapon has both crush & slash
+        // No weapon in the core rulebook has that though
+        const usedParryingDamageType = Weapon.getDamageTypeString(
+          damageType,
+          weaponUsage.combatManeuvers
+        );
+        if (usedParryingDamageType === "crush") {
+          damageRollTerms.push(...(await Weapon.crushSpecialDamage(damageBonusFormula)));
+        } else if (["slash", "impale"].includes(usedParryingDamageType)) {
+          damageRollTerms.push(...Weapon.slashImpaleSpecialDamage(weaponUsage.damage));
+        } else {
+          logMisconfiguration(
+            localize("RQG.Dialog.weaponChat.WeaponDoesNotHaveCombatManeuverError", {
+              weaponName: weaponItem.name,
+            }),
+            true
+          );
+        }
+      }
+    }
+    if (damageBonusFormula.length) {
+      const damageBonusDamageTag = localize("RQG.Dialog.weaponChat.DamageBonusDamageTag");
+      damageRollTerms.push(...Roll.parse(`+ ${damageBonusFormula}[${damageBonusDamageTag}]`, {}));
+    }
+    const maximise = damageRollType === DamageRollTypeEnum.MaxSpecial;
+    const roll = Roll.fromTerms(damageRollTerms);
+    await roll.evaluate({
+      maximize: maximise,
+      async: true,
+    });
+    await roll.toMessage({
+      speaker: speaker,
+      type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+      flavor: `${localize("RQG.Dialog.weaponChat.Damage")}: ${Weapon.getDamageTypeString(
+        damageType,
+        weaponUsage.combatManeuvers
+      )}`,
+    });
+  }
+
+  private static getDamageTypeString(
+    damageType: DamageType,
+    combatManeuvers: CombatManeuver[]
+  ): string {
+    if (damageType === "parry") {
+      if (combatManeuvers.some((cm) => cm.damageType === "crush")) {
+        damageType = "crush";
+      } else if (combatManeuvers.some((cm) => cm.damageType === "slash")) {
+        damageType = "slash";
+      } else if (combatManeuvers.some((cm) => cm.damageType === "impale")) {
+        damageType = "impale";
+      }
+    }
+    return damageType;
+  }
+
+  private static async hitLocationRoll(speaker: ChatSpeakerDataProperties) {
+    const roll = new Roll("1d20");
+    await roll.evaluate({ async: true });
+    await roll.toMessage({
+      speaker: speaker,
+      type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+      flavor: localize("RQG.Dialog.weaponChat.HitLocationRollFlavor"),
+    });
+  }
+
+  private static async fumbleRoll(actor: RqgActor) {
+    const speaker = ChatMessage.getSpeaker({ actor: actor });
+    const fumbleTableName = getGame().settings.get(systemId, "fumbleRollTable");
+    const fumbleTable = getGame().tables?.getName(fumbleTableName);
+    if (!fumbleTable) {
+      logMisconfiguration(
+        localize("RQG.Dialog.weaponChat.FumbleTableMissingWarn", {
+          fumbleTableName: fumbleTableName,
+        }),
+        true
+      );
+      return;
+    }
+    // @ts-ignore TODO draw StoredDocument<RollTable>
+    const draw = await fumbleTable.draw({ displayChat: false });
+    // Construct chat data
+    const numberOfResults =
+      draw.results.length > 1
+        ? localize("RQG.Dialog.weaponChat.PluralResults", { numberOfResults: draw.results.length })
+        : localize("RQG.Dialog.weaponChat.SingularResult");
+    const messageData: ChatMessageDataConstructorData = {
+      flavor: localize("RQG.Dialog.weaponChat.DamageBonusDamageTag", {
+        numberOfResults: numberOfResults,
+        fumbleTableName: fumbleTableName,
+      }),
+      user: getGameUser().id,
+      speaker: speaker,
+      whisper: usersIdsThatOwnActor(actor),
+      type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+      roll: draw.roll,
+      sound: draw.roll ? CONFIG.sounds.dice : null,
+      flags: { "core.RollTable": fumbleTable.id },
+    };
+
+    // Render the chat message which combines the dice roll with the drawn results
+    messageData.content = await renderTemplate(CONFIG.RollTable.resultTemplate, {
+      // @ts-expect-error is "documents" in current foundry versions
+      description: TextEditor.enrichHTML(fumbleTable.data.description, { documents: true }),
+      results: draw.results.map((r: any) => {
+        // TODO fix typing
+        r.text = r.getChatText();
+        return r;
+      }),
+      rollHTML: fumbleTable.data.displayRoll ? await draw.roll.render() : null,
+      table: fumbleTable,
+    });
+
+    // Create the chat message
+    await ChatMessage.create(messageData);
+  }
+
+  private static async crushSpecialDamage(damageBonus: string): Promise<any[]> {
+    if (damageBonus.length) {
+      const specialDamage = Roll.parse(damageBonus, {});
+      const roll = Roll.fromTerms(specialDamage);
+      await roll.evaluate({ maximize: true, async: true });
+      const crushSpecialDamageTag = localize("RQG.Dialog.weaponChat.CrushSpecialDamageTag");
+      return Roll.parse(`+ ${roll.result}[${crushSpecialDamageTag}]`, {});
+    }
+    return [];
+  }
+
+  private static slashImpaleSpecialDamage(weaponDamage: string): any[] {
+    const impaleSpecialDamageTag = localize("RQG.Dialog.weaponChat.ImpaleSpecialDamageTag");
+    return Roll.parse(`+ (${weaponDamage})[${impaleSpecialDamageTag}]`, {});
+  }
+
+  public static getUsedSkillItem(weaponItem: RqgItem, usage: UsageType): RqgItem | undefined {
+    assertItemType(weaponItem.data.type, ItemTypeEnum.Weapon);
+    return weaponItem.actor?.items.get(weaponItem.data.data.usage[usage]?.skillId);
   }
 }

--- a/src/actors/rqgActorSheet.ts
+++ b/src/actors/rqgActorSheet.ts
@@ -762,8 +762,7 @@ export class RqgActorSheet extends ActorSheet<
         } else if (clickCount === 1) {
           setTimeout(async () => {
             if (clickCount === 1) {
-              // @ts-ignore wait for foundry-vtt-types issue #1165 #1166
-              await ItemChatHandler.show(itemId, this.actor, this.token);
+              await item.toChat();
             }
             clickCount = 0;
           }, CONFIG.RQG.dblClickTimeout);
@@ -803,8 +802,7 @@ export class RqgActorSheet extends ActorSheet<
         } else if (clickCount === 1) {
           setTimeout(async () => {
             if (clickCount === 1) {
-              // @ts-ignore wait for foundry-vtt-types issue #1165 #1166
-              await RuneMagicChatHandler.show(itemId, this.actor, this.token);
+              await runeMagicItem.toChat();
             }
             clickCount = 0;
           }, CONFIG.RQG.dblClickTimeout);
@@ -844,8 +842,7 @@ export class RqgActorSheet extends ActorSheet<
         } else if (clickCount === 1) {
           setTimeout(async () => {
             if (clickCount === 1) {
-              // @ts-ignore wait for foundry-vtt-types issue #1165 #1166
-              await SpiritMagicChatHandler.show(itemId, this.actor, this.token);
+              await item.toChat();
             }
             clickCount = 0;
           }, CONFIG.RQG.dblClickTimeout);

--- a/src/actors/sheet-parts/combat.hbs
+++ b/src/actors/sheet-parts/combat.hbs
@@ -14,8 +14,8 @@
   {{#each ownedItems.weapon}}
     {{#if (eq data.data.equippedStatus "equipped")}}
       {{#unless data.data.isNatural}}
-        <div data-item-id="{{data._id}}" class="combat contextmenu item"><img class="item" src="{{img}}"></div>
-        <div data-item-id="{{data._id}}" class="combat contextmenu item">{{name}}
+        <div data-item-id="{{data._id}}" data-weapon-roll class="combat contextmenu item"><img class="item" src="{{img}}"></div>
+        <div data-item-id="{{data._id}}" data-weapon-roll class="combat contextmenu item">{{name}}
           {{#if data.data.isProjectileWeapon}}
             ({{quantity data.data.projectileId @root.data._id @root.tokenId}})
           {{else if data.data.isThrownWeapon}}
@@ -32,13 +32,15 @@
                         value="{{data.data.hitPoints.value}}"> / {{data.data.hitPoints.max}}</label>
           {{/if}}
         </div>
-        <div class="item">
+        <div class="item" data-weapon-roll data-item-id="{{data._id}}">
           <span class="flex-column text-right">
             {{#each data.data.usage}}
               {{#if skillId}}
-                <div  class="combat contextmenu usage {{#if (eq @key "missile")}}missile{{/if}} {{#if unusable}}warning{{/if}}"
+                <div  class="combat contextmenu usage
+                      {{#if (eq @key "missile")}}missile{{/if}} {{#if unusable}}warning{{/if}}
+                       {{#if (eq ../data.data.defaultUsage @key)}}default-usage{{/if}}"
                       {{#if unusable}}title="{{localize "RQG.Actor.Combat.StrDexMinsNotMetTip"}}"{{/if}}
-                      data-skill-id="{{skillId}}" data-item-id="{{../data._id}}" data-weapon-usage-type="{{@key}}">
+                      data-skill-id="{{skillId}}">
                   {{localize (concat "RQG.Game.WeaponUsage." @key)}}
                   <span class="{{experiencedclass skillId @root.data._id @root.tokenId}}">{{skillchance skillId @root.data._id @root.tokenId}}%</span>
                 </div>
@@ -46,13 +48,13 @@
             {{/each}}
           </span>
         </div>
-        <div class="item">
+        <div class="item" data-weapon-roll data-item-id="{{data._id}}">
           <span class="flex-column">
             {{#each data.data.usage}}
               {{#if skillId}}
                 <span class="combat contextmenu usage {{#if (eq @key "missile")}}missile{{/if}}"
-                      data-skill-id="{{skillId}}" data-item-id="{{../data._id}}"
-                      data-weapon-usage-type="{{@key}}">{{damage}}&nbsp;</span>
+                      data-skill-id="{{skillId}}"
+                      >{{damage}}&nbsp;</span>
               {{/if}}
             {{/each}}
           </span>
@@ -95,15 +97,15 @@
 
   {{#each ownedItems.weapon}}
     {{#if data.data.isNatural}}
-      <div data-item-id="{{data._id}}" class="combat contextmenu"><img class="item" src="{{img}}"></div>
-      <div data-item-id="{{data._id}}" class="combat contextmenu">{{name}}</div>
-      <div data-item-id="{{data._id}}" class="combat contextmenu"></div>
+      <div data-item-id="{{data._id}}" data-weapon-roll class="combat contextmenu"><img class="item" src="{{img}}"></div>
+      <div data-item-id="{{data._id}}" data-weapon-roll class="combat contextmenu">{{name}}</div>
+      <div data-item-id="{{data._id}}" data-weapon-roll class="combat contextmenu"></div>
       <div>
           <span class="flex-column text-right">
             {{#each data.data.usage}}
               {{#if skillId}}
                 <span class="combat contextmenu usage {{#if (eq @key "missile")}}missile{{/if}} {{experiencedclass skillId @root.data._id @root.tokenId}}"
-                      data-skill-id="{{skillId}}" data-item-id="{{../data._id}}" data-weapon-usage-type="{{@key}}" title="{{localize "RQG.Game.RollChat"}}">
+                      data-skill-id="{{skillId}}" data-item-id="{{../data._id}}" data-weapon-roll title="{{localize "RQG.Game.RollChat"}}">
                       {{skillchance skillId @root.data._id @root.tokenId}}%
                 </span>
               {{/if}}
@@ -116,7 +118,7 @@
               {{#if skillId}}
                 <span class="combat contextmenu usage {{#if (eq @key "missile")}}missile{{/if}}"
                       data-skill-id="{{skillId}}" data-item-id="{{../data._id}}"
-                      data-weapon-usage-type="{{@key}}" title="{{localize "RQG.Game.RollChat"}}">
+                      data-weapon-roll title="{{localize "RQG.Game.RollChat"}}">
                       {{damage}}&nbsp;
                 </span>
               {{/if}}

--- a/src/actors/sheet-parts/combat.hbs
+++ b/src/actors/sheet-parts/combat.hbs
@@ -65,7 +65,7 @@
               {{#if skillId}}
                 {{#if (eq @key "missile")}}
                   {{#if ../data.data.rate}}
-                    <div class="text-right">1/{{#unless (eq 1 ../data.data.rate)}}{{../data.data.rate}}{{/unless}}MR</div>
+                    <div class="text-right usage {{#if (eq @key "missile")}}missile{{/if}}">1/{{#unless (eq 1 ../data.data.rate)}}{{../data.data.rate}}{{/unless}}MR</div>
                   {{else}}
                     <div class="flex-column">
                       <div>
@@ -131,7 +131,7 @@
               {{#if skillId}}
                 {{#if (eq @key "missile")}}
                   {{#if ../data.data.rate}}
-                    <div class="text-right">1/{{#unless (eq 1 ../data.data.rate)}}{{../data.data.rate}}{{/unless}}{{localize "RQG.Game.MeleeRoundAbbr"}}</div>
+                    <div class="text-right usage {{#if (eq @key "missile")}}missile{{/if}}">1/{{#unless (eq 1 ../data.data.rate)}}{{../data.data.rate}}{{/unless}}{{localize "RQG.Game.MeleeRoundAbbr"}}</div>
                   {{else}}
                     <div class="flex-column">
                       <div>

--- a/src/chat/itemChatHandler.ts
+++ b/src/chat/itemChatHandler.ts
@@ -1,6 +1,5 @@
 import { Ability, ResultEnum } from "../data-model/shared/ability";
 import {
-  activateChatTab,
   formatModifier,
   getGame,
   localize,
@@ -16,44 +15,12 @@ import {
 } from "../system/util";
 import { RqgActor } from "../actors/rqgActor";
 import { ChatSpeakerDataProperties } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatSpeakerData";
-import { ItemChatFlags, RqgChatMessageFlags } from "../data-model/shared/rqgDocumentFlags";
+import { RqgChatMessageFlags } from "../data-model/shared/rqgDocumentFlags";
 import { RqgItem } from "../items/rqgItem";
 import { ChatMessageDataConstructorData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatMessageData";
 import { RqgChatMessage } from "./RqgChatMessage";
 
 export class ItemChatHandler {
-  public static async show(
-    itemId: string,
-    actor: RqgActor,
-    token: TokenDocument | undefined
-  ): Promise<void> {
-    const item = actor.items.get(itemId);
-    if (!item || !("chance" in item.data.data) || item.data.data.chance == null) {
-      const msg = localize("RQG.Item.Notification.ItemWithIdDoesNotHaveChanceError", {
-        itemId: itemId,
-        actorName: actor.name,
-      });
-      ui.notifications?.error(msg);
-      throw new RqgError(msg);
-    }
-
-    const flags: ItemChatFlags = {
-      type: "itemChat",
-      chat: {
-        actorUuid: actor.uuid,
-        tokenUuid: token?.uuid,
-        chatImage: item.data.img ?? "",
-        itemUuid: item.uuid,
-      },
-      formData: {
-        modifier: "",
-      },
-    };
-
-    await ChatMessage.create(await ItemChatHandler.renderContent(flags));
-    activateChatTab();
-  }
-
   /**
    * Do a roll from the Item Chat message. Use the flags on the chatMessage to get the required data.
    * Called from {@link RqgChatMessage.doRoll}

--- a/src/chat/itemChatHandler.ts
+++ b/src/chat/itemChatHandler.ts
@@ -1,6 +1,4 @@
-import { Ability, ResultEnum } from "../data-model/shared/ability";
 import {
-  formatModifier,
   getGame,
   localize,
   RqgError,
@@ -14,7 +12,6 @@ import {
   getRequiredRqgActorFromUuid,
 } from "../system/util";
 import { RqgActor } from "../actors/rqgActor";
-import { ChatSpeakerDataProperties } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatSpeakerData";
 import { RqgChatMessageFlags } from "../data-model/shared/rqgDocumentFlags";
 import { RqgItem } from "../items/rqgItem";
 import { ChatMessageDataConstructorData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatMessageData";
@@ -28,41 +25,11 @@ export class ItemChatHandler {
   public static async rollFromChat(chatMessage: RqgChatMessage): Promise<void> {
     const flags = chatMessage.data.flags.rqg;
     assertChatMessageFlagType(flags?.type, "itemChat");
-    const actor = await getRequiredRqgActorFromUuid<RqgActor>(flags.chat.actorUuid);
-    const token = await getDocumentFromUuid<TokenDocument>(flags.chat.tokenUuid);
-    const speaker = ChatMessage.getSpeaker({ actor: actor, token: token });
     const item = (await getRequiredDocumentFromUuid(flags.chat.itemUuid)) as RqgItem | undefined;
     requireValue(item, "Couldn't find item on item chat message");
     const { modifier } = await ItemChatHandler.getFormDataFromFlags(flags);
 
-    await ItemChatHandler.roll(item, modifier, actor, speaker);
-  }
-
-  public static async roll(
-    item: RqgItem,
-    modifier: number,
-    actor: RqgActor,
-    speaker: ChatSpeakerDataProperties
-  ): Promise<void> {
-    const chance: number = Number((item?.data.data as any).chance) || 0;
-    let flavor = localize("RQG.Dialog.itemChat.RollFlavor", { name: item.name });
-    if (modifier !== 0) {
-      flavor += localize("RQG.Dialog.itemChat.RollFlavorModifier", {
-        modifier: formatModifier(modifier),
-      });
-    }
-    const result = await Ability.roll(flavor, chance, modifier, speaker);
-    await ItemChatHandler.checkExperience(actor, item, result);
-  }
-
-  public static async checkExperience(
-    actor: RqgActor,
-    item: RqgItem,
-    result: ResultEnum
-  ): Promise<void> {
-    if (result <= ResultEnum.Success && !(item.data.data as any).hasExperience) {
-      await actor.AwardExperience(item.id);
-    }
+    await item.abilityRoll({ modifier: modifier });
   }
 
   public static async renderContent(

--- a/src/chat/runeMagicChatHandler.ts
+++ b/src/chat/runeMagicChatHandler.ts
@@ -1,12 +1,7 @@
-import { ItemDataSource } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/itemData";
 import { RqgActor } from "../actors/rqgActor";
 import { ItemTypeEnum } from "../data-model/item-data/itemTypes";
-import { RuneDataPropertiesData } from "../data-model/item-data/runeData";
-import { Ability, ResultEnum, ResultMessage } from "../data-model/shared/ability";
 import { RqgItem } from "../items/rqgItem";
 import {
-  activateChatTab,
-  assertActorType,
   assertChatMessageFlagType,
   assertItemType,
   cleanIntegerString,
@@ -18,18 +13,13 @@ import {
   getRequiredRqgActorFromUuid,
   localize,
   requireValue,
-  RqgError,
   usersIdsThatOwnActor,
 } from "../system/util";
-import { systemId } from "../system/config";
-import { RqgChatMessageFlags, RuneMagicChatFlags } from "../data-model/shared/rqgDocumentFlags";
-import { ActorTypeEnum } from "../data-model/actor-data/rqgActorData";
-import {
-  ChatSpeakerData,
-  ChatSpeakerDataProperties,
-} from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatSpeakerData";
+import { RqgChatMessageFlags } from "../data-model/shared/rqgDocumentFlags";
+import { ChatSpeakerData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatSpeakerData";
 import { RqgChatMessage } from "./RqgChatMessage";
 import { ChatMessageDataConstructorData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatMessageData";
+import { RuneMagic } from "../actors/item-specific/runeMagic";
 
 export class RuneMagicChatHandler {
   /**
@@ -39,12 +29,9 @@ export class RuneMagicChatHandler {
   public static async rollFromChat(chatMessage: RqgChatMessage): Promise<void> {
     const flags = chatMessage.data.flags.rqg;
     assertChatMessageFlagType(flags?.type, "runeMagicChat");
-    const actor = await getRequiredRqgActorFromUuid<RqgActor>(flags.chat.actorUuid);
-    const token = await getDocumentFromUuid<TokenDocument>(flags.chat.tokenUuid);
-    const speaker = ChatMessage.getSpeaker({ actor: actor, token: token });
-    const runeMagicItem = (await getRequiredDocumentFromUuid(flags.chat.itemUuid)) as
-      | RqgItem
-      | undefined;
+    const runeMagicItem = await getRequiredDocumentFromUuid<RqgItem | undefined>(
+      flags.chat.itemUuid
+    );
     requireValue(runeMagicItem, "Couldn't find item on item chat message");
     const {
       runePointCost,
@@ -54,225 +41,15 @@ export class RuneMagicChatHandler {
       otherModifiers,
       selectedRuneId,
     } = await RuneMagicChatHandler.getFormDataFromFlags(flags);
-    await RuneMagicChatHandler.roll(
-      runeMagicItem,
+
+    await runeMagicItem.abilityRoll({
       runePointCost,
       magicPointBoost,
       ritualOrMeditation,
       skillAugmentation,
       otherModifiers,
-      actor,
-      speaker,
-      selectedRuneId
-    );
-  }
-
-  public static async roll(
-    runeMagicItem: RqgItem,
-    runePointsCast: number,
-    magicPointBoost: number,
-    ritualOrMeditation: number,
-    skillAugmentation: number,
-    otherModifiers: number,
-    actor: RqgActor,
-    speaker: ChatSpeakerDataProperties,
-    usedRuneId?: string
-  ): Promise<void> {
-    assertItemType(runeMagicItem?.data.type, ItemTypeEnum.RuneMagic);
-    const runeMagicCultId = runeMagicItem?.data.data.cultId;
-    const cult = actor.getEmbeddedDocument("Item", runeMagicCultId) as RqgItem | undefined;
-    assertItemType(cult?.data.type, ItemTypeEnum.Cult);
-    if (!usedRuneId) {
-      const eligibleRunes = RuneMagicChatHandler.getEligibleRunes(runeMagicItem, actor);
-      usedRuneId = RuneMagicChatHandler.getStrongestRune(eligibleRunes)?.id ?? "";
-    }
-    const runeItem = actor.getEmbeddedDocument("Item", usedRuneId) as RqgItem | undefined;
-    assertItemType(runeItem?.data.type, ItemTypeEnum.Rune);
-
-    const validationError = RuneMagicChatHandler.validateData(
-      actor,
-      cult,
-      runePointsCast,
-      magicPointBoost
-    );
-    if (validationError) {
-      ui.notifications?.warn(validationError);
-      return;
-    }
-
-    const resultMessages: ResultMessage[] = [
-      {
-        result: ResultEnum.Critical,
-        html: localize("RQG.Dialog.runeMagicChat.resultMessageCritical", {
-          magicPointBoost: magicPointBoost,
-        }),
-      },
-      {
-        result: ResultEnum.Special,
-        html: localize("RQG.Dialog.runeMagicChat.resultMessageSpecial", {
-          runePointCost: runePointsCast,
-          magicPointBoost: magicPointBoost,
-        }),
-      },
-      {
-        result: ResultEnum.Success,
-        html: localize("RQG.Dialog.runeMagicChat.resultMessageSuccess", {
-          runePointCost: runePointsCast,
-          magicPointBoost: magicPointBoost,
-        }),
-      },
-      {
-        result: ResultEnum.Failure,
-        html: localize("RQG.Dialog.runeMagicChat.resultMessageFailure"),
-      },
-      {
-        result: ResultEnum.Fumble,
-        html: localize("RQG.Dialog.runeMagicChat.resultMessageFumble", {
-          runePointCost: runePointsCast,
-        }),
-      },
-    ];
-
-    const result = await Ability.roll(
-      localize("RQG.Dialog.runeMagicChat.Cast", { spellName: runeMagicItem.name }),
-      Number(runeItem.data.data.chance),
-      ritualOrMeditation + skillAugmentation + otherModifiers,
-      speaker,
-      resultMessages
-    );
-
-    await RuneMagicChatHandler.handleResult(
-      result,
-      runePointsCast,
-      magicPointBoost,
-      actor,
-      runeItem,
-      runeMagicItem
-    );
-  }
-
-  private static async handleResult(
-    result: ResultEnum,
-    runePointsUsed: number,
-    magicPointsUsed: number,
-    actor: RqgActor,
-    runeItem: RqgItem,
-    runeMagicItem: RqgItem
-  ): Promise<void> {
-    assertItemType(runeItem.data.type, ItemTypeEnum.Rune);
-    assertItemType(runeMagicItem.data.type, ItemTypeEnum.RuneMagic);
-    const cult = actor.getEmbeddedDocument("Item", runeMagicItem.data.data.cultId ?? "") as
-      | RqgItem
-      | undefined;
-    assertItemType(cult?.data.type, ItemTypeEnum.Cult);
-    const isOneUse = runeMagicItem.data.data.isOneUse;
-
-    switch (result) {
-      case ResultEnum.Critical:
-      case ResultEnum.SpecialCritical:
-      case ResultEnum.HyperCritical:
-        // spell takes effect, Rune Points NOT spent, Rune gets xp check, boosting Magic Points spent
-        await RuneMagicChatHandler.SpendRuneAndMagicPoints(
-          0,
-          magicPointsUsed,
-          actor,
-          cult,
-          isOneUse
-        );
-        await actor.AwardExperience(runeItem.id);
-        break;
-
-      case ResultEnum.Success:
-      case ResultEnum.Special:
-        // spell takes effect, Rune Points spent, Rune gets xp check, boosting Magic Points spent
-        await RuneMagicChatHandler.SpendRuneAndMagicPoints(
-          runePointsUsed,
-          magicPointsUsed,
-          actor,
-          cult,
-          isOneUse
-        );
-        await actor.AwardExperience(runeItem.id);
-        break;
-
-      case ResultEnum.Failure:
-        {
-          // spell fails, no Rune Point Loss, if Magic Point boosted, lose 1 Magic Point if boosted
-          const boosted = magicPointsUsed >= 1 ? 1 : 0;
-          await RuneMagicChatHandler.SpendRuneAndMagicPoints(0, boosted, actor, cult, isOneUse);
-        }
-        break;
-
-      case ResultEnum.Fumble:
-        // spell fails, lose Rune Points, if Magic Point boosted, lose 1 Magic Point if boosted
-        const boosted = magicPointsUsed >= 1 ? 1 : 0;
-        await RuneMagicChatHandler.SpendRuneAndMagicPoints(
-          runePointsUsed,
-          boosted,
-          actor,
-          cult,
-          isOneUse
-        );
-        break;
-
-      default:
-        const msg = "Got unexpected result from roll in runeMagicChat";
-        ui.notifications?.error(msg);
-        throw new RqgError(msg);
-    }
-  }
-
-  private static async SpendRuneAndMagicPoints(
-    runePoints: number,
-    magicPoints: number,
-    actor: RqgActor,
-    cult: RqgItem,
-    isOneUse: boolean
-  ) {
-    assertItemType(cult.data.type, ItemTypeEnum.Cult);
-    assertActorType(actor.data.type, ActorTypeEnum.Character);
-    // At this point if the current Rune Points or Magic Points are zero
-    // it's too late. That validation happened earlier.
-    const newRunePointTotal = (cult.data.data.runePoints.value || 0) - runePoints;
-    const newMagicPointTotal = (actor?.data.data.attributes.magicPoints.value || 0) - magicPoints;
-    let newRunePointMaxTotal = cult.data.data.runePoints.max || 0;
-    if (isOneUse) {
-      newRunePointMaxTotal -= runePoints;
-      if (newRunePointMaxTotal < (cult.data.data.runePoints.max || 0)) {
-        ui.notifications?.info(
-          localize("RQG.Dialog.runeMagicChat.SpentOneUseRunePoints", {
-            actorName: actor?.name,
-            runePoints: runePoints,
-            cultName: cult.name,
-          })
-        );
-      }
-    }
-    const updateCultItemRunePoints: DeepPartial<ItemDataSource> = {
-      _id: cult?.id,
-      data: { runePoints: { value: newRunePointTotal, max: newRunePointMaxTotal } },
-    };
-    await actor?.updateEmbeddedDocuments("Item", [updateCultItemRunePoints]);
-    const updateActorMagicPoints = {
-      data: { attributes: { magicPoints: { value: newMagicPointTotal } } },
-    };
-    await actor?.update(updateActorMagicPoints);
-  }
-
-  public static validateData(
-    actor: RqgActor,
-    cultItem: RqgItem,
-    runePointsUsed: number,
-    magicPointsBoost: number
-  ): string {
-    assertItemType(cultItem?.data.type, ItemTypeEnum.Cult);
-    if (runePointsUsed > (Number(cultItem.data.data.runePoints.value) || 0)) {
-      return getGame().i18n.format("RQG.Dialog.runeMagicChat.validationNotEnoughRunePoints");
-    } else if (magicPointsBoost > (Number(actor?.data.data.attributes?.magicPoints?.value) || 0)) {
-      return localize("RQG.Dialog.runeMagicChat.validationNotEnoughMagicPoints");
-    } else {
-      return "";
-    }
+      selectedRuneId,
+    });
   }
 
   public static async renderContent(
@@ -283,7 +60,7 @@ export class RuneMagicChatHandler {
     const token = await getDocumentFromUuid<TokenDocument>(flags.chat.tokenUuid);
     const runeMagicItem = await getRequiredDocumentFromUuid<RqgItem>(flags.chat.itemUuid);
     assertItemType(runeMagicItem.data.type, ItemTypeEnum.RuneMagic);
-    const eligibleRunes = RuneMagicChatHandler.getEligibleRunes(runeMagicItem, actor);
+    const eligibleRunes = RuneMagic.getEligibleRunes(runeMagicItem);
     const { otherModifiers, selectedRuneId, ritualOrMeditation, skillAugmentation } =
       await RuneMagicChatHandler.getFormDataFromFlags(flags);
     const selectedRune = actor.getEmbeddedDocument("Item", selectedRuneId) as RqgItem | undefined;
@@ -355,12 +132,12 @@ export class RuneMagicChatHandler {
     const otherModifiers = convertFormValueToInteger(flags.formData.otherModifiers);
     const selectedRuneId = convertFormValueToString(flags.formData.selectedRuneId);
     return {
-      runePointCost: runePointCost,
-      magicPointBoost: magicPointBoost,
-      ritualOrMeditation: ritualOrMeditation,
-      skillAugmentation: skillAugmentation,
-      otherModifiers: otherModifiers,
-      selectedRuneId: selectedRuneId,
+      runePointCost,
+      magicPointBoost,
+      ritualOrMeditation,
+      skillAugmentation,
+      otherModifiers,
+      selectedRuneId,
     };
   }
 
@@ -379,53 +156,5 @@ export class RuneMagicChatHandler {
     flags.formData.skillAugmentation = cleanIntegerString(formData.get("skillAugmentation"));
     flags.formData.otherModifiers = cleanIntegerString(formData.get("otherModifiers"));
     flags.formData.selectedRuneId = convertFormValueToString(formData.get("selectedRuneId"));
-  }
-
-  /**
-   * Given a rune spell and an actor, returns the runes that are possible to use for casting that spell.
-   */
-  static getEligibleRunes(runeMagicItem: RqgItem, actor: RqgActor): RqgItem[] {
-    assertItemType(runeMagicItem.data.type, ItemTypeEnum.RuneMagic);
-    assertActorType(actor.data.type, ActorTypeEnum.Character);
-
-    // The cult from where the spell was learned
-    const cult = actor.getEmbeddedDocument("Item", runeMagicItem.data.data.cultId) as
-      | RqgItem
-      | undefined;
-    assertItemType(cult?.data.type, ItemTypeEnum.Cult);
-
-    // Get the name of the "magic" rune.
-    const magicRuneName = getGame().settings.get(systemId, "magicRuneName");
-
-    let usableRuneNames: string[];
-    if (runeMagicItem.data.data.runes.includes(magicRuneName)) {
-      // Actor can use any of the cult's runes to cast
-      // And some cults have the same rune more than once, so de-dupe them
-      usableRuneNames = [...new Set(cult.data.data.runes)];
-    } else {
-      // Actor can use any of the Rune Magic Spell's runes to cast
-      usableRuneNames = [...new Set(runeMagicItem.data.data.runes)];
-    }
-
-    let runesForCasting: RqgItem[] = [];
-    // Get the actor's versions of the runes, which will have their "chance"
-    usableRuneNames.forEach((runeName: string) => {
-      const actorRune = actor.items.getName(runeName);
-      assertItemType(actorRune?.data.type, ItemTypeEnum.Rune);
-      runesForCasting.push(actorRune);
-    });
-
-    return runesForCasting;
-  }
-
-  static getStrongestRune(runeMagicItems: RqgItem[]): RqgItem | undefined {
-    if (runeMagicItems.length === 0) {
-      return undefined;
-    }
-    return runeMagicItems.reduce((strongest: RqgItem, current: RqgItem) => {
-      const strongestRuneChance = (strongest.data.data as RuneDataPropertiesData).chance ?? 0;
-      const currentRuneChance = (current.data.data as RuneDataPropertiesData).chance ?? 0;
-      return strongestRuneChance > currentRuneChance ? strongest : current;
-    });
   }
 }

--- a/src/chat/runeMagicChatHandler.ts
+++ b/src/chat/runeMagicChatHandler.ts
@@ -32,41 +32,6 @@ import { RqgChatMessage } from "./RqgChatMessage";
 import { ChatMessageDataConstructorData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatMessageData";
 
 export class RuneMagicChatHandler {
-  public static async show(
-    runeMagicItemId: string,
-    actor: RqgActor,
-    token: TokenDocument | undefined
-  ): Promise<void> {
-    const runeMagicItem = actor.items.get(runeMagicItemId);
-    assertItemType(runeMagicItem?.data.type, ItemTypeEnum.RuneMagic);
-    const cult = actor.items.get(runeMagicItem.data.data.cultId);
-    assertItemType(cult?.data.type, ItemTypeEnum.Cult);
-
-    const eligibleRunes = RuneMagicChatHandler.getEligibleRunes(runeMagicItem, actor);
-    const defaultRuneId = RuneMagicChatHandler.getStrongestRune(eligibleRunes)?.id;
-
-    const flags: RuneMagicChatFlags = {
-      type: "runeMagicChat",
-      chat: {
-        actorUuid: actor.uuid,
-        tokenUuid: token?.uuid,
-        chatImage: runeMagicItem.img ?? "",
-        itemUuid: runeMagicItem?.uuid,
-      },
-      formData: {
-        runePointCost: runeMagicItem.data.data.points.toString(),
-        magicPointBoost: "",
-        ritualOrMeditation: "0",
-        skillAugmentation: "0",
-        otherModifiers: "",
-        selectedRuneId: defaultRuneId ?? "",
-      },
-    };
-
-    await ChatMessage.create(await this.renderContent(flags));
-    activateChatTab();
-  }
-
   /**
    * Do a roll from the Rune Magic Chat message. Use the flags on the chatMessage to get the required data.
    * Called from {@link RqgChatMessage.doRoll}
@@ -419,7 +384,7 @@ export class RuneMagicChatHandler {
   /**
    * Given a rune spell and an actor, returns the runes that are possible to use for casting that spell.
    */
-  private static getEligibleRunes(runeMagicItem: RqgItem, actor: RqgActor): RqgItem[] {
+  static getEligibleRunes(runeMagicItem: RqgItem, actor: RqgActor): RqgItem[] {
     assertItemType(runeMagicItem.data.type, ItemTypeEnum.RuneMagic);
     assertActorType(actor.data.type, ActorTypeEnum.Character);
 
@@ -453,7 +418,7 @@ export class RuneMagicChatHandler {
     return runesForCasting;
   }
 
-  private static getStrongestRune(runeMagicItems: RqgItem[]): RqgItem | undefined {
+  static getStrongestRune(runeMagicItems: RqgItem[]): RqgItem | undefined {
     if (runeMagicItems.length === 0) {
       return undefined;
     }

--- a/src/chat/spiritMagicChatHandler.hbs
+++ b/src/chat/spiritMagicChatHandler.hbs
@@ -1,17 +1,20 @@
 <form>
   <div class="rqg chat-content spirit-magic-chat">
+    <h2><img class="item" src="{{chat.chatImage}}"> {{chatHeading}}</h2>
 
-    <h2>
-      <img class="item" src="{{chat.chatImage}}"> {{chatHeading}}
-    </h2>
+    <div class="flex-row">
+      <div>
+        <label>{{localize "RQG.Dialog.spiritMagicChat.Level"}}
+          <input class="chat-number-input" type="text" value="{{formData.level}}" name="level">
+        </label>
+      </div>
 
-    <label>{{localize "RQG.Dialog.spiritMagicChat.Level"}}
-      <input class="chat-number-input" type="text" value="{{formData.level}}" name="level">
-    </label><br>
-
-    <label>{{localize "RQG.Dialog.spiritMagicChat.Boost"}}
-      <input class="chat-number-input" type="text" value="{{formData.boost}}" name="boost">
-    </label>
-    <button type="submit" data-chat-roll>{{localize "RQG.Dialog.Common.RollFormat" chance=chance}}</button>
+      <div>
+        <label>{{localize "RQG.Dialog.spiritMagicChat.Boost"}}
+          <input class="chat-number-input" type="text" value="{{formData.boost}}" name="boost">
+        </label>
+      </div>
+    </div>
+    <button data-chat-roll>{{localize "RQG.Dialog.Common.RollFormat" chance=chance}}</button>
   </div>
 </form>

--- a/src/chat/spiritMagicChatHandler.ts
+++ b/src/chat/spiritMagicChatHandler.ts
@@ -1,6 +1,5 @@
 import { Ability, ResultEnum } from "../data-model/shared/ability";
 import {
-  activateChatTab,
   assertChatMessageFlagType,
   assertItemType,
   cleanIntegerString,
@@ -14,7 +13,7 @@ import {
 } from "../system/util";
 import { RqgActor } from "../actors/rqgActor";
 import { ItemTypeEnum } from "../data-model/item-data/itemTypes";
-import { RqgChatMessageFlags, SpiritMagicChatFlags } from "../data-model/shared/rqgDocumentFlags";
+import { RqgChatMessageFlags } from "../data-model/shared/rqgDocumentFlags";
 import { RqgItem } from "../items/rqgItem";
 import { ChatSpeakerDataProperties } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatSpeakerData";
 import { RqgChatMessage } from "./RqgChatMessage";

--- a/src/chat/spiritMagicChatHandler.ts
+++ b/src/chat/spiritMagicChatHandler.ts
@@ -21,32 +21,6 @@ import { RqgChatMessage } from "./RqgChatMessage";
 import { ChatMessageDataConstructorData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatMessageData";
 
 export class SpiritMagicChatHandler {
-  public static async show(
-    spiritMagicItemId: string,
-    actor: RqgActor,
-    token: TokenDocument | undefined
-  ): Promise<void> {
-    const spiritMagicItem = actor.items.get(spiritMagicItemId);
-    assertItemType(spiritMagicItem?.data.type, ItemTypeEnum.SpiritMagic);
-
-    const flags: SpiritMagicChatFlags = {
-      type: "spiritMagicChat",
-      chat: {
-        actorUuid: actor.uuid,
-        tokenUuid: token?.uuid,
-        chatImage: spiritMagicItem?.img ?? "",
-        itemUuid: spiritMagicItem?.uuid,
-      },
-      formData: {
-        level: spiritMagicItem.data.data.points.toString(),
-        boost: "",
-      },
-    };
-
-    await ChatMessage.create(await this.renderContent(flags));
-    activateChatTab();
-  }
-
   /**
    * Do a roll from the Spirit Magic Chat message. Use the flags on the chatMessage to get the required data.
    * Called from {@link RqgChatMessage.doRoll}

--- a/src/chat/spiritMagicChatHandler.ts
+++ b/src/chat/spiritMagicChatHandler.ts
@@ -1,7 +1,5 @@
-import { Ability, ResultEnum } from "../data-model/shared/ability";
 import {
   assertChatMessageFlagType,
-  assertItemType,
   cleanIntegerString,
   convertFormValueToInteger,
   getDocumentFromUuid,
@@ -12,10 +10,8 @@ import {
   usersIdsThatOwnActor,
 } from "../system/util";
 import { RqgActor } from "../actors/rqgActor";
-import { ItemTypeEnum } from "../data-model/item-data/itemTypes";
 import { RqgChatMessageFlags } from "../data-model/shared/rqgDocumentFlags";
 import { RqgItem } from "../items/rqgItem";
-import { ChatSpeakerDataProperties } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatSpeakerData";
 import { RqgChatMessage } from "./RqgChatMessage";
 import { ChatMessageDataConstructorData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatMessageData";
 
@@ -27,69 +23,10 @@ export class SpiritMagicChatHandler {
   public static async rollFromChat(chatMessage: RqgChatMessage): Promise<void> {
     const flags = chatMessage.data.flags.rqg;
     assertChatMessageFlagType(flags?.type, "spiritMagicChat");
-    const actor = await getRequiredRqgActorFromUuid<RqgActor>(flags.chat.actorUuid);
-    const token = await getDocumentFromUuid<TokenDocument>(flags.chat.tokenUuid);
     const spiritMagicItem = (await getRequiredDocumentFromUuid(flags.chat.itemUuid)) as RqgItem;
-    const speaker = ChatMessage.getSpeaker({ actor: actor, token: token });
-
     const { level, boost } = await SpiritMagicChatHandler.getFormDataFromFlags(flags);
-    await SpiritMagicChatHandler.roll(spiritMagicItem, level, boost, actor, speaker);
-  }
 
-  public static async roll(
-    spiritMagicItem: RqgItem,
-    level: number,
-    boost: number,
-    actor: RqgActor,
-    speaker: ChatSpeakerDataProperties
-  ): Promise<void> {
-    const validationError = SpiritMagicChatHandler.validateData(
-      actor,
-      spiritMagicItem,
-      level,
-      boost
-    );
-    if (validationError) {
-      ui.notifications?.warn(validationError);
-    } else {
-      const result = await Ability.roll(
-        localize("RQG.Dialog.spiritMagicChat.Cast", { spellName: spiritMagicItem.name }),
-        actor.data.data.characteristics.power.value * 5,
-        0,
-        speaker
-      );
-      await SpiritMagicChatHandler.drawMagicPoints(actor, level + boost, result);
-    }
-  }
-
-  public static validateData(
-    actor: RqgActor,
-    spiritMagicItem: RqgItem,
-    level: number,
-    boost: number
-  ): string | undefined {
-    assertItemType(spiritMagicItem.data.type, ItemTypeEnum.SpiritMagic);
-    if (level > spiritMagicItem.data.data.points) {
-      return localize("RQG.Dialog.spiritMagicChat.CantCastSpellAboveLearnedLevel");
-    } else if (level + boost > (actor.data.data.attributes.magicPoints.value || 0)) {
-      return localize("RQG.Dialog.spiritMagicChat.NotEnoughMagicPoints");
-    } else {
-      return;
-    }
-  }
-
-  public static async drawMagicPoints(
-    actor: RqgActor,
-    amount: number,
-    result: ResultEnum
-  ): Promise<void> {
-    if (result <= ResultEnum.Success) {
-      const newMp = (actor.data.data.attributes.magicPoints.value || 0) - amount;
-      await actor.update({ "data.attributes.magicPoints.value": newMp });
-      ui.notifications?.info(
-        localize("RQG.Dialog.spiritMagicChat.SuccessfullyCastInfo", { amount: amount })
-      );
-    }
+    await spiritMagicItem.abilityRoll({ level, boost });
   }
 
   public static async renderContent(

--- a/src/chat/weaponChatHandler.hbs
+++ b/src/chat/weaponChatHandler.hbs
@@ -5,13 +5,17 @@
       <i>{{chatHeading}}</i>
     </h2>
 
+    <select name="usage" {{#if hideUsageOptions}}class="no-display"{{/if}}>
+      {{selectOptions usageOptions selected=formData.usage}}
+    </select><br>
+
     <label>{{localize 'RQG.Dialog.Common.OtherModifiers'}}
       <input class="chat-number-input" type="text" value="{{formData.otherModifiers}}" name="otherModifiers">
     </label>
     <i class="fas fa-arrow-right"></i> <span>{{chance}}%</span>
 
     <div class="flex-row flex-wrap gap03rem">
-      {{#with (lookup weaponItemData.usage chat.usage)}}
+      {{#with (lookup weaponItemData.usage formData.usage)}}
       {{#each combatManeuvers}}
             <button name="combatManeuverRoll" value="{{name}}"
                 {{#if (eq name ../../formData.combatManeuverName)}}class="active"{{/if}}>

--- a/src/chat/weaponChatHandler.ts
+++ b/src/chat/weaponChatHandler.ts
@@ -1,4 +1,3 @@
-import { Ability, ResultEnum } from "../data-model/shared/ability";
 import { RqgActor } from "../actors/rqgActor";
 import { ItemTypeEnum } from "../data-model/item-data/itemTypes";
 import {
@@ -8,27 +7,19 @@ import {
   convertFormValueToInteger,
   convertFormValueToString,
   getDocumentFromUuid,
-  getGame,
   getGameUser,
   getRequiredDocumentFromUuid,
   getRequiredRqgActorFromUuid,
-  hasOwnProperty,
   localize,
-  logMisconfiguration,
-  requireValue,
-  RqgError,
   usersIdsThatOwnActor,
 } from "../system/util";
 
-import { DeepPartial } from "snowpack";
-import { ItemDataSource } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/itemData";
 import { ChatMessageDataConstructorData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatMessageData";
-import { CombatManeuver, DamageType, UsageType } from "../data-model/item-data/weaponData";
+import { UsageType } from "../data-model/item-data/weaponData";
 import { RqgChatMessageFlags } from "../data-model/shared/rqgDocumentFlags";
 import { RqgItem } from "../items/rqgItem";
-import { ChatSpeakerDataProperties } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatSpeakerData";
 import { RqgChatMessage } from "./RqgChatMessage";
-import { systemId } from "../system/config";
+import { Weapon } from "../actors/item-specific/weapon";
 
 export enum DamageRollTypeEnum {
   Normal = "normal",
@@ -44,75 +35,21 @@ export class WeaponChatHandler {
   public static async rollFromChat(chatMessage: RqgChatMessage): Promise<void> {
     const flags = chatMessage.data.flags.rqg;
     assertChatMessageFlagType(flags?.type, "weaponChat");
-
-    const actor = await getRequiredRqgActorFromUuid<RqgActor>(flags.chat.actorUuid);
-    const token = await getDocumentFromUuid<TokenDocument>(flags.chat.tokenUuid);
     const weaponItem = (await getRequiredDocumentFromUuid(flags.chat.weaponUuid)) as
       | RqgItem
       | undefined;
     assertItemType(weaponItem?.data.type, ItemTypeEnum.Weapon);
-    const speaker = ChatMessage.getSpeaker({ actor: actor, token: token });
+
     const { otherModifiers, actionName, actionValue, usageType } =
       await WeaponChatHandler.getFormDataFromFlags(flags);
 
-    switch (actionName) {
-      case "combatManeuverRoll":
-        const weaponUsage = weaponItem.data.data.usage[usageType];
-        const combatManeuver = weaponUsage.combatManeuvers.find((m) => m.name === actionValue);
-        requireValue(
-          combatManeuver,
-          `Couldn't find combatmaneuver [${actionName}] and usage type [${usageType}] on weapon [${weaponItem.name}]`,
-          weaponItem
-        );
-        await WeaponChatHandler.combatManeuverRoll(
-          weaponItem,
-          actor,
-          usageType,
-          combatManeuver,
-          chatMessage,
-          otherModifiers,
-          speaker
-        );
-        return;
-
-      case "damageRoll":
-        const damageRollType = flags.formData.actionValue as DamageRollTypeEnum; // TODO improve typing
-        await WeaponChatHandler.damageRoll(
-          actor,
-          weaponItem,
-          convertFormValueToString(flags?.formData.usage) as UsageType,
-          convertFormValueToString(flags.formData.combatManeuverName),
-          damageRollType,
-          speaker
-        );
-        return;
-
-      case "hitLocationRoll":
-        await WeaponChatHandler.hitLocationRoll(speaker);
-        return;
-
-      case "fumbleRoll":
-        await WeaponChatHandler.fumbleRoll(actor, speaker);
-        return;
-
-      default:
-        const msg = localize("RQG.Dialog.weaponChat.UnknownButtonInChatError", {
-          actionButton: actionName,
-        });
-        ui.notifications?.error(msg);
-        throw new RqgError(msg, actionName);
-    }
-  }
-
-  public static async checkExperience(
-    actor: RqgActor,
-    skillItem: RqgItem,
-    result: ResultEnum
-  ): Promise<void> {
-    assertItemType(skillItem.data.type, ItemTypeEnum.Skill);
-    if (result <= ResultEnum.Success) {
-      actor.AwardExperience(skillItem.id);
-    }
+    await weaponItem?.abilityRoll({
+      actionName,
+      actionValue,
+      otherModifiers,
+      usageType,
+      chatMessage,
+    });
   }
 
   public static async renderContent(
@@ -123,7 +60,7 @@ export class WeaponChatHandler {
     const token = await getDocumentFromUuid<TokenDocument>(flags.chat.tokenUuid);
     const weaponItem = await getRequiredDocumentFromUuid<RqgItem>(flags.chat.weaponUuid);
     const { otherModifiers, usageType } = await WeaponChatHandler.getFormDataFromFlags(flags);
-    const skillItem = WeaponChatHandler.getUsedSkillItem(actor, weaponItem, usageType);
+    const skillItem = Weapon.getUsedSkillItem(weaponItem, usageType);
     assertItemType(skillItem?.data.type, ItemTypeEnum.Skill);
 
     const specialization = skillItem.data.data.specialization
@@ -209,18 +146,7 @@ export class WeaponChatHandler {
     });
   }
 
-  static getDefaultUsage(weapon: RqgItem): UsageType {
-    assertItemType(weapon.data.type, ItemTypeEnum.Weapon);
-    const defaultUsage = weapon.data.data.defaultUsage;
-    if (defaultUsage) {
-      return defaultUsage;
-    }
-    const options = WeaponChatHandler.getUsageTypeOptions(weapon);
-    // Fallback to picking the first available
-    return Object.keys(options)[0] as UsageType;
-  }
-
-  private static getUsageTypeOptions(weapon: RqgItem): {} {
+  static getUsageTypeOptions(weapon: RqgItem): {} {
     assertItemType(weapon.data.type, ItemTypeEnum.Weapon);
     return Object.entries(weapon.data.data.usage).reduce((acc: any, [key, usage]) => {
       if (usage.skillId) {
@@ -228,291 +154,5 @@ export class WeaponChatHandler {
       }
       return acc;
     }, {});
-  }
-
-  private static async combatManeuverRoll(
-    weaponItem: RqgItem,
-    actor: RqgActor,
-    usage: UsageType,
-    combatManeuver: CombatManeuver,
-    chatMessage: RqgChatMessage,
-    otherModifiers: number,
-    speaker: ChatSpeakerDataProperties
-  ): Promise<void> {
-    assertItemType(weaponItem.data.type, ItemTypeEnum.Weapon);
-    requireValue(chatMessage, "No chat message provided for combarManeuverRoll");
-    const damageType = combatManeuver?.damageType;
-    const specialDamageTypeDescription =
-      damageType === "special" ? combatManeuver?.description || undefined : undefined;
-    const flags = chatMessage.data.flags.rqg;
-    assertChatMessageFlagType(flags?.type, "weaponChat");
-
-    flags.chat.specialDamageTypeText =
-      specialDamageTypeDescription ??
-      CONFIG.RQG.combatManeuvers.get(combatManeuver?.name ?? "")?.specialDescriptionHtml;
-
-    const projectileItemData = weaponItem.data.data.isProjectileWeapon
-      ? actor.items.get(weaponItem.data.data.projectileId)?.data
-      : weaponItem.data; // Thrown (or melee)
-
-    let originalAmmoQty: number = 0;
-
-    // Decrease quantity of linked projectile if shooting
-    if (
-      projectileItemData?.type === ItemTypeEnum.Weapon &&
-      projectileItemData.data.quantity &&
-      projectileItemData.data.quantity > 0 &&
-      usage === "missile" &&
-      !["parry", "special"].includes(damageType ?? "")
-    ) {
-      originalAmmoQty = projectileItemData.data.quantity;
-      const updateData: DeepPartial<ItemDataSource> = {
-        _id: projectileItemData._id,
-        data: { quantity: --projectileItemData.data.quantity },
-      };
-      await actor.updateEmbeddedDocuments("Item", [updateData]);
-    }
-
-    if (usage === "missile" && !projectileItemData) {
-      ui.notifications?.warn(
-        localize("RQG.Dialog.weaponChat.OutOfAmmoWarn", {
-          projectileName: "---",
-          combatManeuverName: combatManeuver?.name,
-        })
-      );
-      return;
-    }
-
-    // Prevent using weapons with projectile quantity 0
-    if (
-      projectileItemData?.type === ItemTypeEnum.Weapon &&
-      projectileItemData.data.quantity != null &&
-      projectileItemData.data.quantity <= 0
-    ) {
-      if (originalAmmoQty > 0) {
-        ui.notifications?.warn(
-          localize("RQG.Dialog.weaponChat.UsedLastOfAmmoWarn", {
-            projectileName: projectileItemData.name,
-          })
-        );
-      } else {
-        ui.notifications?.warn(
-          localize("RQG.Dialog.weaponChat.OutOfAmmoWarn", {
-            projectileName: projectileItemData.name,
-            combatManeuverName: combatManeuver?.name,
-          })
-        );
-        return;
-      }
-    }
-
-    const skillItem = WeaponChatHandler.getUsedSkillItem(actor, weaponItem, usage);
-    assertItemType(skillItem?.data.type, ItemTypeEnum.Skill);
-
-    const chance: number = Number(skillItem.data.data.chance) || 0;
-
-    flags.chat.result = await Ability.roll(
-      skillItem.name + " " + WeaponChatHandler.getDamageTypeString(damageType, [combatManeuver]),
-      chance,
-      otherModifiers,
-      speaker
-    );
-    await WeaponChatHandler.checkExperience(actor, skillItem, flags.chat.result);
-
-    const data = await WeaponChatHandler.renderContent(flags);
-    await chatMessage.update(data);
-  }
-
-  private static async damageRoll(
-    actor: RqgActor,
-    weaponItem: RqgItem,
-    usageType: UsageType,
-    combatManeuverName: string | undefined,
-    damageRollType: DamageRollTypeEnum,
-    speaker: ChatSpeakerDataProperties
-  ): Promise<void> {
-    requireValue(
-      combatManeuverName,
-      localize("RQG.Dialog.weaponChat.NoCombatManeuverInDamageRollError")
-    );
-    assertItemType(weaponItem.data.type, ItemTypeEnum.Weapon);
-    let damageBonusFormula: string =
-      actor.data.data.attributes.damageBonus !== "0"
-        ? `${actor.data.data.attributes.damageBonus}`
-        : "";
-
-    const weaponUsage = weaponItem.data.data.usage[usageType];
-    const weaponDamageTag = localize("RQG.Dialog.weaponChat.WeaponDamageTag");
-    const weaponDamage = hasOwnProperty(weaponUsage, "damage")
-      ? Roll.parse(`(${weaponUsage.damage})[${weaponDamageTag}]`, {})
-      : [];
-
-    if (usageType === "missile") {
-      if (weaponItem.data.data.isThrownWeapon) {
-        damageBonusFormula = "ceil(" + actor.data.data.attributes.damageBonus + "/2)";
-      } else {
-        damageBonusFormula = "";
-      }
-    }
-
-    const damageRollTerms =
-      hasOwnProperty(weaponUsage, "damage") && weaponUsage.damage ? weaponDamage : []; // Don't add 0 damage rollTerm
-
-    const damageType = weaponUsage.combatManeuvers.find(
-      (m) => m.name === combatManeuverName
-    )?.damageType;
-    requireValue(
-      damageType,
-      localize("RQG.Dialog.weaponChat.WeaponDoesNotHaveCombatManeuverError")
-    );
-
-    if ([DamageRollTypeEnum.Special, DamageRollTypeEnum.MaxSpecial].includes(damageRollType)) {
-      if (["slash", "impale"].includes(damageType)) {
-        damageRollTerms.push(...WeaponChatHandler.slashImpaleSpecialDamage(weaponUsage.damage));
-      } else if (damageType === "crush") {
-        damageRollTerms.push(...(await WeaponChatHandler.crushSpecialDamage(damageBonusFormula)));
-      } else if (damageType === "parry") {
-        // Parry will use crush if existing or slash/impale if not, will work unless some weapon has both crush & slash
-        // No weapon in the core rulebook has that though
-        const usedParryingDamageType = WeaponChatHandler.getDamageTypeString(
-          damageType,
-          weaponUsage.combatManeuvers
-        );
-        if (usedParryingDamageType === "crush") {
-          damageRollTerms.push(...(await WeaponChatHandler.crushSpecialDamage(damageBonusFormula)));
-        } else if (["slash", "impale"].includes(usedParryingDamageType)) {
-          damageRollTerms.push(...WeaponChatHandler.slashImpaleSpecialDamage(weaponUsage.damage));
-        } else {
-          logMisconfiguration(
-            localize("RQG.Dialog.weaponChat.WeaponDoesNotHaveCombatManeuverError", {
-              weaponName: weaponItem.name,
-            }),
-            true
-          );
-        }
-      }
-    }
-    if (damageBonusFormula.length) {
-      const damageBonusDamageTag = localize("RQG.Dialog.weaponChat.DamageBonusDamageTag");
-      damageRollTerms.push(...Roll.parse(`+ ${damageBonusFormula}[${damageBonusDamageTag}]`, {}));
-    }
-    const maximise = damageRollType === DamageRollTypeEnum.MaxSpecial;
-    const roll = Roll.fromTerms(damageRollTerms);
-    await roll.evaluate({
-      maximize: maximise,
-      async: true,
-    });
-    await roll.toMessage({
-      speaker: speaker,
-      type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-      flavor: `${localize("RQG.Dialog.weaponChat.Damage")}: ${WeaponChatHandler.getDamageTypeString(
-        damageType,
-        weaponUsage.combatManeuvers
-      )}`,
-    });
-  }
-
-  private static getDamageTypeString(
-    damageType: DamageType,
-    combatManeuvers: CombatManeuver[]
-  ): string {
-    if (damageType === "parry") {
-      if (combatManeuvers.some((cm) => cm.damageType === "crush")) {
-        damageType = "crush";
-      } else if (combatManeuvers.some((cm) => cm.damageType === "slash")) {
-        damageType = "slash";
-      } else if (combatManeuvers.some((cm) => cm.damageType === "impale")) {
-        damageType = "impale";
-      }
-    }
-    return damageType;
-  }
-
-  private static async hitLocationRoll(speaker: ChatSpeakerDataProperties) {
-    const roll = new Roll("1d20");
-    await roll.evaluate({ async: true });
-    await roll.toMessage({
-      speaker: speaker,
-      type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-      flavor: localize("RQG.Dialog.weaponChat.HitLocationRollFlavor"),
-    });
-  }
-
-  private static async fumbleRoll(actor: RqgActor, speaker: ChatSpeakerDataProperties) {
-    const fumbleTableName = getGame().settings.get(systemId, "fumbleRollTable");
-    const fumbleTable = getGame().tables?.getName(fumbleTableName);
-    if (!fumbleTable) {
-      logMisconfiguration(
-        localize("RQG.Dialog.weaponChat.FumbleTableMissingWarn", {
-          fumbleTableName: fumbleTableName,
-        }),
-        true
-      );
-      return;
-    }
-    // @ts-ignore TODO draw StoredDocument<RollTable>
-    const draw = await fumbleTable.draw({ displayChat: false });
-    // Construct chat data
-    const numberOfResults =
-      draw.results.length > 1
-        ? localize("RQG.Dialog.weaponChat.PluralResults", { numberOfResults: draw.results.length })
-        : localize("RQG.Dialog.weaponChat.SingularResult");
-    const messageData: ChatMessageDataConstructorData = {
-      flavor: localize("RQG.Dialog.weaponChat.DamageBonusDamageTag", {
-        numberOfResults: numberOfResults,
-        fumbleTableName: fumbleTableName,
-      }),
-      user: getGameUser().id,
-      speaker: speaker,
-      whisper: usersIdsThatOwnActor(actor),
-      type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-      roll: draw.roll,
-      sound: draw.roll ? CONFIG.sounds.dice : null,
-      flags: { "core.RollTable": fumbleTable.id },
-    };
-
-    // Render the chat message which combines the dice roll with the drawn results
-    messageData.content = await renderTemplate(CONFIG.RollTable.resultTemplate, {
-      // @ts-expect-error is "documents" in current foundry versions
-      description: TextEditor.enrichHTML(fumbleTable.data.description, { documents: true }),
-      results: draw.results.map((r: any) => {
-        // TODO fix typing
-        r.text = r.getChatText();
-        return r;
-      }),
-      rollHTML: fumbleTable.data.displayRoll ? await draw.roll.render() : null,
-      table: fumbleTable,
-    });
-
-    // Create the chat message
-    await ChatMessage.create(messageData);
-  }
-
-  private static async crushSpecialDamage(damageBonus: string): Promise<any[]> {
-    if (damageBonus.length) {
-      const specialDamage = Roll.parse(damageBonus, {});
-      const roll = Roll.fromTerms(specialDamage);
-      await roll.evaluate({ maximize: true, async: true });
-      const crushSpecialDamageTag = localize("RQG.Dialog.weaponChat.CrushSpecialDamageTag");
-      return Roll.parse(`+ ${roll.result}[${crushSpecialDamageTag}]`, {});
-    }
-    return [];
-  }
-
-  private static slashImpaleSpecialDamage(weaponDamage: string): any[] {
-    const impaleSpecialDamageTag = localize("RQG.Dialog.weaponChat.ImpaleSpecialDamageTag");
-    return Roll.parse(`+ (${weaponDamage})[${impaleSpecialDamageTag}]`, {});
-  }
-
-  public static getUsedSkillItem(
-    actor: RqgActor,
-    weaponItem: RqgItem,
-    usage: UsageType
-  ): RqgItem | undefined {
-    assertItemType(weaponItem.data.type, ItemTypeEnum.Weapon);
-
-    return actor.getEmbeddedDocument("Item", weaponItem.data.data.usage[usage]?.skillId) as
-      | RqgItem
-      | undefined;
   }
 }

--- a/src/chat/weaponChatHandler.ts
+++ b/src/chat/weaponChatHandler.ts
@@ -150,7 +150,7 @@ export class WeaponChatHandler {
     assertItemType(weapon.data.type, ItemTypeEnum.Weapon);
     return Object.entries(weapon.data.data.usage).reduce((acc: any, [key, usage]) => {
       if (usage.skillId) {
-        acc[key] = localize(`RQG.Game.WeaponUsage.${key}`);
+        acc[key] = localize(`RQG.Game.WeaponUsage.${key}-full`);
       }
       return acc;
     }, {});

--- a/src/chat/weaponChatHandler.ts
+++ b/src/chat/weaponChatHandler.ts
@@ -508,7 +508,7 @@ export class WeaponChatHandler {
     return Roll.parse(`+ (${weaponDamage})[${impaleSpecialDamageTag}]`, {});
   }
 
-  private static getUsedSkillItem(
+  public static getUsedSkillItem(
     actor: RqgActor,
     weaponItem: RqgItem,
     usage: UsageType

--- a/src/data-model/item-data/weaponData.ts
+++ b/src/data-model/item-data/weaponData.ts
@@ -39,6 +39,7 @@ export interface WeaponDataSourceData extends IPhysicalItem {
   usage: {
     [K in UsageType]: Usage;
   };
+  defaultUsage: UsageType | undefined; // Used to remember how the actor used it lastly
   hitPoints: Resource;
   /** E.g. arm or --- instead of a number */
   hitPointLocation: string;
@@ -117,6 +118,7 @@ export const defaultWeaponData: WeaponDataSourceData = {
       minDexterity: 0,
     },
   },
+  defaultUsage: undefined,
   description: "",
   gmNotes: "",
   hitPoints: defaultResource,

--- a/src/data-model/shared/rqgDocumentFlags.ts
+++ b/src/data-model/shared/rqgDocumentFlags.ts
@@ -1,6 +1,5 @@
 import { ResultEnum } from "./ability";
 import { CharacteristicData } from "../../chat/characteristicChatHandler";
-import { UsageType } from "../item-data/weaponData";
 import { ChatMessageType } from "../../chat/RqgChatMessage";
 
 export const documentRqidFlags = "documentRqidFlags";
@@ -126,12 +125,12 @@ export interface WeaponChatFlags extends BaseRqgChatFlags {
   type: "weaponChat";
   chat: CommonRqgChatFlags & {
     weaponUuid: string;
-    usage: UsageType;
     result: ResultEnum | undefined;
     specialDamageTypeText: string | undefined;
   };
   formData: {
     otherModifiers: FormDataEntryValue;
+    usage: FormDataEntryValue;
     combatManeuverName: FormDataEntryValue;
     actionName: string; // the clicked buttons name (like "combatManeuver" or "damageRoll")
     actionValue: string; // the clicked buttons value (like "slash" or "special")

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -372,7 +372,6 @@
       "Notification": {
         "DatasetNotFound": "Couldn't find dataset for characteristic",
         "CharacteristicNotFound": "Couldn't find characteristic name \"{characteristicName}\" on actor {actorName} to do an action from the characteristics context menu.",
-        "CantShowWeaponChatError": "Couldn't find skillId [{skillItemId}] or weaponId [{weaponItemId}] on actor ${actorName} to show the weapon chat message from the combat context menu.",
         "CantToggleExperienceError": "Couldn't find itemId [{itemId}] on actor {actorName} to toggle experience from the combat context menu.",
         "CantShowItemSheetError": "Couldn't find itemId [{skillItemId}] on actor {actorName} to show skill Item sheet from the combat context menu.",
         "CantShowWeaponSheetError": "Couldn't find itemId [{weaponItemId}] on actor {actorName} to show weapon item sheet from the combat context menu.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1006,7 +1006,11 @@
         "oneHand": "1H",
         "offHand": "offH",
         "twoHand": "2H",
-        "missile": "Missile"
+        "missile": "Missile",
+        "oneHand-full": "One-handed",
+        "offHand-full": "One-handed – offhand",
+        "twoHand-full": "Two-handed",
+        "missile-full": "Missile"
       },
       "RollDifficulty": {
         "0": "Nearly Impossible (*0.5)",

--- a/src/items/rqgItem.ts
+++ b/src/items/rqgItem.ts
@@ -9,11 +9,29 @@ import { WeaponSheet } from "./weapon-item/weaponSheet";
 import { SpiritMagicSheet } from "./spirit-magic-item/spiritMagicSheet";
 import { CultSheet } from "./cult-item/cultSheet";
 import { RuneMagicSheet } from "./rune-magic-item/runeMagicSheet";
-import { getGame, localize, RqgError } from "../system/util";
+import {
+  activateChatTab,
+  assertItemType,
+  getGame,
+  localize,
+  requireValue,
+  RqgError,
+} from "../system/util";
 import { DocumentModificationOptions } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/abstract/document.mjs";
 import { HomelandSheet } from "./homeland-item/homelandSheet";
 import { OccupationSheet } from "./occupation-item/occupationSheet";
 import { systemId } from "../system/config";
+import {
+  ItemChatFlags,
+  RuneMagicChatFlags,
+  SpiritMagicChatFlags,
+  WeaponChatFlags,
+} from "../data-model/shared/rqgDocumentFlags";
+import { ItemChatHandler } from "../chat/itemChatHandler";
+import { RuneMagicChatHandler } from "../chat/runeMagicChatHandler";
+import { SpiritMagicChatHandler } from "../chat/spiritMagicChatHandler";
+import { WeaponChatHandler } from "../chat/weaponChatHandler";
+import { UsageType } from "../data-model/item-data/weaponData";
 
 export class RqgItem extends Item {
   public static init() {
@@ -109,6 +127,84 @@ export class RqgItem extends Item {
       return true;
     });
   }
+
+  public async toChat(): Promise<void> {
+    if (!this.isEmbedded) {
+      const msg = "Item is not embedded";
+      ui.notifications?.error(msg);
+      throw new RqgError(msg, this);
+    }
+    console.log("%€#%€#%#€%#€%€#%#€ toChat !!!!!!!!", this);
+
+    ResponsibleItemClass.get(this.data.type)?.toChat(this);
+    activateChatTab();
+  }
+
+  // public async rollFromChat(chatMessage: RqgChatMessage): Promise<void> {
+  //   const flags = chatMessage.data.flags.rqg;
+  //   assertChatMessageFlagType(flags?.type, "itemChat");
+  //   // const actor = await getRequiredRqgActorFromUuid<RqgActor>(flags.chat.actorUuid);
+  //   // const token = await getDocumentFromUuid<TokenDocument>(flags.chat.tokenUuid);
+  //   // const speaker = ChatMessage.getSpeaker({ actor: this.actor ?? undefined, token: this.actor?.token ?? undefined });
+  //   // const item = (await getRequiredDocumentFromUuid(flags.chat.itemUuid)) as RqgItem | undefined;
+  //   // requireValue(item, "Couldn't find item on item chat message");
+  //   const { modifier } = await ItemChatHandler.getFormDataFromFlags(flags);
+  //
+  //   await this.roll(modifier);
+  // }
+  //
+  // public async roll(modifier: number): Promise<void> {
+  //   const speaker = ChatMessage.getSpeaker({
+  //     actor: this.actor ?? undefined,
+  //     token: this.actor?.token ?? undefined,
+  //   });
+  //
+  //   const chance = Number((this?.data.data as any).chance) || 0;
+  //   let flavor = localize("RQG.Dialog.itemChat.RollFlavor", { name: this.name });
+  //   if (modifier !== 0) {
+  //     flavor += localize("RQG.Dialog.itemChat.RollFlavorModifier", {
+  //       modifier: formatModifier(modifier),
+  //     });
+  //   }
+  //   const result = await Ability.roll(flavor, chance, modifier, speaker);
+  //   this.actor && (await ItemChatHandler.checkExperience(this.actor, this, result)); // TODO should alos be part of RqgItem
+  // }
+  //
+  // getRollData(): this["data"]["data"] {
+  //   return super.getRollData();
+  // }
+  //
+  // /** Do a roll against this ability and factor in all modifiers.
+  //  * stat - an object that implements IAbility
+  //  * chanceMod - a +/- value that changes the chance
+  //  **/
+  // public static async roll(
+  //   flavor: string,
+  //   chance: number,
+  //   chanceMod: number, // TODO supply full EffectModifier so it's possible to show "Broadsword (Bladesharp +10%, Darkness -70%) Fumble"
+  //   speaker: ChatSpeakerDataProperties,
+  //   resultMessages?: ResultMessage[]
+  // ): Promise<ResultEnum> {
+  //   const r = new Roll("1d100");
+  //   await r.evaluate({ async: true });
+  //   const modifiedChance: number = chance + chanceMod;
+  //   const useSpecialCriticals = getGame().settings.get(systemId, "specialCrit");
+  //   const result = Ability.evaluateResult(modifiedChance, r.total!, useSpecialCriticals);
+  //   let resultMsgHtml: string | undefined = "";
+  //   if (resultMessages) {
+  //     resultMsgHtml = resultMessages.find((i) => i.result === result)?.html;
+  //   }
+  //   const sign = chanceMod > 0 ? "+" : "";
+  //   const chanceModText = chanceMod ? `${sign}${chanceMod}` : "";
+  //   const resultText = localize(`RQG.Game.ResultEnum.${result}`);
+  //   await r.toMessage({
+  //     flavor: `${flavor} (${chance}${chanceModText}%) <h1>${resultText}</h1><div>${resultMsgHtml}</div>`,
+  //     speaker: speaker,
+  //     type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+  //   });
+  //   activateChatTab();
+  //   return result;
+  // }
 
   protected _onCreate(
     data: RqgItem["data"]["_source"],

--- a/src/rqg.scss
+++ b/src/rqg.scss
@@ -685,8 +685,12 @@ body {
   }
 
   &.chat-content {
+    &>* {
+      margin-top: 5px;
+      margin-bottom: 5px;
+    }
+
     .chat-options {
-      margin: 10px 0 0 0;
       background: url(./assets/images/ui/mainbackground.webp) repeat-y scroll top left/100%;
     }
 

--- a/src/rqg.scss
+++ b/src/rqg.scss
@@ -396,6 +396,9 @@ body {
         &.missile {
           line-height: 3rem;
         }
+        &.default-usage {
+          font-weight: bold;
+        }
       }
     }
 
@@ -597,7 +600,7 @@ body {
   [data-item-heal-wound],
   [data-item-add-wound],
   [data-rqid-link],
-  [data-weapon-usage-type],
+  [data-weapon-roll],
   [data-reputation-roll],
   [data-rune-magic-roll] {
     &:hover {

--- a/src/system/migrations/migrations-item/migrateDescriptionLinks.ts
+++ b/src/system/migrations/migrations-item/migrateDescriptionLinks.ts
@@ -42,7 +42,7 @@ export async function useRqidDescriptionLinks(itemData: ItemData): Promise<ItemU
         console.log(
           logPrefix,
           // @ts-expect-errors journalId & journalPack
-          `Didn't find a JE from previous link id [${itemData.data?.journalId}], pack [${itemData.data?.journalPack}] but found a link to a standard named JE [${testRqidLink}] - updated item`,
+          `Didn't find a JE from previous link id [${itemData.data?.journalId}], compendium [${itemData.data?.journalPack}] but found a link to a standard named JE [${testRqidLink}] - updated item`,
 
           updateData,
           itemData
@@ -51,7 +51,7 @@ export async function useRqidDescriptionLinks(itemData: ItemData): Promise<ItemU
         console.debug(
           logPrefix,
           // @ts-expect-errors journalId & journalPack
-          `Didn't find a JE from previous link id [${itemData.data?.journalId}], pack [${itemData.data?.journalPack}] or from default rqid link [${testRqidLink}] - no update`,
+          `Didn't find a JE from previous link id [${itemData.data?.journalId}], compendium [${itemData.data?.journalPack}] or from default rqid link [${testRqidLink}] - no update`,
           itemData
         );
       }


### PR DESCRIPTION
Move the selection of "usage" (One hand / Off Hand / Two Hand / Missile) from the actor sheet to the weapon chat message.

Also refactor by moving code like `toChat` & `abilityRoll` from chatHandler to the items for a more OO feel and to not have pass around so many parameters.
