### PR TITLE
fix: opening the elder race sheets from bestiary throws error

### DIFF
--- a/src/actors/rqgActorSheet.ts
+++ b/src/actors/rqgActorSheet.ts
@@ -633,6 +633,20 @@ export class RqgActorSheet extends ActorSheet<
           }
         }
       }
+
+      if (weapon.system.projectileId) {
+        const projectile = actor.items.find((i) => i.id === weapon.system.projectileId);
+        if (projectile) {
+          if (weapon.system.isProjectileWeapon) {
+            weapon.system.selectedAmmo = projectile.name;
+          }
+          if (weapon.system.isThrownWeapon) {
+            weapon.system.thrownWeaponQuantity = projectile.system.quantity;
+          }
+        }
+      } else {
+        weapon.system.ammoNotSelected = "No Ammo Selected";
+      }
     });
     itemTypes[ItemTypeEnum.Armor].sort((a: any, b: any) => a.sort - b.sort);
     itemTypes[ItemTypeEnum.Gear].sort((a: any, b: any) => a.sort - b.sort);

--- a/src/actors/rqgActorSheet.ts
+++ b/src/actors/rqgActorSheet.ts
@@ -634,18 +634,11 @@ export class RqgActorSheet extends ActorSheet<
         }
       }
 
-      if (weapon.system.projectileId) {
-        const projectile = actor.items.find((i) => i.id === weapon.system.projectileId);
-        if (projectile) {
-          if (weapon.system.isProjectileWeapon) {
-            weapon.system.selectedAmmo = projectile.name;
-          }
-          if (weapon.system.isThrownWeapon) {
-            weapon.system.thrownWeaponQuantity = projectile.system.quantity;
-          }
-        }
-      } else {
-        weapon.system.ammoNotSelected = "No Ammo Selected";
+      weapon.system.ammoNotSelected = !weapon.system.projectileId;
+      const projectile = actor.items.find((i) => i.id === weapon.system.projectileId);
+      if (projectile) {
+        weapon.system.projectileQuantity = projectile.system.quantity;
+        weapon.system.projectileName = projectile.name;
       }
     });
     itemTypes[ItemTypeEnum.Armor].sort((a: any, b: any) => a.sort - b.sort);

--- a/src/actors/sheet-parts/combat.hbs
+++ b/src/actors/sheet-parts/combat.hbs
@@ -17,9 +17,15 @@
         <div data-item-id="{{id}}" data-weapon-roll class="combat contextmenu item"><img class="item" src="{{img}}"></div>
         <div data-item-id="{{id}}" data-weapon-roll class="combat contextmenu item">{{name}}
           {{#if system.isProjectileWeapon}}
-            ({{quantity @root.uuid system.projectileId}})
+            ({{#if system.ammoNotSelected}}
+              <span data-tooltip="{{localize "RQG.Actor.Combat.ProjectileWeaponAmmoNotSelectedTip"}}">
+                {{localize "RQG.Actor.Combat.ProjectileWeaponAmmoNotSelectedAlert"}}
+              </span>
+            {{else}}
+              {{system.selectedAmmo}}
+            {{/if}})
           {{else if system.isThrownWeapon}}
-            [{{quantity @root.uuid system.projectileId}}]
+            [{{system.thrownWeaponQuantity}}]
           {{else if system.isProjectile}}
             [{{system.quantity}}]
           {{/if}}

--- a/src/actors/sheet-parts/combat.hbs
+++ b/src/actors/sheet-parts/combat.hbs
@@ -16,19 +16,21 @@
       {{#unless system.isNatural}}
         <div data-item-id="{{id}}" data-weapon-roll class="combat contextmenu item"><img class="item" src="{{img}}"></div>
         <div data-item-id="{{id}}" data-weapon-roll class="combat contextmenu item">{{name}}
-          {{#if system.isProjectileWeapon}}
-            ({{#if system.ammoNotSelected}}
-              <span data-tooltip="{{localize "RQG.Actor.Combat.ProjectileWeaponAmmoNotSelectedTip"}}">
-                {{localize "RQG.Actor.Combat.ProjectileWeaponAmmoNotSelectedAlert"}}
-              </span>
-            {{else}}
-              {{system.selectedAmmo}}
-            {{/if}})
-          {{else if system.isThrownWeapon}}
-            [{{system.thrownWeaponQuantity}}]
-          {{else if system.isProjectile}}
-            [{{system.quantity}}]
-          {{/if}}
+            {{#if system.isProjectileWeapon}}
+              ({{#if system.ammoNotSelected}}
+                <span class="invalid" data-tooltip="{{localize "RQG.Actor.Combat.ProjectileWeaponAmmoNotSelectedTip"}}">
+                  {{localize "RQG.Actor.Combat.ProjectileWeaponAmmoNotSelectedAlert"}}
+                </span>
+              {{else}}
+                <span data-tooltip="{{system.projectileName}}">
+                  {{system.projectileQuantity}}
+                </span>
+              {{/if}})
+            {{else if system.isThrownWeapon}}
+              [{{system.quantity}}]
+            {{else if system.isProjectile}}
+              [{{system.quantity}}]
+            {{/if}}
         </div>
         <div data-item-id="{{id}}" class="combat contextmenu item">
           {{#if system.hitPointLocation}}

--- a/src/assets/pack-templates/equipment-weapons/shield.yaml
+++ b/src/assets/pack-templates/equipment-weapons/shield.yaml
@@ -213,6 +213,6 @@ system:
   range: 0
   isProjectile: false
   isProjectileWeapon: false
-  isThrownWeapon: falseS
+  isThrownWeapon: false
   isRangedWeapon: false
   projectileId:

--- a/src/i18n/en/openSystem.json
+++ b/src/i18n/en/openSystem.json
@@ -217,7 +217,7 @@
         "SpiritCombat": "Spirit Combat",
         "SpiritCombatDamage": "Spirit Combat Damage",
         "SetSRInCombatTracker": "Set SR in combat tracker",
-        "ProjectileWeaponAmmoNotSelectedAlert": "🏹",
+        "ProjectileWeaponAmmoNotSelectedAlert": "no ammo",
         "ProjectileWeaponAmmoNotSelectedTip": "Edit this weapon to select ammunition!"
       },
       "Gear": {

--- a/src/i18n/en/openSystem.json
+++ b/src/i18n/en/openSystem.json
@@ -216,7 +216,9 @@
         "Dodge": "Dodge",
         "SpiritCombat": "Spirit Combat",
         "SpiritCombatDamage": "Spirit Combat Damage",
-        "SetSRInCombatTracker": "Set SR in combat tracker"
+        "SetSRInCombatTracker": "Set SR in combat tracker",
+        "ProjectileWeaponAmmoNotSelectedAlert": "🏹",
+        "ProjectileWeaponAmmoNotSelectedTip": "Edit this weapon to select ammunition!"
       },
       "Gear": {
         "ViewByItemType": "View by Item Type",

--- a/src/rqg.scss
+++ b/src/rqg.scss
@@ -413,6 +413,10 @@ body {
         background: var(--rqg-table-alternate-background);
       }
 
+      .invalid {
+        color: var(--rqg-highlight);
+      }
+
       // Set-token-SR-in-combat button
       button.sr {
         height: 1.5rem;

--- a/src/system/registerHandlebarsHelpers.ts
+++ b/src/system/registerHandlebarsHelpers.ts
@@ -71,20 +71,6 @@ export const registerHandlebarsHelpers = function () {
     )
   );
 
-  Handlebars.registerHelper("quantity", (...args) => {
-    return applyFnToItemFromHandlebarsArgs(args, (item) => {
-      if (!item) {
-        return "---";
-      }
-      if (!hasOwnProperty(item.system, "quantity")) {
-        const msg = `Handlebar helper quantity was called with an item without quantity property`;
-        ui.notifications?.error(msg);
-        throw new RqgError(msg, item);
-      }
-      return item.system.quantity;
-    });
-  });
-
   Handlebars.registerHelper("runeImg", (runeName: string): string | undefined => {
     if (!runeName) {
       return;


### PR DESCRIPTION
Fixes #484

- Display a better message when a projectile weapon does not have ammunition selected

Per discussion, this will not address the fact that we cannot currently pre-link weapons and ammo in the YAML.  Bestiary entries that have projectile weapons will come through showing the alert and the GM will need to edit the weapon to select the ammo to clear the alert.