### PR TITLE
fix: make AP/HP presentation consistent with paper character sheet

### DIFF
--- a/src/actors/_actorsheets.scss
+++ b/src/actors/_actorsheets.scss
@@ -173,6 +173,10 @@
       font-size: 35px;
       font-weight: bold;
     }
+
+    .wounded {
+      color: var(--rqg-highlight);
+    }
   }
 
   .characteristics {
@@ -257,6 +261,42 @@
       font-style: italic;
     }
   }
+
+  .health {
+
+    .strike  {
+      text-decoration:none;position:relative;
+
+      &::before {
+        top: 45%;
+        background: var(--rqg-highlight);
+        opacity: 0.55;
+        content: "";
+        width: 150%;
+        position: absolute;
+        height: 0.2em;
+        border-radius: 1em;
+        left: -30%;
+        white-space: nowrap;
+        display: block;
+        transform: rotate(-45deg);
+      }
+    }
+
+    .health-state {
+      color: var(--rqg-highlight)
+
+    }
+
+    .wounded {
+      background-color: var(--rqg-color-enc-warning);
+      border-color: var(--rqg-highlight);
+    }
+
+  }
+
+
+
 
   .grid.location-row {
     display: grid;

--- a/src/actors/rqgActorSheet.hbs
+++ b/src/actors/rqgActorSheet.hbs
@@ -8,7 +8,7 @@
         <h1 class="charname"><input name="name" type="text" value="{{name}}"></h1>
         <div>
           <div class="flex-row-end gap1rem">
-            {{#unless (eq system.attributes.health "healthy")}}<i>{{localize (concat "RQG.Actor.Attributes.Health." system.attributes.health)}}</i>{{/unless}}
+            {{#unless (eq system.attributes.health "healthy")}}<i class="wounded">{{localize (concat "RQG.Actor.Attributes.Health." system.attributes.health)}}</i>{{/unless}}
             {{#if characterElementRunes}}
               <div class="flex-row gap01rem">
                 {{#each characterElementRunes}}

--- a/src/actors/rqgActorSheet.ts
+++ b/src/actors/rqgActorSheet.ts
@@ -551,9 +551,15 @@ export class RqgActorSheet extends ActorSheet<
     };
 
     // Sort the hit locations
-    itemTypes[ItemTypeEnum.HitLocation].sort(
-      (a: any, b: any) => b.system.dieFrom - a.system.dieFrom
-    );
+    if (getGame().settings.get(systemId, "sortHitLocationsLowToHigh")) {
+      itemTypes[ItemTypeEnum.HitLocation].sort(
+        (a: any, b: any) => a.system.dieFrom - b.system.dieFrom
+      );
+    } else {
+      itemTypes[ItemTypeEnum.HitLocation].sort(
+        (a: any, b: any) => b.system.dieFrom - a.system.dieFrom
+      );
+    }
 
     // Enrich Cult texts for holyDays, gifts, geases, subCults
     await Promise.all(
@@ -988,6 +994,22 @@ export class RqgActorSheet extends ActorSheet<
         }
       });
     });
+
+    // Flip hit location sort order
+    htmlElement
+      ?.querySelectorAll<HTMLElement>("[data-flip-sort-hitlocation-setting]")
+      .forEach((el) => {
+        el.addEventListener("click", async (ev: MouseEvent) => {
+          const currentValue = getGame().settings.get(systemId, "sortHitLocationsLowToHigh");
+          await getGame().settings.set(systemId, "sortHitLocationsLowToHigh", !currentValue);
+          // Rerender all actor sheets the user has open
+          Object.values(ui.windows).forEach((a: any) => {
+            if (a?.document?.type === ActorTypeEnum.Character) {
+              a.render();
+            }
+          });
+        });
+      });
 
     // Set Token SR in Combat Tracker
     htmlElement?.querySelectorAll<HTMLElement>("[data-set-sr]").forEach((el: HTMLElement) => {

--- a/src/actors/sheet-parts/health.hbs
+++ b/src/actors/sheet-parts/health.hbs
@@ -6,6 +6,7 @@
     <div class="flex-row nowrap flex-align-center">
       <label>{{localize "RQG.Actor.Health.TotalHitPoints"}}
         <input
+          {{#unless (eq system.attributes.hitPoints.value system.attributes.hitPoints.max)}} class="wounded" {{/unless}}
           type="number"
           min="-99"
           max="99"
@@ -19,10 +20,15 @@
     {{#if embeddedItems.hitLocation}}
     <div class="grid hit-location item-list">
       <div class="headings"></div>
-      <div class="head1-4">{{localize "RQG.Actor.Health.HitLocation"}}</div>
-      <div class="head5"><span class="text-center">{{localize "RQG.Actor.Health.HitPointsAbbr"}}</span></div>
-      <div class="head6"><span class="text-right">{{localize "RQG.Actor.Health.ArmorPointsAbbr"}}</span></div>
-      <div class="head7">{{localize "RQG.Actor.Health.Wounds"}}</div>
+      <div class="head1-4">
+        <button class="sort" data-flip-sort-hitlocation-setting data-tooltip="{{localize "RQG.Actor.Health.FlipSortOrder"}}" style="width: 1.3rem; padding-top: 2px; margin-top: -2px;">
+          <i class="fas fa-sort"></i>
+        </button>
+        {{localize "RQG.Actor.Health.HitLocation"}}
+      </div>
+      <div class="head5 text-right"><span class="text-right">{{localize "RQG.Actor.Health.ArmorPointsAbbr"}}</span></div>
+      <div class="head6 text-right"><span class="text-center">{{localize "RQG.Actor.Health.HitPointsAbbr"}}</span></div>
+      <div class="head7 text-right">{{localize "RQG.Actor.Health.Wounds"}}</div>
       {{#each embeddedItems.hitLocation}}
         <div class="hit-location contextmenu item" data-item-id="{{id}}"><span class="text-right">{{system.dieFrom}}</span></div>
         <div class="hit-location contextmenu item" data-item-id="{{id}}">-</div>
@@ -30,11 +36,11 @@
         <div class="hit-location contextmenu item" data-item-id="{{id}}">
           {{name}}
           {{#unless (eq system.hitLocationHealthState "healthy")}}
-            <i>&nbsp;{{toLowerCase (localize (concat "RQG.Item.HitLocation.HealthStatusEnum." system.hitLocationHealthState))}}</i>
+            <i class="health-state">&nbsp;{{toLowerCase (localize (concat "RQG.Item.HitLocation.HealthStatusEnum." system.hitLocationHealthState))}}</i>
           {{/unless}}
         </div>
-        <div class="hit-location contextmenu item" data-item-id="{{id}}"><span class="text-right nowrap">{{system.hitPoints.value}} / {{system.hitPoints.max}}</span></div>
         <div class="hit-location contextmenu item" data-item-id="{{id}}"><span class="text-right">{{system.armorPoints}}</span></div>
+        <div class="hit-location contextmenu item" data-item-id="{{id}}"><span class="text-right nowrap{{#unless (eq system.hitPoints.value system.hitPoints.max)}} strike{{/unless}}">{{system.hitPoints.max}}</span>{{#unless (eq system.hitPoints.value system.hitPoints.max)}} <span class="text-right">{{system.hitPoints.value}}{{/unless}}</span></div>
         <div class="hit-location contextmenu item" data-item-id="{{id}}">
           <div data-item-heal-wound title="{{localize "RQG.Actor.Health.HealWound"}}" class="text-right nowrap">
             {{#each system.wounds}}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -53,6 +53,7 @@ declare global {
       "rqg.fumbleRollTable": string;
       "rqg.worldMigrationVersion": string;
       "rqg.hitLocations": Object;
+      "rqg.sortHitLocationsLowToHigh": boolean;
       "rqg.magicRuneName": string;
       "rqg.defaultItemIconSettings": IconSettingsData;
       "rqg.actor-wizard-feature-flag": boolean;

--- a/src/i18n/en/openSystem.json
+++ b/src/i18n/en/openSystem.json
@@ -258,7 +258,8 @@
         "Wounds": "Wounds",
         "HealWound": "Heal Wound",
         "AddWound": "Add Wound",
-        "NoHitLocations": "This character does not have any hit locations, please add some."
+        "NoHitLocations": "This character does not have any hit locations, please add some.",
+        "FlipSortOrder": "Reverse the order of the hit locations"
       },
       "Nav": {
         "Combat": "Combat",
@@ -1089,6 +1090,10 @@
         "settingLabel": "Configure Available Hit Location Names",
         "settingHint": "The hit location names are used in dropdowns for armor coverage and when naming a new hit location.",
         "addLocationPlaceholder": "Add another hitlocation"
+      },
+      "SortHitLocationsLowToHigh": {
+        "settingName": "Sort Hitlocations Low to High",
+        "settingHint": "Activating this setting sorts the character hitlocation in the same way as stat blocks are sorted with the lowest die number first. The setting can be toggled in the actor sheet Health table."
       },
       "DefaultItemIcons": {
         "dialogTitle": "Default Item Icon Settings",

--- a/src/system/rqgSystemSettings.ts
+++ b/src/system/rqgSystemSettings.ts
@@ -22,6 +22,23 @@ export const registerRqgSystemSettings = function () {
     default: hitLocationNamesObject,
   });
 
+  getGame().settings.register(systemId, "sortHitLocationsLowToHigh", {
+    name: "RQG.Settings.SortHitLocationsLowToHigh.settingName",
+    hint: "RQG.Settings.SortHitLocationsLowToHigh.settingHint",
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false,
+    // Rerender all actor sheets the user has open
+    onChange: () => {
+      Object.values(ui.windows).forEach((a: any) => {
+        if (a?.document?.type === "character") {
+          a.render();
+        }
+      });
+    },
+  });
+
   getGame().settings.registerMenu(systemId, "defaultItemIconSettings", {
     name: "RQG.Settings.DefaultItemIcons.settingName",
     label: "RQG.Settings.DefaultItemIcons.settingLabel",


### PR DESCRIPTION
This introduces a hitlocation sort order as well as improve the display of HP & wounds

closes: #517