### PR TITLE
fix: long cult names break layout

### DIFF
--- a/src/actors/_actorsheets.scss
+++ b/src/actors/_actorsheets.scss
@@ -40,6 +40,7 @@
         line-height: 1rem;
         text-align: end;
         margin-bottom: 5px;
+        font-size: var(--font-size-16);
       }
     }
 

--- a/src/actors/_actorsheets.scss
+++ b/src/actors/_actorsheets.scss
@@ -36,7 +36,10 @@
       height: fit-content;
 
       .cult {
+        max-width: 20rem;
         line-height: 1rem;
+        text-align: end;
+        margin-bottom: 5px;
       }
     }
 

--- a/src/actors/rqgActorSheet.hbs
+++ b/src/actors/rqgActorSheet.hbs
@@ -6,43 +6,45 @@
     <div>
       <div class="topheaderline">
         <h1 class="charname"><input name="name" type="text" value="{{name}}"></h1>
-        <div class="flex-row gap1rem">
-          {{#unless (eq system.attributes.health "healthy")}}<i>{{localize (concat "RQG.Actor.Attributes.Health." system.attributes.health)}}</i>{{/unless}}
-          <div>
+        <div>
+          <div class="flex-row-end gap1rem">
+            {{#unless (eq system.attributes.health "healthy")}}<i>{{localize (concat "RQG.Actor.Attributes.Health." system.attributes.health)}}</i>{{/unless}}
+            {{#if characterElementRunes}}
+              <div class="flex-row gap01rem">
+                {{#each characterElementRunes}}
+                  <div class="rune contextmenu item" data-item-id="{{id}}">
+                    <img class="rune" src="{{img}}" {{#if descriptionRqid}} data-rqid-link="{{descriptionRqid}}"{{/if}}>
+                  </div>
+                {{/each}}
+              </div>
+            {{/if}}
+            {{#if characterPowerRunes}}
+              <div class="flex-row gap01rem">
+                {{#each characterPowerRunes}}
+                <div class="rune contextmenu item" data-item-id="{{id}}">
+                  <img class="rune" src="{{img}}" {{#if descriptionRqid}} data-rqid-link="{{descriptionRqid}}"{{/if}}>
+                </div>
+                {{/each}}
+              </div>
+            {{/if}}
+            {{#if characterFormRunes}}
+              <div class="flex-row gap01rem">
+                {{#each characterFormRunes}}
+                <div class="rune contextmenu item" data-item-id="{{id}}">
+                  <img class="rune" src="{{img}}" {{#if descriptionRqid}} data-rqid-link="{{descriptionRqid}}"{{/if}}>
+                </div>
+                {{/each}}
+              </div>
+            {{/if}}
+          </div>
+          {{#if mainCult.id}}
             <div class="cult contextmenu item" data-item-id="{{mainCult.id}}" data-rqid-link="{{mainCult.descriptionRqid}}">
               <b>{{mainCult.name}}
                 {{#if mainCult.hasMultipleCults}}
                   <i class="fa fa-plus-circle x-small-size" aria-hidden="true" data-tooltip="{{localize "RQG.UI.MultipleCults"}}"></i>
                 {{/if}}
-              </b><br>
+              </b>
               <span class="x-small-size">{{mainCult.rank}}</span>
-            </div>
-          </div>
-          {{#if characterElementRunes}}
-            <div class="flex-row gap01rem">
-              {{#each characterElementRunes}}
-                <div class="rune contextmenu item" data-item-id="{{id}}">
-                  <img class="rune" src="{{img}}" {{#if descriptionRqid}} data-rqid-link="{{descriptionRqid}}"{{/if}}>
-                </div>
-              {{/each}}
-            </div>
-          {{/if}}
-          {{#if characterPowerRunes}}
-            <div class="flex-row gap01rem">
-              {{#each characterPowerRunes}}
-              <div class="rune contextmenu item" data-item-id="{{id}}">
-                <img class="rune" src="{{img}}" {{#if descriptionRqid}} data-rqid-link="{{descriptionRqid}}"{{/if}}>
-              </div>
-              {{/each}}
-            </div>
-          {{/if}}
-          {{#if characterFormRunes}}
-            <div class="flex-row gap01rem">
-              {{#each characterFormRunes}}
-              <div class="rune contextmenu item" data-item-id="{{id}}">
-                <img class="rune" src="{{img}}" {{#if descriptionRqid}} data-rqid-link="{{descriptionRqid}}"{{/if}}>
-              </div>
-              {{/each}}
             </div>
           {{/if}}
         </div>

--- a/src/actors/rqgActorSheet.hbs
+++ b/src/actors/rqgActorSheet.hbs
@@ -39,11 +39,10 @@
           </div>
           {{#if mainCult.id}}
             <div class="cult contextmenu item" data-item-id="{{mainCult.id}}" data-rqid-link="{{mainCult.descriptionRqid}}">
-              <b>{{mainCult.name}}
-                {{#if mainCult.hasMultipleCults}}
-                  <i class="fa fa-plus-circle x-small-size" aria-hidden="true" data-tooltip="{{localize "RQG.UI.MultipleCults"}}"></i>
-                {{/if}}
-              </b>
+              {{mainCult.name}}
+              {{#if mainCult.hasMultipleCults}}
+                <i class="fa fa-plus-circle small-size" aria-hidden="true" data-tooltip="{{localize "RQG.UI.MultipleCults"}}"></i>
+              {{/if}}
               <span class="x-small-size">{{mainCult.rank}}</span>
             </div>
           {{/if}}

--- a/src/rqg.scss
+++ b/src/rqg.scss
@@ -116,6 +116,11 @@ body {
     justify-content: flex-start;
   }
 
+  .flex-row-end {
+    display: flex;
+    justify-content: flex-end;
+  }
+
   .flex-column {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
I moved the cult name to under the runes and set a max-width of 20rem
![image](https://user-images.githubusercontent.com/4853677/220846297-dd6199ff-2737-4a13-a3c2-58d18a9aad14.png)


closes #477