### PR TITLE
fix: rqid dialog can give false warning of multiple Rqids

### DIFF
--- a/src/dialog/rqidEditor/rqidEditor.ts
+++ b/src/dialog/rqidEditor/rqidEditor.ts
@@ -1,6 +1,6 @@
 import { Document } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/abstract/module.mjs";
 import { systemId } from "../../system/config";
-import { getRequiredDomDataset } from "../../system/util";
+import { escapeRegex, getRequiredDomDataset } from "../../system/util";
 import { Rqid } from "../../system/api/rqidApi";
 
 export class RqidEditor extends FormApplication {
@@ -33,16 +33,17 @@ export class RqidEditor extends FormApplication {
       this.document.data?.flags?.rqg?.documentRqidFlags?.lang;
     if (documentRqid && documentLang) {
       const rqidDocumentPrefix = documentRqid.split(".")[0];
+      const rqidSearchRegex = new RegExp("^" + escapeRegex(documentRqid) + "$");
 
       // Find out if there exists a duplicate rqid already and propose a
       const worldDocuments = await Rqid.fromRqidRegex(
-        new RegExp(documentRqid),
+        rqidSearchRegex,
         rqidDocumentPrefix,
         documentLang,
         "world"
       );
       const compendiumDocuments = await Rqid.fromRqidRegex(
-        new RegExp(documentRqid),
+        rqidSearchRegex,
         rqidDocumentPrefix,
         documentLang,
         "compendiums"

--- a/src/system/util.ts
+++ b/src/system/util.ts
@@ -144,6 +144,13 @@ export function trimChars(inputString: string, charsToTrim: string): string {
   return inputString.replace(new RegExp(`^[${charsToTrim}]+|[${charsToTrim}]+$`, "g"), "");
 }
 
+/**
+ * Escape any special regex characters.
+ */
+export function escapeRegex(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}
+
 export function logMisconfiguration(msg: string, notify: boolean, ...debugData: any) {
   // TODO only for GM? getGame().user.isGM &&
   console.warn(`RQG | ${msg}`, debugData);


### PR DESCRIPTION
The regex search wasn't for the full string so partial matches would also be found - fixed.
I also added a regex escape  when searching since the rqids contain `.`and that matches any character in regex.