### PR TITLE
fix: fromRqidRegexAll with scope "match" does not give correct results

### DIFF
--- a/src/dialog/rqidEditor/rqidEditor.ts
+++ b/src/dialog/rqidEditor/rqidEditor.ts
@@ -48,7 +48,7 @@ export class RqidEditor extends FormApplication {
         rqidSearchRegex,
         rqidDocumentPrefix,
         documentLang,
-        "compendiums"
+        "packs"
       );
       const worldDocumentInfo = worldDocuments.map((d) => ({
         priority: d.data.flags.rqg.documentRqidFlags.priority,

--- a/src/i18n/en/openSystem.json
+++ b/src/i18n/en/openSystem.json
@@ -1039,9 +1039,9 @@
       "DuplicateWarning": "Warning: Multiple rqids with same priority!",
       "Error": {
         "NoSheet": "No sheet found for document linked to by RQG System ID (rqid) \"{rqid}\". See console log.",
-        "MoreThanOneRqidMatchInWorld": "More than one RQG Document in the world (not in Compendia) matched the rqid \"{rqid}\", lang \"{lang}\", and priority \"{priority}\". Please review your RQG System settings.  See console log for item ids.",
-        "MoreThanOneRqidMatchInCompendia": "More than one RQG Document in installed Compendia matched the rqid \"{rqid}\", lang \"{lang}\", and priority \"{priority}\". Please review your RQG System settings.  See console log for item ids.",
-        "DocumentNotFoundByRqid": "Document not found in world or Compendia matching the rqid \"{rqid}\", and lang \"{lang}\". See console log."
+        "MoreThanOneRqidMatchInWorld": "More than one RQG Document in the world (not in compendium packs) matched the rqid \"{rqid}\", lang \"{lang}\", and priority \"{priority}\". Please review your RQG System settings.  See console log for item ids.",
+        "MoreThanOneRqidMatchInPacks": "More than one RQG Document in installed compendium packs matched the rqid \"{rqid}\", lang \"{lang}\", and priority \"{priority}\". Please review your RQG System settings.  See console log for item ids.",
+        "DocumentNotFoundByRqid": "Document not found in world or compendium packs matching the rqid \"{rqid}\", and lang \"{lang}\". See console log."
       }
     },
     "Notification": {

--- a/src/system/migrations/assignRqidToJEs.ts
+++ b/src/system/migrations/assignRqidToJEs.ts
@@ -47,7 +47,7 @@ export async function assignRqidToJEs(): Promise<void> {
             console.error("Couldn't get journal entry from pack!!!");
             continue;
           }
-          rqidFlags.id = await generateRqid(je, "compendiums", addedRqids);
+          rqidFlags.id = await generateRqid(je, "packs", addedRqids);
           rqidFlags.lang = rqidFlags?.lang ? rqidFlags.lang : "en";
           rqidFlags.priority = rqidFlags?.priority ? rqidFlags.priority : 1999;
 
@@ -72,7 +72,7 @@ export async function assignRqidToJEs(): Promise<void> {
    **/
   async function generateRqid(
     je: Document<any, any>,
-    scope: "all" | "world" | "compendiums",
+    scope: "all" | "world" | "packs",
     alreadyAddedRqids: string[] = []
   ): Promise<string> {
     const proposedRqid = Rqid.getDefaultRqid(je);


### PR DESCRIPTION
I solved the "match" scope by filtering out any compendium pack matches that also exist in the world matches before merging those two lists. It's not the most effective solution since all pack documents that match the regex will be downloaded from the server, but hopefully it's good enough for a first version, and it could be improved upon later without being a breaking change.

I also renamed compendium to pack in a bunch of places while I was in this file...