### PR TITLE
Moonpile/Unconscious-at-Zero-Magic-Points-#414

### DIFF
--- a/src/actors/rqgActorSheet.ts
+++ b/src/actors/rqgActorSheet.ts
@@ -792,8 +792,12 @@ export class RqgActorSheet extends ActorSheet<
 
     // Hack: Temporarily change hp.value to what it will become so getCombinedActorHealth will work
     const hpTmp = this.actor.system.attributes.hitPoints.value;
+    const mpTmp = this.actor.system.attributes.magicPoints.value;
 
     this.actor.system.attributes.hitPoints.value = formData["system.attributes.hitPoints.value"];
+    this.actor.system.attributes.magicPoints.value =
+      formData["system.attributes.magicPoints.value"];
+
     const newHealth = DamageCalculations.getCombinedActorHealth(this.actor);
     if (newHealth !== this.actor.system.attributes.health) {
       // @ts-expect-error this.token should be TokenDocument, but is typed as Token
@@ -825,6 +829,7 @@ export class RqgActorSheet extends ActorSheet<
     }
 
     this.actor.system.attributes.hitPoints.value = hpTmp; // Restore hp so the form will work
+    this.actor.system.attributes.magicPoints.value = mpTmp;
     if (this.token) {
       // @ts-expect-error wait for foundry-vtt-types issue #1165 #1166
       const tokenHealthBefore = this.token?.actor?.system.attributes.health;

--- a/src/system/damageCalculations.ts
+++ b/src/system/damageCalculations.ts
@@ -245,6 +245,8 @@ export class DamageCalculations {
   static getCombinedActorHealth(actor: RqgActor): ActorHealthState {
     const maxHitPoints = actor.system.attributes.hitPoints.max;
 
+    const currentMagicPoints = actor.system.attributes.magicPoints.value;
+
     if (maxHitPoints == null) {
       return "healthy";
     }
@@ -259,6 +261,8 @@ export class DamageCalculations {
     if (totalHitPoints <= 0) {
       return "dead";
     } else if (totalHitPoints <= 2) {
+      return "unconscious";
+    } else if (currentMagicPoints && currentMagicPoints <= 0) {
       return "unconscious";
     } else {
       return actor.items.reduce((acc: ActorHealthState, item: RqgItem) => {

--- a/src/system/damageCalculations.ts
+++ b/src/system/damageCalculations.ts
@@ -245,7 +245,7 @@ export class DamageCalculations {
   static getCombinedActorHealth(actor: RqgActor): ActorHealthState {
     const maxHitPoints = actor.system.attributes.hitPoints.max;
 
-    const currentMagicPoints = actor.system.attributes.magicPoints.value;
+    const currentMagicPoints = actor.system.attributes.magicPoints.value || 0;
 
     if (maxHitPoints == null) {
       return "healthy";
@@ -262,7 +262,7 @@ export class DamageCalculations {
       return "dead";
     } else if (totalHitPoints <= 2) {
       return "unconscious";
-    } else if (currentMagicPoints && currentMagicPoints <= 0) {
+    } else if (currentMagicPoints <= 0) {
       return "unconscious";
     } else {
       return actor.items.reduce((acc: ActorHealthState, item: RqgItem) => {

--- a/src/system/damageCalculations.ts
+++ b/src/system/damageCalculations.ts
@@ -245,7 +245,7 @@ export class DamageCalculations {
   static getCombinedActorHealth(actor: RqgActor): ActorHealthState {
     const maxHitPoints = actor.system.attributes.hitPoints.max;
 
-    const currentMagicPoints = actor.system.attributes.magicPoints.value || 0;
+    const currentMagicPoints = actor.system.attributes.magicPoints.value ?? 0;
 
     if (maxHitPoints == null) {
       return "healthy";
@@ -260,9 +260,7 @@ export class DamageCalculations {
 
     if (totalHitPoints <= 0) {
       return "dead";
-    } else if (totalHitPoints <= 2) {
-      return "unconscious";
-    } else if (currentMagicPoints <= 0) {
+    } else if (totalHitPoints <= 2 || currentMagicPoints <= 0) {
       return "unconscious";
     } else {
       return actor.items.reduce((acc: ActorHealthState, item: RqgItem) => {


### PR DESCRIPTION
When the actor is reduced to zero magic points (or less) their "displayed status" and token effect (if associated with a token) will be set to "unconscious".

Please note that if you open the character sheet from the sidebar instead of by double-clicking the token, the token effect will not be set.

This issue specified that "Magic Points should not be allowed to go into negative numbers", but I'm reconsidering the wisdom of that.  I think forcing negative values to zero will hide situations where the player is spending MP and the logic is not quite right.