### PR TITLE
fix: experience Checks should show anywhere a skill is displayed

### DIFF
--- a/src/actors/sheet-parts/gear-tab.hbs
+++ b/src/actors/sheet-parts/gear-tab.hbs
@@ -195,7 +195,11 @@
                         {{#if unusable}} warning{{/if}}"
                         {{#if unusable}}data-tooltip="{{localize "RQG.Actor.Combat.StrDexMinsNotMetTip"}}"{{/if}}
                   >
-                    {{skillchance @root.uuid skillId}}%&nbsp; {{skillname @root.uuid skillId}}
+                    <span class="combat contextmenu usage {{#if (eq @key "missile")}}missile{{/if}} {{experiencedclass @root.uuid skillId}}"
+                          data-skill-id="{{skillId}}" data-item-id="{{../id}}" data-weapon-roll data-tooltip="{{localize "RQG.Game.RollChat"}}">
+                          {{skillchance @root.uuid skillId}}%
+                    </span>                    
+                    &nbsp; {{skillname @root.uuid skillId}}
                   </div>
                 {{/if}}
               {{/each}}


### PR DESCRIPTION
Fixes #487

- experience checks now show on the "Gear" tab
- can also roll from the "Gear" tab