### PR TITLE
Do minimal changes to make the system run in v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Latest Release Download Count](https://img.shields.io/github/downloads/wakeand/fvtt-system-rqg/latest/rqg.zip)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/wakeand/fvtt-module-reverseinitiativeorder/blob/master/LICENSE)
 
-# RuneQuest Glorantha (Unofficial) system for Foundry Virtual Table Top
+# RuneQuest Glorantha system for Foundry Virtual Table Top
 
 ## Installing
 Paste this into Foundry VTT Install System -> Manifest URL

--- a/src/actors/rqgActiveEffect.ts
+++ b/src/actors/rqgActiveEffect.ts
@@ -20,7 +20,13 @@ export class RqgActiveEffect extends ActiveEffect {
       const affectedItem = items[0];
       const currentValue: number = getProperty(items[0], path) || 0;
       const changeValue: number = Number(change.value) || 0;
-      foundry.utils.setProperty(affectedItem, path, changeValue + currentValue);
+      try {
+        foundry.utils.setProperty(affectedItem, path, changeValue + currentValue);
+      } catch (e) {
+        const msg = `Active Effect on item [${affectedItem.name}] in actor [${actor.name}] failed. Probably because of wrong syntax in the active effect attribute key [${change.key}].`;
+        ui.notifications?.warn(msg);
+        console.warn("RQG |", msg, change, e);
+      }
       return changeValue;
     } else if (items.length === 0) {
       if (this.data.origin && this.data.origin?.split(".")[1] === actor.id) {

--- a/src/dialog/rqidEditor/rqidEditor.ts
+++ b/src/dialog/rqidEditor/rqidEditor.ts
@@ -58,8 +58,11 @@ export class RqidEditor extends FormApplication {
         priority: d.data.flags.rqg.documentRqidFlags.priority,
         // @ts-ignore
         link: TextEditor.enrichHTML(d.link),
-        // @ts-ignore
-        compendium: `${d.compendium?.metadata?.label} (${d.compendium?.metadata?.package})`,
+        // @ts-expect-error compendium
+        compendium: `${d.compendium?.metadata?.label} ⇒ ${
+          // @ts-expect-error compendium  v9 => package, v10 => packageName
+          d.compendium?.metadata?.packageName ?? d.compendium?.metadata?.package
+        }`,
       }));
 
       const uniqueWorldPriorityCount = new Set(

--- a/src/foundryUi/pause.hbs
+++ b/src/foundryUi/pause.hbs
@@ -1,4 +1,4 @@
-<div id="pause" class="{{#if paused}}paused{{/if}}">
-  <img src="{{pauseImage}}">
-  <h3 class="norse">{{ localize "GAME.Paused" }}</h3>
-</div>
+<figure id="pause" class="{{#if paused}}paused{{/if}}">
+  <img src="{{pauseImage}}" class="fa-spin">
+  <figcaption class="norse">{{localize "GAME.Paused"}}</figcaption>
+</figure>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1022,7 +1022,7 @@
     },
     "RQGSystem": {
       "rqid": "RuneQuest System ID (rqid)",
-      "GenerateDefaultRqid": "Create Rune Quest System ID (rqid) based on current document. The rqid should be based on the english document name.",
+      "GenerateDefaultRqid": "Create RuneQuest System ID (rqid) based on current document. The rqid should be based on the english document name.",
       "rqidPriority": "Rqid Priority",
       "rqidLang": "Language",
       "FoundryId": "Foundry ID",

--- a/src/items/rqgItem.ts
+++ b/src/items/rqgItem.ts
@@ -228,8 +228,13 @@ export class RqgItem extends Item {
       "defaultItemIconSettings"
     );
     const item = data._id ? getGame().items?.get(data._id) : undefined;
+    // @ts-expect-errors Foundry v10 vs v9 default icon
+    const defaultIcon = foundry?.documents?.BaseItem?.DEFAULT_ICON
+      ? // @ts-expect-errors Foundry v10 vs v9 default icon
+        foundry.documents.BaseItem.DEFAULT_ICON
+      : foundry.data.ItemData.DEFAULT_ICON;
 
-    if (item?.data.img === foundry.data.ItemData.DEFAULT_ICON) {
+    if (item?.data.img === defaultIcon) {
       const updateData: any = {
         img: defaultItemIconSettings[data.type],
         "data.namePrefix": data.name,

--- a/src/rqg.scss
+++ b/src/rqg.scss
@@ -1101,10 +1101,21 @@ body {
 #pause {
   background: none;
 
-  h3 {
+  figcaption {
     font-size: 3rem;
     text-shadow: 1px 1px 2px var(--rqg-color-main), 0 0 1em var(--rqg-color-main-bg),
       0 0 0.2em var(--rqg-color-main-bg);
+
+
+    margin: 0;
+    //font-size: 2em;
+    font-weight: normal;
+    line-height: 100px;
+    text-align: center;
+    position: relative;
+    z-index: calc(var(--z-index-window) - 1);
+    color: var(--color-text-light-1);
+    //text-shadow: 1px 1px 30px var(--color-shadow-dark);
   }
 }
 

--- a/src/rqg.ts
+++ b/src/rqg.ts
@@ -21,7 +21,7 @@ Hooks.once("init", async () => {
   console.log(
     "%c                                                                                            \n" +
       "                                                                                            \n" +
-      '`7MM"""Mq.  %c(Unofficial)%c                     .g8""8q.                                 mm    \n' +
+      '`7MM"""Mq.                                   .g8""8q.                                 mm    \n' +
       "  MM   `MM.                                .dP'    `YM.                               MM    \n" +
       '  MM   ,M9 `7MM  `7MM  `7MMpMMMb.  .gP"Ya  dM\'      `MM `7MM  `7MM  .gP"Ya  ,pP"Ybd mmMMmm  \n' +
       "  MMmmdM9    MM    MM    MM    MM ,M'   Yb MM        MM   MM    MM ,M'   Yb 8I   `\"   MM    \n" +
@@ -40,13 +40,16 @@ Hooks.once("init", async () => {
       "  `\"bmmmdPY .JMML.`Ybmd9'.JMML.  `Moo9^Yo..JMML  JMML.`Mbmo.JMML  JMML.`Moo9^Yo.\n" +
       "                                                                                \n" +
       "                                                                                \n",
-    "color: #F3A71E",
-    "color: unset",
     "color: #F3A71E"
   );
-  console.log("RQG | Initializing the Runequest Glorantha (Unofficial) Game System");
+  console.log("RQG | Initializing the Runequest Glorantha Game System");
 
   CONFIG.RQG = RQG_CONFIG;
+  // @ts-expect-errors v10
+  if (CONFIG?.compatibility) {
+    // @ts-expect-errors v10 SILENT - no warnings
+    CONFIG.compatibility.mode = CONST.COMPATIBILITY_MODES?.SILENT;
+  }
 
   // CONFIG.debug.hooks = true; // console log when hooks fire
   // CONFIG.debug.time = true; // console log time

--- a/src/system.json
+++ b/src/system.json
@@ -1,8 +1,9 @@
 {
   "name": "rqg",
+  "id": "rqg",
   "type": "system",
-  "title": "RuneQuest Glorantha (Unofficial)",
-  "description": "A RuneQuest Glorantha (Unofficial) system implementation.",
+  "title": "RuneQuest Glorantha",
+  "description": "A RuneQuest Glorantha system implementation.",
   "version": "1.15.0",
   "license": "UNLICENSED",
   "background": "assets/images/ui/priestess.webp",
@@ -132,6 +133,10 @@
   "gridUnits": "m",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
+  "compatibility": {
+    "minimum": 9,
+    "verified": 10
+  },
   "url": "https://github.com/sun-dragon-cult/fvtt-system-rqg",
   "manifest": "https://github.com/sun-dragon-cult/fvtt-system-rqg/releases/latest/download/system.json",
   "download": "https://github.com/sun-dragon-cult/fvtt-system-rqg/releases/download/v1.15.0/rqg.zip",

--- a/src/system/migrations/migrations-item/migrateDescriptionLinks.ts
+++ b/src/system/migrations/migrations-item/migrateDescriptionLinks.ts
@@ -1,6 +1,6 @@
 import { ItemData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs";
 import { ItemUpdate } from "../applyMigrations";
-import { getGame, toKebabCase } from "../../util";
+import { getGame, systemProp, toKebabCase } from "../../util";
 import { Rqid } from "../../api/rqidApi";
 
 const logPrefix = "RQG | Migrate Descr. Link |";
@@ -9,8 +9,8 @@ export async function useRqidDescriptionLinks(itemData: ItemData): Promise<ItemU
   const updateData: ItemUpdate = {};
   updateData.data = updateData.data ?? {};
 
-  if (hasProperty(itemData.data, "journalId")) {
-    const previousRqidLink = (itemData as any).data?.descriptionRqidLink?.id;
+  if (hasProperty((itemData as any)[systemProp()], "journalId")) {
+    const previousRqidLink = (itemData as any)[systemProp()]?.descriptionRqidLink?.id;
     // Already has a rqidLink - don't update
     if (previousRqidLink) {
       return updateData;
@@ -41,8 +41,11 @@ export async function useRqidDescriptionLinks(itemData: ItemData): Promise<ItemU
         };
         console.log(
           logPrefix,
-          // @ts-expect-errors journalId & journalPack
-          `Didn't find a JE from previous link id [${itemData.data?.journalId}], compendium [${itemData.data?.journalPack}] but found a link to a standard named JE [${testRqidLink}] - updated item`,
+          `Didn't find a JE from previous link id [${
+            (itemData as any)[systemProp()]?.journalId
+          }], compendium [${
+            (itemData as any)[systemProp()]?.journalPack
+          }] but found a link to a standard named JE [${testRqidLink}] - updated item`,
 
           updateData,
           itemData
@@ -50,8 +53,11 @@ export async function useRqidDescriptionLinks(itemData: ItemData): Promise<ItemU
       } else {
         console.debug(
           logPrefix,
-          // @ts-expect-errors journalId & journalPack
-          `Didn't find a JE from previous link id [${itemData.data?.journalId}], compendium [${itemData.data?.journalPack}] or from default rqid link [${testRqidLink}] - no update`,
+          `Didn't find a JE from previous link id [${
+            (itemData as any)[systemProp()]?.journalId
+          }], compendium [${
+            (itemData as any)[systemProp()]?.journalPack
+          }] or from default rqid link [${testRqidLink}] - no update`,
           itemData
         );
       }
@@ -66,13 +72,13 @@ export async function useRqidDescriptionLinks(itemData: ItemData): Promise<ItemU
 
 async function getUpdateViaPreviousLink(itemData: ItemData): Promise<ItemUpdate | undefined> {
   // Follow the old link and get its values
-  const oldJournalId: string | undefined = (itemData.data as any).journalId;
+  const oldJournalId: string | undefined = (itemData as any)[systemProp()]?.journalId;
   if (!oldJournalId) {
     // no previous id - will check if there is a match with default rqid as well...
     return undefined;
   }
 
-  const oldJournalPack: string | undefined = (itemData.data as any).journalPack;
+  const oldJournalPack: string | undefined = (itemData as any)[systemProp()]?.journalPack;
   const updateData = oldJournalPack
     ? await getUpdateFromCompendium(oldJournalId, oldJournalPack)
     : getUpdateFromWorld(oldJournalId);

--- a/src/system/migrations/migrations-item/renameFireSky.ts
+++ b/src/system/migrations/migrations-item/renameFireSky.ts
@@ -1,5 +1,6 @@
 import { ItemData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs";
 import { ItemUpdate } from "../applyMigrations";
+import { systemProp } from "../../util";
 
 export async function renameFireSky(itemData: ItemData): Promise<ItemUpdate> {
   let updateData: ItemUpdate = {};
@@ -15,7 +16,7 @@ export async function renameFireSky(itemData: ItemData): Promise<ItemUpdate> {
 
   // Rename Rune item references to the Fire rune
   // A Rune can not have itself as a minor rune so there is no risk of overwriting updateData above
-  const minorRunes = (itemData.data as any).minorRunes;
+  const minorRunes = (itemData as any)[systemProp()]?.minorRunes;
   if (minorRunes?.includes("Fire (element)")) {
     updateData = {
       data: {
@@ -27,7 +28,7 @@ export async function renameFireSky(itemData: ItemData): Promise<ItemUpdate> {
   }
 
   // Cult, RuneMagic & Skill items have "runes" property that might point to Fire Rune
-  const runes = (itemData.data as any).runes;
+  const runes = (itemData as any)[systemProp()]?.runes;
   if (runes?.includes("Fire (element)")) {
     updateData = {
       data: {

--- a/src/system/migrations/migrations-item/renameRuneMagicDurationSpecial.ts
+++ b/src/system/migrations/migrations-item/renameRuneMagicDurationSpecial.ts
@@ -2,9 +2,13 @@ import { ItemTypeEnum } from "../../../data-model/item-data/itemTypes";
 import { ItemData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs";
 import { ItemUpdate } from "../applyMigrations";
 import { SpellDurationEnum } from "../../../data-model/item-data/spell";
+import { systemProp } from "../../util";
 
 export async function renameRuneMagicDurationSpecial(itemData: ItemData): Promise<ItemUpdate> {
-  if (itemData.type === ItemTypeEnum.RuneMagic && (itemData.data.duration as any) === "duration") {
+  if (
+    itemData.type === ItemTypeEnum.RuneMagic &&
+    (itemData as any)[systemProp()]?.duration === "duration"
+  ) {
     return {
       data: {
         duration: SpellDurationEnum.Special,

--- a/src/system/util.ts
+++ b/src/system/util.ts
@@ -545,3 +545,14 @@ export function activateChatTab() {
   // @ts-ignore 0.8 tabs
   ui?.sidebar?.tabs.chat && ui.sidebar?.activateTab(ui.sidebar.tabs.chat.tabName);
 }
+
+/**
+ * This is for the transition period before we make a clean switch to Foundry v10.
+ * When reading data from itemData the actual data is either behind `.data` or `.system`
+ * depending on Foundry version.
+ * If the data is no longer an item (just an item data object) the Foundry polyfills won't work.
+ * In that case use the `systemProp` constant to make it work in both: `itemdata[systemProp()]`.
+ */
+export function systemProp(): string {
+  return (getGame() as any).data.release.generation > 9 ? "system" : "data";
+}


### PR DESCRIPTION
This should move the system into a transitional state where it's possible to use it in both Foundry v9 and v10. This means that v10 specific functionality cannot be used yet in the code, and that the we rely on the polyfills for old Foundry data model and we just silence the compatibility warnings.

The new v10 journal system can make the journals look a bit weird in v10 - that will be addressed when we transition to v10 for real. Another change when running v10 is that the permission system for who is allowed to see the journals now is in effect, so players need to have at least "Observer" rights on the journals they are supposed to see.

Disclaimer: there most probably are incompatibilities left when running v10. 