### PR TITLE
refactor: type rqids better

### DIFF
--- a/src/active-effect/rqgActiveEffect.ts
+++ b/src/active-effect/rqgActiveEffect.ts
@@ -5,6 +5,7 @@ import {
   logMisconfiguration,
 } from "../system/util";
 import { Rqid } from "../system/api/rqidApi";
+import { toRqidString } from "../system/api/rqidValidation";
 
 import type { AnyMutableObject } from "fvtt-types/utils";
 import Document = foundry.abstract.Document;
@@ -58,7 +59,7 @@ export class RqgActiveEffect extends ActiveEffect<ActiveEffect.SubType> {
       if (isMultiMatch) {
         items.push(...actor.getEmbeddedDocumentsByRqidRegex(rqid ?? ""));
       } else {
-        const bestMatch = actor.getBestEmbeddedDocumentByRqid(rqid);
+        const bestMatch = actor.getBestEmbeddedDocumentByRqid(toRqidString(rqid));
         if (bestMatch) {
           items.push(bestMatch);
         }

--- a/src/actors/context-menus/cult-context-menu.ts
+++ b/src/actors/context-menus/cult-context-menu.ts
@@ -1,14 +1,9 @@
 import { RqgActorSheet } from "../rqgActorSheet";
-import {
-  getDomDataset,
-  getRequiredDomDataset,
-  localize,
-  localizeItemType,
-  RqgError,
-} from "../../system/util";
+import { getRequiredDomDataset, localize, localizeItemType, RqgError } from "../../system/util";
 import { contextMenuRunes } from "./contextMenuRunes";
 import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import { Rqid } from "../../system/api/rqidApi";
+import { isValidRqidString } from "../../system/api/rqidValidation";
 import type { CultItem } from "@item-model/cultDataModel.ts";
 import type { CharacterActor } from "../../data-model/actor-data/rqgActorData.ts";
 
@@ -17,12 +12,15 @@ export const cultMenuOptions = (actor: CharacterActor): ContextMenu.Entry<HTMLEl
     name: localize("RQG.ContextMenu.ViewDescription"),
     icon: contextMenuRunes.ViewDescription,
     condition: (el: HTMLElement) => {
-      const rqid = getDomDataset(el, "rqid-link");
-      return !!rqid;
+      const itemId = getRequiredDomDataset(el, "item-id");
+      const item = actor.items.get(itemId) as CultItem | undefined;
+      return isValidRqidString(item?.system.descriptionRqidLink?.rqid);
     },
     callback: async (el: HTMLElement) => {
-      const rqid = getDomDataset(el, "rqid-link");
-      if (rqid) {
+      const itemId = getRequiredDomDataset(el, "item-id");
+      const item = actor.items.get(itemId) as CultItem | undefined;
+      const rqid = item?.system.descriptionRqidLink?.rqid;
+      if (isValidRqidString(rqid)) {
         await Rqid.renderRqidDocument(rqid);
       }
     },

--- a/src/actors/context-menus/rune-context-menu.ts
+++ b/src/actors/context-menus/rune-context-menu.ts
@@ -1,7 +1,6 @@
 import { RqgActorSheet } from "../rqgActorSheet";
 import {
   assertDocumentSubType,
-  getDomDatasetAmongSiblings,
   getRequiredDomDataset,
   localize,
   localizeItemType,
@@ -11,6 +10,7 @@ import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import { showImproveAbilityDialog } from "../../applications/improveAbilityDialog";
 import { contextMenuRunes } from "./contextMenuRunes";
 import { Rqid } from "../../system/api/rqidApi";
+import { isValidRqidString } from "../../system/api/rqidValidation";
 import type { RuneItem } from "@item-model/runeDataModel.ts";
 import type { CharacterActor } from "../../data-model/actor-data/rqgActorData.ts";
 
@@ -69,12 +69,15 @@ export const runeMenuOptions = (
     name: localize("RQG.ContextMenu.ViewDescription"),
     icon: contextMenuRunes.ViewDescription,
     condition: (el: HTMLElement) => {
-      const rqid = getDomDatasetAmongSiblings(el, "rqid-link");
-      return !!rqid;
+      const itemId = getRequiredDomDataset(el, "item-id");
+      const item = actor.items.get(itemId) as RuneItem | undefined;
+      return isValidRqidString(item?.system.descriptionRqidLink?.rqid);
     },
     callback: async (el: HTMLElement) => {
-      const rqid = getDomDatasetAmongSiblings(el, "rqid-link");
-      if (rqid) {
+      const itemId = getRequiredDomDataset(el, "item-id");
+      const item = actor.items.get(itemId) as RuneItem | undefined;
+      const rqid = item?.system.descriptionRqidLink?.rqid;
+      if (isValidRqidString(rqid)) {
         await Rqid.renderRqidDocument(rqid);
       }
     },

--- a/src/actors/context-menus/rune-magic-context-menu.ts
+++ b/src/actors/context-menus/rune-magic-context-menu.ts
@@ -2,7 +2,6 @@ import { RqgActorSheet } from "../rqgActorSheet";
 import { RqgActor } from "../rqgActor";
 import {
   assertDocumentSubType,
-  getDomDatasetAmongSiblings,
   getRequiredDomDataset,
   localize,
   localizeItemType,
@@ -11,6 +10,7 @@ import {
 import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import { contextMenuRunes } from "./contextMenuRunes";
 import { Rqid } from "../../system/api/rqidApi";
+import { isValidRqidString } from "../../system/api/rqidValidation";
 import type { RuneMagicItem } from "@item-model/runeMagicDataModel.ts";
 import type { RqgItem } from "@items/rqgItem.ts";
 
@@ -46,12 +46,15 @@ export const runeMagicMenuOptions = (actor: RqgActor): ContextMenu.Entry<HTMLEle
     name: localize("RQG.ContextMenu.ViewDescription"),
     icon: contextMenuRunes.ViewDescription,
     condition: (el: HTMLElement) => {
-      const rqid = getDomDatasetAmongSiblings(el, "rqid-link");
-      return !!rqid;
+      const itemId = getRequiredDomDataset(el, "item-id");
+      const item = actor.items.get(itemId) as RuneMagicItem | undefined;
+      return isValidRqidString(item?.system.descriptionRqidLink?.rqid);
     },
     callback: async (el: HTMLElement) => {
-      const rqid = getDomDatasetAmongSiblings(el, "rqid-link");
-      if (rqid) {
+      const itemId = getRequiredDomDataset(el, "item-id");
+      const item = actor.items.get(itemId) as RuneMagicItem | undefined;
+      const rqid = item?.system.descriptionRqidLink?.rqid;
+      if (isValidRqidString(rqid)) {
         await Rqid.renderRqidDocument(rqid);
       }
     },

--- a/src/actors/context-menus/skill-context-menu.ts
+++ b/src/actors/context-menus/skill-context-menu.ts
@@ -3,7 +3,6 @@ import { RqgActor } from "../rqgActor";
 import {
   assertDocumentSubType,
   getDomDataset,
-  getDomDatasetAmongSiblings,
   getRequiredDomDataset,
   isDocumentSubType,
   localize,
@@ -15,6 +14,7 @@ import { SkillCategoryEnum, type SkillItem } from "@item-model/skillDataModel.ts
 import { showImproveAbilityDialog } from "../../applications/improveAbilityDialog";
 import { contextMenuRunes } from "./contextMenuRunes";
 import { Rqid } from "../../system/api/rqidApi";
+import { isValidRqidString } from "../../system/api/rqidValidation";
 import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqgActorData.ts";
 
 export const skillMenuOptions = (
@@ -107,12 +107,15 @@ export const skillMenuOptions = (
     name: localize("RQG.ContextMenu.ViewDescription"),
     icon: contextMenuRunes.ViewDescription,
     condition: (el: HTMLElement) => {
-      const rqid = getDomDatasetAmongSiblings(el, "rqid-link");
-      return !!rqid;
+      const itemId = getDomDataset(el, "item-id");
+      const item = actor.items.get(itemId ?? "") as SkillItem | undefined;
+      return isValidRqidString(item?.system.descriptionRqidLink?.rqid);
     },
     callback: async (el: HTMLElement) => {
-      const rqid = getDomDatasetAmongSiblings(el, "rqid-link");
-      if (rqid) {
+      const itemId = getRequiredDomDataset(el, "item-id");
+      const item = actor.items.get(itemId) as SkillItem | undefined;
+      const rqid = item?.system.descriptionRqidLink?.rqid;
+      if (isValidRqidString(rqid)) {
         await Rqid.renderRqidDocument(rqid);
       }
     },

--- a/src/actors/context-menus/spirit-magic-context-menu.ts
+++ b/src/actors/context-menus/spirit-magic-context-menu.ts
@@ -2,7 +2,6 @@ import { RqgActorSheet } from "../rqgActorSheet";
 import {
   assertDocumentSubType,
   getDomDataset,
-  getDomDatasetAmongSiblings,
   getRequiredDomDataset,
   localize,
   localizeItemType,
@@ -11,6 +10,7 @@ import {
 import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import { contextMenuRunes } from "./contextMenuRunes";
 import { Rqid } from "../../system/api/rqidApi";
+import { isValidRqidString } from "../../system/api/rqidValidation";
 import type { SpiritMagicItem } from "@item-model/spiritMagicDataModel.ts";
 import type { CharacterActor } from "../../data-model/actor-data/rqgActorData.ts";
 
@@ -50,12 +50,15 @@ export const spiritMagicMenuOptions = (actor: CharacterActor): ContextMenu.Entry
     name: localize("RQG.ContextMenu.ViewDescription"),
     icon: contextMenuRunes.ViewDescription,
     condition: (el: HTMLElement) => {
-      const rqid = getDomDatasetAmongSiblings(el, "rqid-link");
-      return !!rqid;
+      const itemId = getDomDataset(el, "item-id");
+      const item = actor.items.get(itemId ?? "") as SpiritMagicItem | undefined;
+      return isValidRqidString(item?.system.descriptionRqidLink?.rqid);
     },
     callback: async (el: HTMLElement) => {
-      const rqid = getDomDatasetAmongSiblings(el, "rqid-link");
-      if (rqid) {
+      const itemId = getRequiredDomDataset(el, "item-id");
+      const item = actor.items.get(itemId) as SpiritMagicItem | undefined;
+      const rqid = item?.system.descriptionRqidLink?.rqid;
+      if (isValidRqidString(rqid)) {
         await Rqid.renderRqidDocument(rqid);
       }
     },

--- a/src/actors/rqgActor.ts
+++ b/src/actors/rqgActor.ts
@@ -17,6 +17,7 @@ import {
 import { initializeAllCharacteristics } from "./context-menus/characteristic-context-menu";
 import { RQG_CONFIG, systemId } from "../system/config";
 import { Rqid } from "../system/api/rqidApi";
+import type { RqidString } from "../system/api/rqidApi";
 import { AbilitySuccessLevelEnum } from "../rolls/AbilityRoll/AbilityRoll.defs";
 import type { CharacteristicRollOptions } from "../rolls/CharacteristicRoll/CharacteristicRoll.types";
 import { CharacteristicRoll } from "../rolls/CharacteristicRoll/CharacteristicRoll";
@@ -65,7 +66,7 @@ export class RqgActor extends Actor {
   /**
    * Only handles embedded Items
    */
-  public getEmbeddedDocumentsByRqid(rqid: string | undefined): RqgItem[] {
+  public getEmbeddedDocumentsByRqid(rqid: RqidString | undefined): RqgItem[] {
     if (!rqid) {
       return [];
     }
@@ -74,7 +75,7 @@ export class RqgActor extends Actor {
     ) as RqgItem[];
   }
 
-  public getBestEmbeddedDocumentByRqid(rqid: string | undefined): RqgItem | undefined {
+  public getBestEmbeddedDocumentByRqid(rqid: RqidString | undefined): RqgItem | undefined {
     return this.getEmbeddedDocumentsByRqid(rqid).sort(Rqid.compareRqidPrio)[0];
   }
 
@@ -304,7 +305,7 @@ export class RqgActor extends Actor {
     assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
     const actorHitlocationRqids = this.items
       .filter((i) => isDocumentSubType<HitLocationItem>(i, ItemTypeEnum.HitLocation))
-      .map((hl: HitLocationItem) => hl.flags?.rqg?.documentRqidFlags?.id ?? "");
+      .map((hl: HitLocationItem) => hl.flags?.rqg?.documentRqidFlags?.id ?? "") as string[];
     if (
       CONFIG.RQG.bodytypes.humanoid.length === actorHitlocationRqids.length &&
       CONFIG.RQG.bodytypes.humanoid.every((hitLocationRqid) =>

--- a/src/actors/rqgActorSheetDataPrep.ts
+++ b/src/actors/rqgActorSheetDataPrep.ts
@@ -743,7 +743,7 @@ export async function organizeEmbeddedItems(
     const cultCommonRuneMagicRqids =
       spellCult?.system.commonRuneMagicRqidLinks.map((r) => r.rqid) ?? [];
 
-    (rm.system as any).isCommon = cultCommonRuneMagicRqids.includes(
+    (rm.system as any).isCommon = (cultCommonRuneMagicRqids as string[]).includes(
       rm?.flags?.rqg?.documentRqidFlags?.id ?? "",
     );
   });

--- a/src/applications/AttackFlow/attackDialogV2.ts
+++ b/src/applications/AttackFlow/attackDialogV2.ts
@@ -35,6 +35,7 @@ import { HitLocationRoll } from "../../rolls/HitLocationRoll/HitLocationRoll";
 import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqgActorData.ts";
 import type { SkillItem } from "@item-model/skillDataModel.ts";
 import type { HitLocationItem } from "@item-model/hitLocationDataModel.ts";
+import { toRqidString } from "../../system/api/rqidValidation";
 import type { DeepPartial } from "fvtt-types/utils";
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
@@ -152,8 +153,9 @@ export class AttackDialogV2 extends HandlebarsApplicationMixin(ApplicationV2<Att
 
     const skillRqid: string | undefined =
       this.weaponItem?.system.usage[formData.usageType].skillRqidLink?.rqid;
-    const usedSkill: RqgItem | undefined =
-      this.weaponItem?.actor?.getBestEmbeddedDocumentByRqid(skillRqid);
+    const usedSkill: RqgItem | undefined = this.weaponItem?.actor?.getBestEmbeddedDocumentByRqid(
+      toRqidString(skillRqid),
+    );
     const validUsedSkill = isDocumentSubType<SkillItem>(usedSkill, ItemTypeEnum.Skill)
       ? usedSkill
       : undefined;
@@ -310,7 +312,7 @@ export class AttackDialogV2 extends HandlebarsApplicationMixin(ApplicationV2<Att
     }
 
     const skillRqid = weaponItem.system.usage[selectedUsageType].skillRqidLink?.rqid;
-    const usedSkill = weaponItem.actor?.getBestEmbeddedDocumentByRqid(skillRqid);
+    const usedSkill = weaponItem.actor?.getBestEmbeddedDocumentByRqid(toRqidString(skillRqid));
 
     if (!isDocumentSubType<SkillItem>(usedSkill, ItemTypeEnum.Skill)) {
       ui.notifications?.warn(localize("RQG.Dialog.Attack.NoValidSkillForWeaponUsageWarn"));
@@ -373,9 +375,8 @@ export class AttackDialogV2 extends HandlebarsApplicationMixin(ApplicationV2<Att
       return;
     }
 
-    const skillItem = actor?.getBestEmbeddedDocumentByRqid(
-      weaponItem.system.usage[formDataObject.usageType].skillRqidLink?.rqid,
-    );
+    const skillRqid = weaponItem.system.usage[formDataObject.usageType].skillRqidLink?.rqid;
+    const skillItem = actor?.getBestEmbeddedDocumentByRqid(toRqidString(skillRqid));
     if (!isDocumentSubType<SkillItem>(skillItem, ItemTypeEnum.Skill)) {
       ui.notifications?.warn(localize("RQG.Dialog.Attack.NoValidSkillForWeaponUsageWarn"));
       return;

--- a/src/applications/AttackFlow/attackDialogV2.ts
+++ b/src/applications/AttackFlow/attackDialogV2.ts
@@ -19,7 +19,7 @@ import type { RqgActor } from "@actors/rqgActor.ts";
 import type { RqgItem } from "@items/rqgItem.ts";
 import type { RqgToken } from "../../combat/rqgToken";
 import { ItemTypeEnum } from "@item-model/itemTypes.ts";
-import type { CombatManeuver, Usage, UsageType, WeaponItem } from "@item-model/weaponDataModel.ts";
+import type { CombatManeuver, UsageType, WeaponItem } from "@item-model/weaponDataModel.ts";
 import { templatePaths } from "../../system/loadHandlebarsTemplates";
 import { systemId } from "../../system/config";
 import type { AbilityRollOptions } from "../../rolls/AbilityRoll/AbilityRoll.types";
@@ -33,10 +33,9 @@ import { AbilityRoll } from "../../rolls/AbilityRoll/AbilityRoll";
 import type { HitLocationRollOptions } from "../../rolls/HitLocationRoll/HitLocationRoll.types";
 import { HitLocationRoll } from "../../rolls/HitLocationRoll/HitLocationRoll";
 import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqgActorData.ts";
-import type { SkillItem } from "@item-model/skillDataModel.ts";
 import type { HitLocationItem } from "@item-model/hitLocationDataModel.ts";
-import { toRqidString } from "../../system/api/rqidValidation";
 import type { DeepPartial } from "fvtt-types/utils";
+import { Weapon } from "@items/weapon-item/weapon";
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
@@ -151,14 +150,7 @@ export class AttackDialogV2 extends HandlebarsApplicationMixin(ApplicationV2<Att
       isOutOfAmmo = ammoQuantity <= 0;
     }
 
-    const skillRqid: string | undefined =
-      this.weaponItem?.system.usage[formData.usageType].skillRqidLink?.rqid;
-    const usedSkill: RqgItem | undefined = this.weaponItem?.actor?.getBestEmbeddedDocumentByRqid(
-      toRqidString(skillRqid),
-    );
-    const validUsedSkill = isDocumentSubType<SkillItem>(usedSkill, ItemTypeEnum.Skill)
-      ? usedSkill
-      : undefined;
+    const validUsedSkill = Weapon.resolveLinkedSkill(this.weaponItem, formData.usageType);
     const hasValidSkillForSelectedUsage = !!validUsedSkill;
     formData.halvedModifier = hasValidSkillForSelectedUsage
       ? -Math.floor(validUsedSkill.system.chance / 2)
@@ -311,10 +303,9 @@ export class AttackDialogV2 extends HandlebarsApplicationMixin(ApplicationV2<Att
       return;
     }
 
-    const skillRqid = weaponItem.system.usage[selectedUsageType].skillRqidLink?.rqid;
-    const usedSkill = weaponItem.actor?.getBestEmbeddedDocumentByRqid(toRqidString(skillRqid));
+    const usedSkill = Weapon.resolveLinkedSkill(weaponItem, selectedUsageType);
 
-    if (!isDocumentSubType<SkillItem>(usedSkill, ItemTypeEnum.Skill)) {
+    if (!usedSkill) {
       ui.notifications?.warn(localize("RQG.Dialog.Attack.NoValidSkillForWeaponUsageWarn"));
     }
   }
@@ -375,9 +366,8 @@ export class AttackDialogV2 extends HandlebarsApplicationMixin(ApplicationV2<Att
       return;
     }
 
-    const skillRqid = weaponItem.system.usage[formDataObject.usageType].skillRqidLink?.rqid;
-    const skillItem = actor?.getBestEmbeddedDocumentByRqid(toRqidString(skillRqid));
-    if (!isDocumentSubType<SkillItem>(skillItem, ItemTypeEnum.Skill)) {
+    const skillItem = Weapon.resolveLinkedSkill(weaponItem, formDataObject.usageType);
+    if (!skillItem) {
       ui.notifications?.warn(localize("RQG.Dialog.Attack.NoValidSkillForWeaponUsageWarn"));
       return;
     }
@@ -657,8 +647,8 @@ export class AttackDialogV2 extends HandlebarsApplicationMixin(ApplicationV2<Att
       return [];
     }
     assertDocumentSubType<WeaponItem>(weapon, ItemTypeEnum.Weapon);
-    return Object.entries<Usage>(weapon.system.usage).reduce((acc: any, [key, usage]) => {
-      if (usage?.skillRqidLink?.rqid) {
+    return Object.entries(weapon.system.usage).reduce((acc: any, [key]) => {
+      if (Weapon.hasLinkedSkillReference(weapon, key as UsageType)) {
         acc.push({ value: key, label: localize(`RQG.Game.WeaponUsage.${key}-full`) });
       }
       return acc;

--- a/src/applications/AttackFlow/defenceDialogV2.ts
+++ b/src/applications/AttackFlow/defenceDialogV2.ts
@@ -854,7 +854,7 @@ export class DefenceDialogV2 extends HandlebarsApplicationMixin(
 
   private static usageHasParryManeuver(usage: WeaponItem["system"]["usage"][UsageType]): boolean {
     return (
-      usage.skillRqidLink?.rqid != null &&
+      !!toRqidString(usage.skillRqidLink?.rqid) &&
       usage.combatManeuvers?.some((m) => m.damageType === "parry")
     );
   }

--- a/src/applications/AttackFlow/defenceDialogV2.ts
+++ b/src/applications/AttackFlow/defenceDialogV2.ts
@@ -40,6 +40,7 @@ import { updateChatMessage } from "../../sockets/SocketableRequests";
 import { HitLocationRoll } from "../../rolls/HitLocationRoll/HitLocationRoll";
 import type { SkillItem } from "@item-model/skillDataModel.ts";
 import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqgActorData.ts";
+import { toRqidString } from "../../system/api/rqidValidation";
 import type { DeepPartial } from "fvtt-types/utils";
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
@@ -240,7 +241,7 @@ export class DefenceDialogV2 extends HandlebarsApplicationMixin(
 
     const selectedParrySkill =
       formData.defence === "parry"
-        ? defendingActor?.getBestEmbeddedDocumentByRqid(parrySkillRqid)
+        ? defendingActor?.getBestEmbeddedDocumentByRqid(toRqidString(parrySkillRqid))
         : undefined;
     const isSelectedParryWeaponBroken =
       formData.defence === "parry" &&
@@ -345,7 +346,9 @@ export class DefenceDialogV2 extends HandlebarsApplicationMixin(
     }
 
     const parrySkillRqid = parryingWeaponItem.system.usage[selectedUsage]?.skillRqidLink?.rqid;
-    const parrySkill = parryingWeaponItem.actor?.getBestEmbeddedDocumentByRqid(parrySkillRqid);
+    const parrySkill = parryingWeaponItem.actor?.getBestEmbeddedDocumentByRqid(
+      toRqidString(parrySkillRqid),
+    );
 
     if (!isDocumentSubType<SkillItem>(parrySkill, ItemTypeEnum.Skill)) {
       ui.notifications?.warn(localize("RQG.Dialog.Defence.NoValidParrySkillForWeaponUsageWarn"));
@@ -433,9 +436,9 @@ export class DefenceDialogV2 extends HandlebarsApplicationMixin(
     let defendSkillItem: RqgItem | undefined;
     switch (formDataObject.defence) {
       case "parry": {
-        defendSkillItem = defendingActor?.getBestEmbeddedDocumentByRqid(parrySkillRqid) as
-          | RqgItem
-          | undefined;
+        defendSkillItem = defendingActor?.getBestEmbeddedDocumentByRqid(
+          toRqidString(parrySkillRqid),
+        );
 
         if (!isDocumentSubType<SkillItem>(defendSkillItem, ItemTypeEnum.Skill)) {
           ui.notifications?.warn(
@@ -680,9 +683,10 @@ export class DefenceDialogV2 extends HandlebarsApplicationMixin(
     if (isDocumentSubType<WeaponItem>(attackWeapon, ItemTypeEnum.Weapon)) {
       const attackWeaponUsage = attackChatMessage.system.attackWeaponUsage as UsageType | undefined;
       const attackSkill = attackWeaponUsage
-        ? attackWeapon?.actor?.getBestEmbeddedDocumentByRqid(
-            attackWeapon.system.usage[attackWeaponUsage]?.skillRqidLink?.rqid,
-          )
+        ? (() => {
+            const rqid = attackWeapon.system.usage[attackWeaponUsage]?.skillRqidLink?.rqid;
+            return attackWeapon?.actor?.getBestEmbeddedDocumentByRqid(toRqidString(rqid));
+          })()
         : undefined;
 
       await defendSkillItem?.checkExperience?.(defenceRoll?.successLevel);
@@ -696,9 +700,9 @@ export class DefenceDialogV2 extends HandlebarsApplicationMixin(
     parrySkillRqid: string | undefined,
   ): { defenceName: string; defenceChance: number } {
     if (defence === "parry") {
-      const parrySkill = defendingActor?.getBestEmbeddedDocumentByRqid(parrySkillRqid) as
-        | SkillItem
-        | undefined;
+      const parrySkill = defendingActor?.getBestEmbeddedDocumentByRqid(
+        toRqidString(parrySkillRqid),
+      ) as SkillItem | undefined;
       return {
         defenceName: parrySkill?.name ?? "",
         defenceChance: parrySkill?.system.chance ?? 0,

--- a/src/applications/AttackFlow/defenceDialogV2.ts
+++ b/src/applications/AttackFlow/defenceDialogV2.ts
@@ -25,7 +25,6 @@ import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import type {
   CombatManeuver,
   DamageType,
-  Usage,
   UsageType,
   WeaponItem,
 } from "@item-model/weaponDataModel.ts";
@@ -853,7 +852,7 @@ export class DefenceDialogV2 extends HandlebarsApplicationMixin(
     return usages;
   }
 
-  private static usageHasParryManeuver(usage: Usage): boolean {
+  private static usageHasParryManeuver(usage: WeaponItem["system"]["usage"][UsageType]): boolean {
     return (
       usage.skillRqidLink?.rqid != null &&
       usage.combatManeuvers?.some((m) => m.damageType === "parry")

--- a/src/applications/actorWizardApplication.ts
+++ b/src/applications/actorWizardApplication.ts
@@ -15,6 +15,8 @@ import { RqidLink } from "../data-model/shared/rqidLink";
 import { RqgItem } from "../items/rqgItem";
 import { actorWizardFlags, documentRqidFlags } from "../data-model/shared/rqgDocumentFlags";
 import { Rqid } from "../system/api/rqidApi";
+import { isValidRqidString, toRqidString } from "../system/api/rqidValidation";
+import type { RqidString } from "../system/api/rqidApi";
 import type { IAbility } from "../data-model/shared/ability";
 import type { RqgActor } from "../actors/rqgActor";
 import { templatePaths } from "../system/loadHandlebarsTemplates";
@@ -331,7 +333,7 @@ export class ActorWizard extends ActorWizardBase {
       const homelandRunes: TemplateItem[] = [];
       if (selectedHomeland.system.runeRqidLinks) {
         for (const runeRqidLink of selectedHomeland.system.runeRqidLinks) {
-          const rune = (await Rqid.fromRqid(runeRqidLink.rqid)) as RuneItem | undefined;
+          const rune = await Rqid.fromRqid(runeRqidLink.rqid);
           if (rune) {
             assertDocumentSubType<RuneItem>(rune, ItemTypeEnum.Rune);
             rune.system.chance = 10; // Homeland runes always grant +10%, this is for display purposes only
@@ -350,7 +352,7 @@ export class ActorWizard extends ActorWizardBase {
       const homelandSkills: TemplateItem[] = [];
       if (selectedHomeland.system.skillRqidLinks) {
         for (const skillRqidLink of selectedHomeland.system.skillRqidLinks) {
-          const skill = (await Rqid.fromRqid(skillRqidLink.rqid)) as SkillItem | undefined;
+          const skill = await Rqid.fromRqid(skillRqidLink.rqid);
           if (skill) {
             assertDocumentSubType<SkillItem>(skill, ItemTypeEnum.Skill);
             const templateSkill = skill as TemplateItem;
@@ -373,7 +375,7 @@ export class ActorWizard extends ActorWizardBase {
       const homelandPassions: TemplateItem[] = [];
       if (selectedHomeland.system.passionRqidLinks) {
         for (const passionRqidLink of selectedHomeland.system.passionRqidLinks) {
-          const passion = (await Rqid.fromRqid(passionRqidLink.rqid)) as PassionItem | undefined;
+          const passion = await Rqid.fromRqid(passionRqidLink.rqid);
           if (passion) {
             assertDocumentSubType<PassionItem>(passion, ItemTypeEnum.Passion);
             passion.system.hasExperience = false;
@@ -542,7 +544,10 @@ export class ActorWizard extends ActorWizardBase {
         );
       }
       if (target.name === "selectedHomelandRqid") {
-        await wizard.setHomeland(formData.object["selectedHomelandRqid"] as string);
+        const homelandRqid = formData.object["selectedHomelandRqid"];
+        if (isValidRqidString(homelandRqid)) {
+          await wizard.setHomeland(homelandRqid);
+        }
       }
     }
     if (target instanceof HTMLInputElement && target.classList.contains("wizard-choice-input")) {
@@ -691,16 +696,21 @@ export class ActorWizard extends ActorWizardBase {
     // and mark them not present on the species
     const speciesRqids = this.species.selectedSpeciesTemplate?.items
       .map((i) => i.getFlag(systemId, documentRqidFlags)?.id)
-      .filter((id): id is string => id != null);
+      .filter((id): id is RqidString => id != null);
     for (const choiceKey in this.choices) {
       const choice = this.choices[choiceKey];
-      if (choice && speciesRqids && !speciesRqids.includes(choiceKey)) {
+      if (
+        choice &&
+        speciesRqids &&
+        isValidRqidString(choiceKey) &&
+        !speciesRqids.includes(choiceKey)
+      ) {
         choice.speciesPresent = false;
       }
     }
   }
 
-  async setHomeland(selectedHomelandRqid: string): Promise<void> {
+  async setHomeland(selectedHomelandRqid: RqidString): Promise<void> {
     const selectedHomeland = (await Rqid.fromRqid(selectedHomelandRqid)) as RqgItem | undefined;
 
     this.homeland.selectedHomeland = selectedHomeland;
@@ -779,7 +789,8 @@ export class ActorWizard extends ActorWizardBase {
     const adds = [];
     const deletes: string[] = [];
     for (const key in this.choices) {
-      const existingItems = this.actor.getEmbeddedDocumentsByRqid(key);
+      const keyRqid = toRqidString(key);
+      const existingItems = this.actor.getEmbeddedDocumentsByRqid(keyRqid);
       if (existingItems.length > 0) {
         for (const actorItem of existingItems) {
           // Handle Skills, Runes, and Passions, which use the .present property of the choice
@@ -846,7 +857,7 @@ export class ActorWizard extends ActorWizardBase {
           if (!itemsToAddFromTemplate) {
             // Didn't find items by rqid, so just take what's on the Species Template
             itemsToAddFromTemplate =
-              this.species.selectedSpeciesTemplate?.getEmbeddedDocumentsByRqid(key) || [];
+              this.species.selectedSpeciesTemplate?.getEmbeddedDocumentsByRqid(keyRqid) || [];
             console.log(
               `Actor Species Template had an item with rqid "${key} that was not found in by rqid. Using item from the Actor Species Template.`,
               itemsToAddFromTemplate,

--- a/src/applications/rqid-batch-editor/rqidBatchEditor.ts
+++ b/src/applications/rqid-batch-editor/rqidBatchEditor.ts
@@ -7,6 +7,8 @@ import {
   toKebabCase,
 } from "../../system/util";
 import { Rqid } from "../../system/api/rqidApi";
+import { isValidRqidString } from "../../system/api/rqidValidation";
+import type { RqidString } from "../../system/api/rqidApi";
 import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import type { DocumentRqidFlags } from "../../data-model/shared/rqgDocumentFlags";
 import type { RqgActor } from "@actors/rqgActor.ts";
@@ -373,7 +375,7 @@ export class RqidBatchEditor extends foundry.appv1.api.FormApplication<
             return;
           }
           const rqidFlags: DocumentRqidFlags = {
-            id: newRqid,
+            id: isValidRqidString(newRqid) ? newRqid : ("" as RqidString),
             lang:
               itemUpdate.documentRqidFlags.lang ?? game.settings?.get(systemId, "worldLanguage"),
             priority: itemUpdate.documentRqidFlags.priority ?? 0,
@@ -845,8 +847,9 @@ export class RqidBatchEditor extends foundry.appv1.api.FormApplication<
     itemNames2Rqid: Map<string, string | undefined>,
   ): ItemRqidUpdate[] {
     return itemChanges.reduce((acc: ItemRqidUpdate[], itemChange) => {
+      const mappedRqid = itemNames2Rqid.get(itemChange.name);
       const rqidFlags: DocumentRqidFlags = {
-        id: itemNames2Rqid.get(itemChange.name),
+        id: mappedRqid && isValidRqidString(mappedRqid) ? mappedRqid : undefined,
         lang: itemChange.documentRqidFlags.lang ?? game.settings?.get(systemId, "worldLanguage"),
         priority: itemChange.documentRqidFlags.priority ?? 0,
       };

--- a/src/applications/rqidEditor/rqidEditor.hbs
+++ b/src/applications/rqidEditor/rqidEditor.hbs
@@ -3,7 +3,7 @@
     <label for="rqid-editor">{{localize "RQG.RQGSystem.Rqid.Id"}}</label>
     <div class="input-button">
       {{#if parentRqid}}<span class="parent-rqid">{{parentRqid}}.</span>{{/if}}
-      <span>{{rqidPrefix}}</span>
+      <span>{{rqidDocumentNamePart}}</span>
       <input type="text" id="rqid-editor" name="rqidNamePart" value="{{rqidNamePart}}" />
       <a data-tooltip="{{localize "RQG.RQGSystem.Rqid.GenerateDefault"}}" data-generate-default-rqid><i
         class="fas fa-wand-magic-sparkles"></i></a>

--- a/src/applications/rqidEditor/rqidEditor.ts
+++ b/src/applications/rqidEditor/rqidEditor.ts
@@ -1,6 +1,6 @@
 import { systemId } from "../../system/config";
 import { escapeRegex, getRequiredDomDataset, toKebabCase, trimChars } from "../../system/util";
-import { Rqid } from "../../system/api/rqidApi";
+import { Rqid, isRqidDocumentName } from "../../system/api/rqidApi";
 import { templatePaths } from "../../system/loadHandlebarsTemplates";
 
 import Document = foundry.abstract.Document;
@@ -27,7 +27,7 @@ interface RqidEditorData {
   uuid: string;
   folder: string;
   flags: { rqg: { documentRqidFlags: { lang: string; priority: number } } };
-  rqidPrefix: string;
+  rqidDocumentNamePart: string;
   rqidNamePart: string | undefined;
   parentRqid: string;
   parentMissingRqid: boolean;
@@ -159,21 +159,21 @@ export class RqidEditor extends FormApplication {
     let rqidLinkData: Pick<RqidEditorData, "rqidLink" | "fullRqid"> = {};
 
     if (documentRqid && documentLang) {
-      const rqidDocumentPrefix = documentRqid.split(".")[0];
+      const rqidDocumentName = documentRqid.split(".")[0];
       const rqidSearchRegex = new RegExp("^" + escapeRegex(documentRqid) + "$");
 
-      // Embedded documents (like JournalEntryPage with "jp" prefix) have no top-level game collection,
+      // Embedded documents (like JournalEntryPage with "jp" document name) have no top-level game collection,
       // so skip the duplicate search to avoid errors from getGameProperty("jp")
-      if (!this.document.isEmbedded) {
+      if (!this.document.isEmbedded && isRqidDocumentName(rqidDocumentName)) {
         const worldDocuments = await Rqid.fromRqidRegex(
           rqidSearchRegex,
-          rqidDocumentPrefix,
+          rqidDocumentName,
           documentLang,
           { source: "world", mode: "all" },
         );
         const compendiumDocuments = await Rqid.fromRqidRegex(
           rqidSearchRegex,
-          rqidDocumentPrefix,
+          rqidDocumentName,
           documentLang,
           { source: "packs", mode: "all" },
         );
@@ -243,7 +243,7 @@ export class RqidEditor extends FormApplication {
           },
         },
       },
-      rqidPrefix: `${documentIdPart}.${documentType}.`,
+      rqidDocumentNamePart: `${documentIdPart}.${documentType}.`,
       rqidNamePart: Rqid.getDocumentFlag(this.document)?.id?.split(".").pop(),
       parentRqid: parentRqid,
       parentMissingRqid: this.document.isEmbedded && !parentRqid,

--- a/src/data-model/item-data/cultDataModel.ts
+++ b/src/data-model/item-data/cultDataModel.ts
@@ -1,6 +1,8 @@
 import type { RqgItem } from "@items/rqgItem.ts";
 import { RqgItemDataModel } from "./RqgItemDataModel";
 import { rqidLinkSchemaField, rqidLinkArraySchemaField } from "../shared/rqidLinkField";
+import type { RqidLink } from "../shared/rqidLink";
+import type { RqidString } from "../../system/api/rqidApi";
 import { resourceSchemaField } from "../shared/resourceSchemaField";
 import { enumChoices } from "../shared/enumChoices";
 
@@ -33,6 +35,10 @@ const { ArrayField, SchemaField, StringField } = foundry.data.fields;
 type CultSchema = ReturnType<typeof CultDataModel.defineSchema>;
 
 export class CultDataModel extends RqgItemDataModel<CultSchema> {
+  declare runeRqidLinks: RqidLink<`i.rune.${string}`>[];
+  declare commonRuneMagicRqidLinks: RqidLink<`i.rune-magic.${string}`>[];
+  declare descriptionRqidLink: RqidLink<RqidString>;
+
   static override defineSchema() {
     return {
       deity: new StringField({ blank: true, nullable: true, initial: undefined }),

--- a/src/data-model/item-data/homelandDataModel.ts
+++ b/src/data-model/item-data/homelandDataModel.ts
@@ -1,6 +1,7 @@
 import type { RqgItem } from "@items/rqgItem.ts";
 import { RqgItemDataModel } from "./RqgItemDataModel";
 import { rqidLinkSchemaField, rqidLinkArraySchemaField } from "../shared/rqidLinkField";
+import type { RqidLink } from "../shared/rqidLink";
 
 export type HomelandItem = RqgItem & { system: Item.SystemOfType<"homeland"> };
 
@@ -9,6 +10,10 @@ const { StringField } = foundry.data.fields;
 type HomelandSchema = ReturnType<typeof HomelandDataModel.defineSchema>;
 
 export class HomelandDataModel extends RqgItemDataModel<HomelandSchema> {
+  declare skillRqidLinks: RqidLink<`i.skill.${string}`>[];
+  declare runeRqidLinks: RqidLink<`i.rune.${string}`>[];
+  declare passionRqidLinks: RqidLink<`i.passion.${string}`>[];
+
   static override defineSchema() {
     return {
       homeland: new StringField({ blank: true, nullable: false, initial: "" }),

--- a/src/data-model/item-data/runeDataModel.ts
+++ b/src/data-model/item-data/runeDataModel.ts
@@ -2,6 +2,8 @@ import type { RqgItem } from "@items/rqgItem.ts";
 import { RqgItemDataModel } from "./RqgItemDataModel";
 import { abilitySchemaFields } from "../shared/abilitySchemaFields";
 import { rqidLinkSchemaField, rqidLinkArraySchemaField } from "../shared/rqidLinkField";
+import type { RqidLink } from "../shared/rqidLink";
+import type { RqidString } from "../../system/api/rqidApi";
 import { enumChoices } from "../shared/enumChoices";
 
 export type RuneItem = RqgItem & { system: Item.SystemOfType<"rune"> };
@@ -33,6 +35,8 @@ type RuneSchema = ReturnType<typeof RuneDataModel.defineSchema>;
 const runeTypeValues = new Set<string>(Object.values(RuneTypeEnum));
 
 export class RuneDataModel extends RqgItemDataModel<RuneSchema> {
+  declare descriptionRqidLink: RqidLink<RqidString>;
+
   static override defineSchema() {
     return {
       ...abilitySchemaFields(),

--- a/src/data-model/item-data/runeMagicDataModel.ts
+++ b/src/data-model/item-data/runeMagicDataModel.ts
@@ -1,6 +1,8 @@
 import type { RqgItem } from "@items/rqgItem.ts";
 import { RqgItemDataModel } from "./RqgItemDataModel";
 import { spellSchemaFields } from "../shared/spellSchemaFields";
+import type { RqidLink } from "../shared/rqidLink";
+import type { RqidString } from "../../system/api/rqidApi";
 
 export type RuneMagicItem = RqgItem & { system: Item.SystemOfType<"runeMagic"> };
 import { rqidLinkArraySchemaField } from "../shared/rqidLinkField";
@@ -10,6 +12,8 @@ const { BooleanField, StringField } = foundry.data.fields;
 type RuneMagicSchema = ReturnType<typeof RuneMagicDataModel.defineSchema>;
 
 export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chance: number }> {
+  declare descriptionRqidLink: RqidLink<RqidString>;
+
   static override defineSchema() {
     return {
       ...spellSchemaFields(),

--- a/src/data-model/item-data/skillDataModel.ts
+++ b/src/data-model/item-data/skillDataModel.ts
@@ -2,6 +2,8 @@ import type { RqgItem } from "@items/rqgItem.ts";
 import { RqgItemDataModel } from "./RqgItemDataModel";
 import { abilitySchemaFields } from "../shared/abilitySchemaFields";
 import { rqidLinkSchemaField, rqidLinkArraySchemaField } from "../shared/rqidLinkField";
+import type { RqidLink } from "../shared/rqidLink";
+import type { RqidString } from "../../system/api/rqidApi";
 import { enumChoices } from "../shared/enumChoices";
 
 export type SkillItem = RqgItem & { system: Item.SystemOfType<"skill"> };
@@ -30,6 +32,9 @@ export class SkillDataModel extends RqgItemDataModel<
   SkillSchema,
   { chance: number; categoryMod: number }
 > {
+  declare runeRqidLinks: RqidLink<`i.rune.${string}`>[];
+  declare descriptionRqidLink: RqidLink<RqidString>;
+
   static override defineSchema() {
     return {
       ...abilitySchemaFields(),

--- a/src/data-model/item-data/spiritMagicDataModel.ts
+++ b/src/data-model/item-data/spiritMagicDataModel.ts
@@ -1,6 +1,8 @@
 import type { RqgItem } from "@items/rqgItem.ts";
 import { RqgItemDataModel } from "./RqgItemDataModel";
 import { spellSchemaFields } from "../shared/spellSchemaFields";
+import type { RqidLink } from "../shared/rqidLink";
+import type { RqidString } from "../../system/api/rqidApi";
 
 export type SpiritMagicItem = RqgItem & { system: Item.SystemOfType<"spiritMagic"> };
 
@@ -9,6 +11,8 @@ const { ArrayField, BooleanField, StringField } = foundry.data.fields;
 type SpiritMagicSchema = ReturnType<typeof SpiritMagicDataModel.defineSchema>;
 
 export class SpiritMagicDataModel extends RqgItemDataModel<SpiritMagicSchema> {
+  declare descriptionRqidLink: RqidLink<RqidString>;
+
   static override defineSchema() {
     return {
       ...spellSchemaFields(),

--- a/src/data-model/item-data/weaponDataModel.ts
+++ b/src/data-model/item-data/weaponDataModel.ts
@@ -108,7 +108,7 @@ export class WeaponDataModel extends RqgItemDataModel<WeaponSchema> {
   }
 
   /**
-   * Encode legacy weapon skill link data into the rqid field as a sentinel string
+   * Encode legacy weapon skill link data into the rqid field as a legacy-encoded rqid
    * so it survives schema cleaning and can be resolved by migrations.
    */
   static override migrateData(source: Record<string, unknown>): Record<string, unknown> {
@@ -120,7 +120,10 @@ export class WeaponDataModel extends RqgItemDataModel<WeaponSchema> {
         if (!u || typeof u !== "object") {
           continue;
         }
-        encodeLegacyWeaponSkillReferenceInRqid(u);
+        const encoded = encodeLegacyWeaponSkillReferenceInRqid(u);
+        if (encoded) {
+          u["skillRqidLink"] = encoded;
+        }
       }
     }
 

--- a/src/data-model/item-data/weaponDataModel.ts
+++ b/src/data-model/item-data/weaponDataModel.ts
@@ -1,10 +1,12 @@
 import type { RqgItem } from "@items/rqgItem.ts";
+import type { RqidString } from "../../system/api/rqidApi";
 import { RqidLink } from "../shared/rqidLink";
 import { RqgItemDataModel } from "./RqgItemDataModel";
 import { physicalItemSchemaFields } from "../shared/physicalItemSchemaFields";
 import { rqidLinkSchemaField } from "../shared/rqidLinkField";
 import { resourceSchemaField } from "../shared/resourceSchemaField";
 import { enumChoices } from "../shared/enumChoices";
+import { legacyWeaponSkillRefsFlag, preserveLegacyWeaponSkillReference } from "./weaponSkillLink";
 
 export type WeaponItem = RqgItem & { system: Item.SystemOfType<"weapon"> };
 
@@ -35,7 +37,7 @@ export type CombatManeuver = {
 
 export type Usage = {
   /** The corresponding skill */
-  skillRqidLink: RqidLink | undefined;
+  skillRqidLink: RqidLink<RqidString | ""> | undefined;
   combatManeuvers: CombatManeuver[];
   /** Weapon damage formula */
   damage: string;
@@ -106,28 +108,42 @@ export class WeaponDataModel extends RqgItemDataModel<WeaponSchema> {
   }
 
   /**
-   * Preserve legacy skillOrigin/skillId into the skillRqidLink field before
-   * schema cleaning strips them. Uses the "NOT-FOUND" encoding that the
-   * world migration (migrateWeaponSkillLinks) knows how to resolve.
+   * Preserve legacy weapon skill link inputs in flags before schema cleaning
+   * strips them, so migrations can still convert them into a valid rqid link.
    */
   static override migrateData(source: Record<string, unknown>): Record<string, unknown> {
     const usage = source["usage"] as Record<string, Record<string, unknown>> | undefined;
+    const legacyRefsByUsage: Record<string, { skillOrigin?: string; skillId?: string }> = {};
+
     if (usage && typeof usage === "object") {
       for (const usageType of ["oneHand", "offHand", "twoHand", "missile"]) {
         const u = usage[usageType];
         if (!u || typeof u !== "object") {
           continue;
         }
-        const skillOrigin = u["skillOrigin"] as string | undefined;
-        const skillId = u["skillId"] as string | undefined;
-        if (skillOrigin && (!u["skillRqidLink"] || (u["skillRqidLink"] as any).rqid === "")) {
-          u["skillRqidLink"] = {
-            rqid: `i.skill.[${skillOrigin}] / [${skillId ?? ""}]`,
-            name: "NOT-FOUND",
-          };
+        const legacyRef = preserveLegacyWeaponSkillReference(u);
+        if (legacyRef?.skillOrigin || legacyRef?.skillId) {
+          legacyRefsByUsage[usageType] = legacyRef;
         }
       }
     }
+
+    if (Object.keys(legacyRefsByUsage).length > 0) {
+      const flags = (source["flags"] as Record<string, unknown> | undefined) ?? {};
+      source["flags"] = flags;
+
+      const rqgFlags = (flags["rqg"] as Record<string, unknown> | undefined) ?? {};
+      flags["rqg"] = rqgFlags;
+
+      const existingLegacyRefs =
+        (rqgFlags[legacyWeaponSkillRefsFlag] as Record<string, unknown> | undefined) ?? {};
+
+      rqgFlags[legacyWeaponSkillRefsFlag] = {
+        ...existingLegacyRefs,
+        ...legacyRefsByUsage,
+      };
+    }
+
     return super.migrateData(source);
   }
 }

--- a/src/data-model/item-data/weaponDataModel.ts
+++ b/src/data-model/item-data/weaponDataModel.ts
@@ -6,7 +6,7 @@ import { physicalItemSchemaFields } from "../shared/physicalItemSchemaFields";
 import { rqidLinkSchemaField } from "../shared/rqidLinkField";
 import { resourceSchemaField } from "../shared/resourceSchemaField";
 import { enumChoices } from "../shared/enumChoices";
-import { legacyWeaponSkillRefsFlag, preserveLegacyWeaponSkillReference } from "./weaponSkillLink";
+import { encodeLegacyWeaponSkillReferenceInRqid } from "./weaponSkillLink";
 
 export type WeaponItem = RqgItem & { system: Item.SystemOfType<"weapon"> };
 
@@ -108,12 +108,11 @@ export class WeaponDataModel extends RqgItemDataModel<WeaponSchema> {
   }
 
   /**
-   * Preserve legacy weapon skill link inputs in flags before schema cleaning
-   * strips them, so migrations can still convert them into a valid rqid link.
+   * Encode legacy weapon skill link data into the rqid field as a sentinel string
+   * so it survives schema cleaning and can be resolved by migrations.
    */
   static override migrateData(source: Record<string, unknown>): Record<string, unknown> {
     const usage = source["usage"] as Record<string, Record<string, unknown>> | undefined;
-    const legacyRefsByUsage: Record<string, { skillOrigin?: string; skillId?: string }> = {};
 
     if (usage && typeof usage === "object") {
       for (const usageType of ["oneHand", "offHand", "twoHand", "missile"]) {
@@ -121,27 +120,8 @@ export class WeaponDataModel extends RqgItemDataModel<WeaponSchema> {
         if (!u || typeof u !== "object") {
           continue;
         }
-        const legacyRef = preserveLegacyWeaponSkillReference(u);
-        if (legacyRef?.skillOrigin || legacyRef?.skillId) {
-          legacyRefsByUsage[usageType] = legacyRef;
-        }
+        encodeLegacyWeaponSkillReferenceInRqid(u);
       }
-    }
-
-    if (Object.keys(legacyRefsByUsage).length > 0) {
-      const flags = (source["flags"] as Record<string, unknown> | undefined) ?? {};
-      source["flags"] = flags;
-
-      const rqgFlags = (flags["rqg"] as Record<string, unknown> | undefined) ?? {};
-      flags["rqg"] = rqgFlags;
-
-      const existingLegacyRefs =
-        (rqgFlags[legacyWeaponSkillRefsFlag] as Record<string, unknown> | undefined) ?? {};
-
-      rqgFlags[legacyWeaponSkillRefsFlag] = {
-        ...existingLegacyRefs,
-        ...legacyRefsByUsage,
-      };
     }
 
     return super.migrateData(source);

--- a/src/data-model/item-data/weaponSkillLink.ts
+++ b/src/data-model/item-data/weaponSkillLink.ts
@@ -1,7 +1,6 @@
 const legacyWeaponSkillRefPattern = /^i\.skill\.\[(?<skillOrigin>.*)] \/ \[(?<itemId>.*)]$/;
 export const legacySkillOriginField = "_legacySkillOrigin";
 export const legacySkillIdField = "_legacySkillId";
-export const legacyWeaponSkillRefsFlag = "_legacyWeaponSkillRefs";
 
 export type LegacyWeaponSkillRef = {
   skillOrigin?: string;
@@ -49,20 +48,9 @@ export function getLegacyWeaponSkillReference(
 }
 
 export function getLegacyWeaponSkillReferenceForUsage(
-  itemData: { flags?: unknown; system?: unknown },
+  itemData: { system?: unknown },
   usageType: string,
 ): LegacyWeaponSkillRef | undefined {
-  const legacyFromFlags = (
-    (itemData.flags as Record<string, unknown> | undefined)?.["rqg"] as
-      | Record<string, unknown>
-      | undefined
-  )?.[legacyWeaponSkillRefsFlag] as Record<string, LegacyWeaponSkillRef> | undefined;
-
-  const flaggedLegacyRef = legacyFromFlags?.[usageType];
-  if (flaggedLegacyRef?.skillOrigin || flaggedLegacyRef?.skillId) {
-    return flaggedLegacyRef;
-  }
-
   const usage = (
     (itemData.system as Record<string, unknown> | undefined)?.["usage"] as
       | Record<string, Record<string, unknown>>
@@ -76,22 +64,27 @@ export function getLegacyWeaponSkillReferenceForUsage(
   return getLegacyWeaponSkillReference(usage);
 }
 
-export function preserveLegacyWeaponSkillReference(
-  usage: Record<string, unknown>,
-): LegacyWeaponSkillRef | undefined {
+/**
+ * Encode legacy weapon skill references into the `skillRqidLink.rqid` field
+ * as a sentinel string `i.skill.[skillOrigin] / [skillId]`.
+ * This keeps legacy data inside the schema so it survives Foundry's schema cleaning.
+ */
+export function encodeLegacyWeaponSkillReferenceInRqid(usage: Record<string, unknown>): void {
   const legacyRef = getLegacyWeaponSkillReference(usage);
   if (!legacyRef?.skillOrigin && !legacyRef?.skillId) {
-    return undefined;
+    return;
   }
 
   const skillRqidLink = usage["skillRqidLink"] as Record<string, unknown> | undefined;
-  if (skillRqidLink && isLegacyWeaponSkillReferenceRqid(skillRqidLink["rqid"])) {
-    skillRqidLink["rqid"] = "";
-    skillRqidLink["name"] = "";
+  if (!skillRqidLink) {
+    return;
   }
 
-  return {
-    skillOrigin: legacyRef.skillOrigin ?? "",
-    skillId: legacyRef.skillId ?? "",
-  };
+  const currentRqid = skillRqidLink["rqid"];
+  if (currentRqid && !isLegacyWeaponSkillReferenceRqid(currentRqid) && currentRqid !== "") {
+    return; // Already has a valid rqid — don't overwrite
+  }
+
+  skillRqidLink["rqid"] = `i.skill.[${legacyRef.skillOrigin ?? ""}] / [${legacyRef.skillId ?? ""}]`;
+  skillRqidLink["name"] = skillRqidLink["name"] || "";
 }

--- a/src/data-model/item-data/weaponSkillLink.ts
+++ b/src/data-model/item-data/weaponSkillLink.ts
@@ -66,25 +66,26 @@ export function getLegacyWeaponSkillReferenceForUsage(
 
 /**
  * Encode legacy weapon skill references into the `skillRqidLink.rqid` field
- * as a sentinel string `i.skill.[skillOrigin] / [skillId]`.
+ * as a legacy-encoded rqid `i.skill.[skillOrigin] / [skillId]`.
  * This keeps legacy data inside the schema so it survives Foundry's schema cleaning.
+ * Returns the updated skillRqidLink value, or undefined if no encoding was needed.
  */
-export function encodeLegacyWeaponSkillReferenceInRqid(usage: Record<string, unknown>): void {
+export function encodeLegacyWeaponSkillReferenceInRqid(
+  usage: Record<string, unknown>,
+): { rqid: string; name: string } | undefined {
   const legacyRef = getLegacyWeaponSkillReference(usage);
   if (!legacyRef?.skillOrigin && !legacyRef?.skillId) {
-    return;
+    return undefined;
   }
 
   const skillRqidLink = usage["skillRqidLink"] as Record<string, unknown> | undefined;
-  if (!skillRqidLink) {
-    return;
-  }
-
-  const currentRqid = skillRqidLink["rqid"];
+  const currentRqid = skillRqidLink?.["rqid"];
   if (currentRqid && !isLegacyWeaponSkillReferenceRqid(currentRqid) && currentRqid !== "") {
-    return; // Already has a valid rqid — don't overwrite
+    return undefined; // Already has a valid rqid — don't overwrite
   }
 
-  skillRqidLink["rqid"] = `i.skill.[${legacyRef.skillOrigin ?? ""}] / [${legacyRef.skillId ?? ""}]`;
-  skillRqidLink["name"] = skillRqidLink["name"] || "";
+  return {
+    rqid: `i.skill.[${legacyRef.skillOrigin ?? ""}] / [${legacyRef.skillId ?? ""}]`,
+    name: (skillRqidLink?.["name"] as string) || "",
+  };
 }

--- a/src/data-model/item-data/weaponSkillLink.ts
+++ b/src/data-model/item-data/weaponSkillLink.ts
@@ -1,0 +1,97 @@
+const legacyWeaponSkillRefPattern = /^i\.skill\.\[(?<skillOrigin>.*)] \/ \[(?<itemId>.*)]$/;
+export const legacySkillOriginField = "_legacySkillOrigin";
+export const legacySkillIdField = "_legacySkillId";
+export const legacyWeaponSkillRefsFlag = "_legacyWeaponSkillRefs";
+
+export type LegacyWeaponSkillRef = {
+  skillOrigin?: string;
+  skillId?: string;
+};
+
+export function isLegacyWeaponSkillReferenceRqid(value: unknown): value is string {
+  return typeof value === "string" && legacyWeaponSkillRefPattern.test(value);
+}
+
+export function parseLegacyWeaponSkillReference(value: unknown): LegacyWeaponSkillRef | undefined {
+  if (!isLegacyWeaponSkillReferenceRqid(value)) {
+    return undefined;
+  }
+
+  const match = value.match(legacyWeaponSkillRefPattern);
+  if (!match?.groups) {
+    return undefined;
+  }
+
+  return {
+    skillOrigin: match.groups["skillOrigin"],
+    skillId: match.groups["itemId"],
+  };
+}
+
+export function getLegacyWeaponSkillReference(
+  usage: Record<string, unknown>,
+): LegacyWeaponSkillRef | undefined {
+  const skillOrigin = usage[legacySkillOriginField] as string | undefined;
+  const skillId = usage[legacySkillIdField] as string | undefined;
+
+  if (skillOrigin || skillId) {
+    return { skillOrigin, skillId };
+  }
+
+  const rawSkillOrigin = usage["skillOrigin"] as string | undefined;
+  const rawSkillId = usage["skillId"] as string | undefined;
+  if (rawSkillOrigin || rawSkillId) {
+    return { skillOrigin: rawSkillOrigin, skillId: rawSkillId };
+  }
+
+  const legacyEncodedRqid = (usage["skillRqidLink"] as { rqid?: unknown } | undefined)?.rqid;
+  return parseLegacyWeaponSkillReference(legacyEncodedRqid);
+}
+
+export function getLegacyWeaponSkillReferenceForUsage(
+  itemData: { flags?: unknown; system?: unknown },
+  usageType: string,
+): LegacyWeaponSkillRef | undefined {
+  const legacyFromFlags = (
+    (itemData.flags as Record<string, unknown> | undefined)?.["rqg"] as
+      | Record<string, unknown>
+      | undefined
+  )?.[legacyWeaponSkillRefsFlag] as Record<string, LegacyWeaponSkillRef> | undefined;
+
+  const flaggedLegacyRef = legacyFromFlags?.[usageType];
+  if (flaggedLegacyRef?.skillOrigin || flaggedLegacyRef?.skillId) {
+    return flaggedLegacyRef;
+  }
+
+  const usage = (
+    (itemData.system as Record<string, unknown> | undefined)?.["usage"] as
+      | Record<string, Record<string, unknown>>
+      | undefined
+  )?.[usageType];
+
+  if (!usage) {
+    return undefined;
+  }
+
+  return getLegacyWeaponSkillReference(usage);
+}
+
+export function preserveLegacyWeaponSkillReference(
+  usage: Record<string, unknown>,
+): LegacyWeaponSkillRef | undefined {
+  const legacyRef = getLegacyWeaponSkillReference(usage);
+  if (!legacyRef?.skillOrigin && !legacyRef?.skillId) {
+    return undefined;
+  }
+
+  const skillRqidLink = usage["skillRqidLink"] as Record<string, unknown> | undefined;
+  if (skillRqidLink && isLegacyWeaponSkillReferenceRqid(skillRqidLink["rqid"])) {
+    skillRqidLink["rqid"] = "";
+    skillRqidLink["name"] = "";
+  }
+
+  return {
+    skillOrigin: legacyRef.skillOrigin ?? "",
+    skillId: legacyRef.skillId ?? "",
+  };
+}

--- a/src/data-model/shared/rqgDocumentFlags.ts
+++ b/src/data-model/shared/rqgDocumentFlags.ts
@@ -1,6 +1,8 @@
 export const documentRqidFlags = "documentRqidFlags" as const;
 export const actorWizardFlags = "actorWizardFlags" as const;
 
+import type { RqidString } from "../../system/api/rqidApi";
+
 export interface RqgItemFlags {
   [documentRqidFlags]: DocumentRqidFlags;
 }
@@ -38,7 +40,7 @@ export interface RqgActorFlags {
   [actorWizardFlags]?: {
     actorWizardComplete?: boolean;
     selectedSpeciesUuid?: string;
-    selectedHomelandRqid?: string;
+    selectedHomelandRqid?: RqidString;
     isActorTemplate?: boolean;
     wizardChoices?: string;
   };
@@ -56,7 +58,7 @@ export interface DocumentRqidFlags {
    * Third part is the sluggified id given to the document.
    * Example `i.skill.ride-bison`or `je..rune-descriptions-air`
    */
-  id?: string;
+  id?: RqidString;
   /** Defines what language the document is written in. Example "en", "pl" */
   lang?: string;
   /** Defines how this rqid should be ranked compared to others with the same id. Higher number wins. */

--- a/src/data-model/shared/rqidLink.ts
+++ b/src/data-model/shared/rqidLink.ts
@@ -1,15 +1,16 @@
 import { Rqid } from "../../system/api/rqidApi";
+import { isValidRqidString } from "../../system/api/rqidValidation";
 import { getDomDataset } from "../../system/util";
 
-export class RqidLink {
+export class RqidLink<R extends string = string> {
   /** The rqid to link to */
-  readonly rqid: string;
+  readonly rqid: R;
   /** Display name of the link */
   readonly name: string;
 
-  bonus?: number | null | undefined;
+  bonus: number | null | undefined;
 
-  constructor(rqid: string, name: string) {
+  constructor(rqid: R, name: string) {
     this.rqid = rqid;
     this.name = name;
   }
@@ -31,7 +32,9 @@ export class RqidLink {
           if (ev.target instanceof HTMLInputElement || targetUuid || targetRqidLink !== rqid) {
             return; // exclude inputs and embedded uuid & rqid links
           }
-          await Rqid.renderRqidDocument(rqid, anchor);
+          if (isValidRqidString(rqid)) {
+            await Rqid.renderRqidDocument(rqid, anchor);
+          }
         });
       }
     });

--- a/src/data-model/shared/rqidLinkField.ts
+++ b/src/data-model/shared/rqidLinkField.ts
@@ -1,4 +1,5 @@
 const { NumberField, SchemaField, StringField } = foundry.data.fields;
+import { isValidRqidString } from "../../system/api/rqidValidation";
 
 /**
  * Returns a SchemaField representing a single RqidLink (rqid + name + optional bonus).
@@ -9,7 +10,12 @@ export function rqidLinkSchemaField(
 ) {
   return new SchemaField(
     {
-      rqid: new StringField({ blank: true, nullable: false, initial: "" }),
+      rqid: new StringField({
+        blank: true,
+        nullable: false,
+        initial: "",
+        validate: (value: string) => isValidRqidString(value, { allowEmpty: true }),
+      }),
       name: new StringField({ blank: true, nullable: false, initial: "" }),
       bonus: new NumberField({ integer: true, nullable: true, initial: undefined }),
     },

--- a/src/data-model/shared/rqidLinkField.ts
+++ b/src/data-model/shared/rqidLinkField.ts
@@ -1,20 +1,31 @@
 const { NumberField, SchemaField, StringField } = foundry.data.fields;
+import type { RqidString } from "../../system/api/rqidApi";
 import { isValidRqidString } from "../../system/api/rqidValidation";
+
+type RqidOrEmpty = RqidString | "";
 
 /**
  * Returns a SchemaField representing a single RqidLink (rqid + name + optional bonus).
  * Use this for fields like `descriptionRqidLink`.
  */
 export function rqidLinkSchemaField(
-  options: { nullable: boolean; initial?: undefined } = { nullable: true },
+  options: {
+    nullable: boolean;
+    initial?: undefined;
+    validateRqid?: (value: string) => value is RqidOrEmpty;
+  } = { nullable: true },
 ) {
+  const validateRqid: (value: string) => value is RqidOrEmpty =
+    options.validateRqid ??
+    ((value: string): value is RqidOrEmpty => isValidRqidString(value, { allowEmpty: true }));
+
   return new SchemaField(
     {
       rqid: new StringField({
         blank: true,
         nullable: false,
         initial: "",
-        validate: (value: string) => isValidRqidString(value, { allowEmpty: true }),
+        validate: validateRqid,
       }),
       name: new StringField({ blank: true, nullable: false, initial: "" }),
       bonus: new NumberField({ integer: true, nullable: true, initial: undefined }),

--- a/src/items/cult-item/cult.ts
+++ b/src/items/cult-item/cult.ts
@@ -101,7 +101,7 @@ export class Cult extends AbstractEmbeddedItem {
 
     const runeMagicItems = await Promise.all(
       cult.system.commonRuneMagicRqidLinks.map(
-        async (rqidLink) => (await Rqid.fromRqid(rqidLink.rqid)) as RuneMagicItem | undefined,
+        async (rqidLink) => await Rqid.fromRqid(rqidLink.rqid),
       ),
     );
 

--- a/src/items/occupation-item/occupationSheet.ts
+++ b/src/items/occupation-item/occupationSheet.ts
@@ -51,7 +51,7 @@ function normalizeOccupationalSkills(skills: unknown): OccupationalSkill[] {
       return {
         incomeSkill: Boolean(occupationalSkill.incomeSkill),
         bonus: Number.isFinite(bonusValue) ? bonusValue : 0,
-        skillRqidLink: { rqid, name },
+        skillRqidLink: { rqid, name, bonus: undefined },
       };
     })
     .filter((skill): skill is OccupationalSkill => skill !== undefined);
@@ -289,6 +289,7 @@ export class OccupationSheet extends RqgItemSheet {
           skillRqidLink: {
             rqid: droppedRqid.id,
             name: droppedItem.name || "",
+            bonus: undefined,
           },
         };
 

--- a/src/items/occupation-item/occupationSheetV2.ts
+++ b/src/items/occupation-item/occupationSheetV2.ts
@@ -55,7 +55,7 @@ function normalizeOccupationalSkills(skills: unknown): OccupationalSkill[] {
       return {
         incomeSkill: Boolean(occupationalSkill.incomeSkill),
         bonus: Number.isFinite(bonusValue) ? bonusValue : 0,
-        skillRqidLink: { rqid, name },
+        skillRqidLink: { rqid, name, bonus: undefined },
       };
     })
     .filter((skill): skill is OccupationalSkill => skill !== undefined);
@@ -253,6 +253,7 @@ export class OccupationSheetV2 extends RqgItemSheetV2 {
           skillRqidLink: {
             rqid: droppedRqid.id,
             name: droppedItem.name || "",
+            bonus: undefined,
           },
         };
         const occSkills = normalizeOccupationalSkills(this.document.system.occupationalSkills);

--- a/src/items/rune-item/rune.ts
+++ b/src/items/rune-item/rune.ts
@@ -3,6 +3,7 @@ import { RqgActor } from "@actors/rqgActor.ts";
 import { RqgItem } from "../rqgItem";
 import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import { assertDocumentSubType, isDocumentSubType } from "../../system/util";
+import { toRqidString } from "../../system/api/rqidValidation";
 import type { RuneItem } from "@item-model/runeDataModel.ts";
 
 export class Rune extends AbstractEmbeddedItem {
@@ -22,7 +23,7 @@ export class Rune extends AbstractEmbeddedItem {
       }
       if (rune.system.opposingRuneRqidLink?.rqid) {
         const opposingRune = actor.getBestEmbeddedDocumentByRqid(
-          rune.system.opposingRuneRqidLink.rqid,
+          toRqidString(rune.system.opposingRuneRqidLink.rqid),
         );
         const chance = chanceResult["system.chance"] ?? chanceResult.system.chance;
         if (opposingRune && chance != null) {

--- a/src/items/rune-magic-item/runeMagic.ts
+++ b/src/items/rune-magic-item/runeMagic.ts
@@ -16,6 +16,7 @@ import { templatePaths } from "../../system/loadHandlebarsTemplates";
 import { AbilitySuccessLevelEnum } from "../../rolls/AbilityRoll/AbilityRoll.defs";
 import type { RuneMagicItem } from "@item-model/runeMagicDataModel.ts";
 import type { CultItem } from "@item-model/cultDataModel.ts";
+import { toRqidString } from "../../system/api/rqidValidation";
 
 type RpAndMpCost = { mp: number; rp: number; exp: boolean };
 
@@ -214,7 +215,10 @@ export class RuneMagic extends AbstractEmbeddedItem {
     }
     // Get the actor's versions of the runes, which will have their "chance"
     const runesForCasting = usableRuneRqids
-      .map((runeRqid) => runeMagicItem.actor?.getBestEmbeddedDocumentByRqid(runeRqid) as RuneItem)
+      .map(
+        (runeRqid) =>
+          runeMagicItem.actor?.getBestEmbeddedDocumentByRqid(toRqidString(runeRqid)) as RuneItem,
+      )
       .filter(isTruthy);
 
     return runesForCasting;

--- a/src/items/weapon-item/weapon.ts
+++ b/src/items/weapon-item/weapon.ts
@@ -11,6 +11,7 @@ import {
 import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import { getLocationRelatedUpdates } from "../shared/physicalItemUtil";
 import { Rqid } from "../../system/api/rqidApi";
+import { toRqidString } from "../../system/api/rqidValidation";
 import type { WeaponItem } from "@item-model/weaponDataModel.ts";
 
 export class Weapon extends AbstractEmbeddedItem {
@@ -78,18 +79,19 @@ export class Weapon extends AbstractEmbeddedItem {
     skillRqid: string | undefined,
     actor: RqgActor,
   ): Promise<boolean> {
-    if (!skillRqid) {
+    const normalizedSkillRqid = toRqidString(skillRqid);
+    if (!normalizedSkillRqid) {
       return true; // No rqid (no linked skill) so count this as a success.
     }
-    const embeddedSkill = actor.getBestEmbeddedDocumentByRqid(skillRqid);
+    const embeddedSkill = actor.getBestEmbeddedDocumentByRqid(normalizedSkillRqid);
 
     if (!embeddedSkill) {
-      const skill = await Rqid.fromRqid(skillRqid);
+      const skill = await Rqid.fromRqid(normalizedSkillRqid);
       if (!skill) {
         logMisconfiguration(
           localize("RQG.Item.Notification.CantFindWeaponSkillWarning"),
           true,
-          skillRqid,
+          normalizedSkillRqid,
         );
         return false;
       }

--- a/src/items/weapon-item/weapon.ts
+++ b/src/items/weapon-item/weapon.ts
@@ -11,8 +11,10 @@ import {
 import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import { getLocationRelatedUpdates } from "../shared/physicalItemUtil";
 import { Rqid } from "../../system/api/rqidApi";
+import type { RqidString } from "../../system/api/rqidApi";
 import { toRqidString } from "../../system/api/rqidValidation";
-import type { WeaponItem } from "@item-model/weaponDataModel.ts";
+import type { SkillItem } from "@item-model/skillDataModel.ts";
+import type { Usage, UsageType, WeaponItem } from "@item-model/weaponDataModel.ts";
 
 export class Weapon extends AbstractEmbeddedItem {
   static override preUpdateItem(
@@ -98,5 +100,28 @@ export class Weapon extends AbstractEmbeddedItem {
       await actor.createEmbeddedDocuments("Item", [skill as any]);
     }
     return true;
+  }
+
+  public static hasLinkedSkillReference(weaponItem: WeaponItem, usageType: UsageType): boolean {
+    return !!weaponItem.system.usage[usageType].skillRqidLink?.rqid;
+  }
+
+  public static resolveLinkedSkill(
+    weaponItem: WeaponItem,
+    usageType: UsageType,
+  ): SkillItem | undefined {
+    const usage = weaponItem.system.usage[usageType] as Usage;
+    const skillRqid = usage.skillRqidLink?.rqid;
+    if (!skillRqid) {
+      return undefined;
+    }
+
+    const embeddedByRqid = weaponItem.actor?.getBestEmbeddedDocumentByRqid(skillRqid as RqidString);
+
+    if (isDocumentSubType<SkillItem>(embeddedByRqid, ItemTypeEnum.Skill)) {
+      return embeddedByRqid;
+    }
+
+    return undefined;
   }
 }

--- a/src/items/weapon-item/weapon.ts
+++ b/src/items/weapon-item/weapon.ts
@@ -11,7 +11,6 @@ import {
 import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import { getLocationRelatedUpdates } from "../shared/physicalItemUtil";
 import { Rqid } from "../../system/api/rqidApi";
-import type { RqidString } from "../../system/api/rqidApi";
 import { toRqidString } from "../../system/api/rqidValidation";
 import type { SkillItem } from "@item-model/skillDataModel.ts";
 import type { Usage, UsageType, WeaponItem } from "@item-model/weaponDataModel.ts";
@@ -103,7 +102,7 @@ export class Weapon extends AbstractEmbeddedItem {
   }
 
   public static hasLinkedSkillReference(weaponItem: WeaponItem, usageType: UsageType): boolean {
-    return !!weaponItem.system.usage[usageType].skillRqidLink?.rqid;
+    return !!toRqidString(weaponItem.system.usage[usageType].skillRqidLink?.rqid);
   }
 
   public static resolveLinkedSkill(
@@ -111,12 +110,12 @@ export class Weapon extends AbstractEmbeddedItem {
     usageType: UsageType,
   ): SkillItem | undefined {
     const usage = weaponItem.system.usage[usageType] as Usage;
-    const skillRqid = usage.skillRqidLink?.rqid;
+    const skillRqid = toRqidString(usage.skillRqidLink?.rqid);
     if (!skillRqid) {
       return undefined;
     }
 
-    const embeddedByRqid = weaponItem.actor?.getBestEmbeddedDocumentByRqid(skillRqid as RqidString);
+    const embeddedByRqid = weaponItem.actor?.getBestEmbeddedDocumentByRqid(skillRqid);
 
     if (isDocumentSubType<SkillItem>(embeddedByRqid, ItemTypeEnum.Skill)) {
       return embeddedByRqid;

--- a/src/items/weapon-item/weaponSkillLinks.test.ts
+++ b/src/items/weapon-item/weaponSkillLinks.test.ts
@@ -4,7 +4,6 @@ import { WeaponDataModel } from "@item-model/weaponDataModel.ts";
 import { ActorTypeEnum } from "../../data-model/actor-data/rqgActorData";
 import {
   encodeLegacyWeaponSkillReferenceInRqid,
-  getLegacyWeaponSkillReference,
   getLegacyWeaponSkillReferenceForUsage,
   isLegacyWeaponSkillReferenceRqid,
   parseLegacyWeaponSkillReference,
@@ -70,7 +69,7 @@ describe("weapon skill link handling", () => {
     vi.mocked(fromUuid).mockResolvedValue(null);
   });
 
-  it("accepts legacy sentinel payloads in the weapon rqid schema", () => {
+  it("accepts legacy-encoded rqid payloads in the weapon rqid schema", () => {
     const schema = WeaponDataModel.defineSchema();
     const usageField: any = schema.usage;
     const oneHandField: any = usageField.schema.oneHand;
@@ -87,18 +86,29 @@ describe("weapon skill link handling", () => {
       skillRqidLink: { rqid: "", name: "" },
     };
 
-    encodeLegacyWeaponSkillReferenceInRqid(usage);
+    const result = encodeLegacyWeaponSkillReferenceInRqid(usage);
 
-    expect((usage["skillRqidLink"] as any).rqid).toBe(
-      "i.skill.[Compendium.world.new-attack-type.Item.bite] / [abc123]",
-    );
-    expect(getLegacyWeaponSkillReference(usage)).toEqual({
-      skillOrigin: "Compendium.world.new-attack-type.Item.bite",
-      skillId: "abc123",
+    expect(result).toEqual({
+      rqid: "i.skill.[Compendium.world.new-attack-type.Item.bite] / [abc123]",
+      name: "",
     });
   });
 
-  it("preserves existing sentinel in rqid field", () => {
+  it("creates skillRqidLink when missing and encodes legacy data", () => {
+    const usage: Record<string, unknown> = {
+      skillOrigin: "Compendium.world.old-weapon.Item.sword",
+      skillId: "oldId",
+    };
+
+    const result = encodeLegacyWeaponSkillReferenceInRqid(usage);
+
+    expect(result).toEqual({
+      rqid: "i.skill.[Compendium.world.old-weapon.Item.sword] / [oldId]",
+      name: "",
+    });
+  });
+
+  it("preserves existing legacy-encoded rqid in rqid field", () => {
     const usage: Record<string, unknown> = {
       skillRqidLink: {
         rqid: "i.skill.[Compendium.world.new-attack-type.Item.bite] / [embedded-bite]",
@@ -112,12 +122,13 @@ describe("weapon skill link handling", () => {
       skillId: "embedded-bite",
     });
 
-    // Encoding again should not change it
-    encodeLegacyWeaponSkillReferenceInRqid(usage);
+    // Encoding again should return the same legacy-encoded rqid
+    const result = encodeLegacyWeaponSkillReferenceInRqid(usage);
 
-    expect((usage["skillRqidLink"] as any).rqid).toBe(
-      "i.skill.[Compendium.world.new-attack-type.Item.bite] / [embedded-bite]",
-    );
+    expect(result).toEqual({
+      rqid: "i.skill.[Compendium.world.new-attack-type.Item.bite] / [embedded-bite]",
+      name: "NOT-FOUND",
+    });
   });
 
   it("reads legacy references from system.usage fields", () => {
@@ -138,7 +149,7 @@ describe("weapon skill link handling", () => {
     });
   });
 
-  it("migration turns sentinel rqid into a valid rqid link", async () => {
+  it("migration turns legacy-encoded rqid into a valid rqid link", async () => {
     const originSkill = makeSkill({ id: "world-bite", name: "Bite", rqid: "i.skill.bite" });
     const actor = {
       name: "Actor",
@@ -193,7 +204,7 @@ describe("weapon skill link handling", () => {
     expect(Weapon.resolveLinkedSkill(weapon, "oneHand")).toBe(embeddedSkill);
   });
 
-  it("hasLinkedSkillReference returns false for sentinel rqid", () => {
+  it("hasLinkedSkillReference returns false for legacy-encoded rqid", () => {
     const weapon = makeWeapon({
       usage: {
         oneHand: {
@@ -208,7 +219,7 @@ describe("weapon skill link handling", () => {
     expect(Weapon.hasLinkedSkillReference(weapon, "oneHand")).toBe(false);
   });
 
-  it("resolveLinkedSkill returns undefined for sentinel rqid", () => {
+  it("resolveLinkedSkill returns undefined for legacy-encoded rqid", () => {
     const actor = {
       items: withItemGet([]),
       getBestEmbeddedDocumentByRqid: vi.fn(() => undefined),
@@ -230,15 +241,13 @@ describe("weapon skill link handling", () => {
     expect(actor.getBestEmbeddedDocumentByRqid).not.toHaveBeenCalled();
   });
 
-  it("does not overwrite a valid rqid with a sentinel", () => {
+  it("does not overwrite a valid rqid with a legacy-encoded rqid", () => {
     const usage: Record<string, unknown> = {
       skillOrigin: "Compendium.world.new-attack-type.Item.bite",
       skillId: "abc123",
       skillRqidLink: { rqid: "i.skill.bite", name: "Bite" },
     };
 
-    encodeLegacyWeaponSkillReferenceInRqid(usage);
-
-    expect((usage["skillRqidLink"] as any).rqid).toBe("i.skill.bite");
+    expect(encodeLegacyWeaponSkillReferenceInRqid(usage)).toBeUndefined();
   });
 });

--- a/src/items/weapon-item/weaponSkillLinks.test.ts
+++ b/src/items/weapon-item/weaponSkillLinks.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ItemTypeEnum } from "@item-model/itemTypes.ts";
+import { WeaponDataModel } from "@item-model/weaponDataModel.ts";
+import { ActorTypeEnum } from "../../data-model/actor-data/rqgActorData";
+import {
+  getLegacyWeaponSkillReference,
+  getLegacyWeaponSkillReferenceForUsage,
+  isLegacyWeaponSkillReferenceRqid,
+  legacyWeaponSkillRefsFlag,
+  parseLegacyWeaponSkillReference,
+  preserveLegacyWeaponSkillReference,
+} from "@item-model/weaponSkillLink.ts";
+import { Weapon } from "./weapon";
+import { migrateWeaponSkillLinks } from "../../system/migrations/migrations-item/migrateWeaponSkillLinks";
+
+type TestItemCollection = any[] & { get: (id: string) => any };
+
+function withItemGet(items: any[]): TestItemCollection {
+  const collection = [...items] as TestItemCollection;
+  collection.get = (id: string) => collection.find((item) => item.id === id || item._id === id);
+  return collection;
+}
+
+function makeSkill({ id, name, rqid }: { id: string; name: string; rqid?: string }): any {
+  return {
+    id,
+    _id: id,
+    type: ItemTypeEnum.Skill,
+    name,
+    system: { chance: 75 },
+    flags: rqid
+      ? {
+          rqg: {
+            documentRqidFlags: {
+              id: rqid,
+            },
+          },
+        }
+      : {},
+  };
+}
+
+function makeWeapon({ actor, usage }: { actor?: any; usage?: Record<string, any> } = {}): any {
+  const emptyUsage = {
+    skillRqidLink: undefined,
+    combatManeuvers: [],
+    damage: "",
+    minStrength: 0,
+    minDexterity: 0,
+    strikeRank: 0,
+  };
+
+  return {
+    type: ItemTypeEnum.Weapon,
+    actor,
+    system: {
+      usage: {
+        oneHand: { ...emptyUsage },
+        offHand: { ...emptyUsage },
+        twoHand: { ...emptyUsage },
+        missile: { ...emptyUsage },
+        ...usage,
+      },
+    },
+  };
+}
+
+describe("weapon skill link handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fromUuid).mockResolvedValue(null);
+  });
+
+  it("rejects legacy remembered payloads in the weapon rqid schema", () => {
+    const schema = WeaponDataModel.defineSchema();
+    const usageField: any = schema.usage;
+    const oneHandField: any = usageField.schema.oneHand;
+    const skillRqidLinkField: any = oneHandField.schema.skillRqidLink;
+    const validate = skillRqidLinkField.schema.rqid.options.validate as (value: string) => boolean;
+
+    expect(validate("i.skill.[Compendium.world.new-attack-type.Item.bite] / [abc123]")).toBe(false);
+  });
+
+  it("preserves legacy link data in dedicated migration fields", () => {
+    const usage: Record<string, unknown> = {
+      skillOrigin: "Compendium.world.new-attack-type.Item.bite",
+      skillId: "abc123",
+    };
+
+    const preserved = preserveLegacyWeaponSkillReference(usage);
+
+    expect(preserved).toEqual({
+      skillOrigin: "Compendium.world.new-attack-type.Item.bite",
+      skillId: "abc123",
+    });
+    expect(getLegacyWeaponSkillReference(usage)).toEqual({
+      skillOrigin: "Compendium.world.new-attack-type.Item.bite",
+      skillId: "abc123",
+    });
+  });
+
+  it("moves previously remembered legacy rqids into flags-based preservation input", () => {
+    const usage: Record<string, unknown> = {
+      skillRqidLink: {
+        rqid: "i.skill.[Compendium.world.new-attack-type.Item.bite] / [embedded-bite]",
+        name: "NOT-FOUND",
+      },
+    };
+
+    expect(isLegacyWeaponSkillReferenceRqid((usage["skillRqidLink"] as any).rqid)).toBe(true);
+    expect(parseLegacyWeaponSkillReference((usage["skillRqidLink"] as any).rqid)).toEqual({
+      skillOrigin: "Compendium.world.new-attack-type.Item.bite",
+      skillId: "embedded-bite",
+    });
+
+    const preserved = preserveLegacyWeaponSkillReference(usage);
+
+    expect(preserved).toEqual({
+      skillOrigin: "Compendium.world.new-attack-type.Item.bite",
+      skillId: "embedded-bite",
+    });
+    expect((usage["skillRqidLink"] as any).rqid).toBe("");
+  });
+
+  it("reads preserved legacy references from rqg flags first", () => {
+    const itemData: Record<string, unknown> = {
+      flags: {
+        rqg: {
+          [legacyWeaponSkillRefsFlag]: {
+            oneHand: {
+              skillOrigin: "Compendium.world.new-attack-type.Item.bite",
+              skillId: "embedded-bite",
+            },
+          },
+        },
+      },
+      system: {
+        usage: {
+          ["oneHand"]: {
+            skillOrigin: "Compendium.world.new-attack-type.Item.should-not-be-used",
+            skillId: "other-id",
+          },
+        },
+      },
+    };
+
+    expect(getLegacyWeaponSkillReferenceForUsage(itemData, "oneHand")).toEqual({
+      skillOrigin: "Compendium.world.new-attack-type.Item.bite",
+      skillId: "embedded-bite",
+    });
+  });
+
+  it("migration turns preserved legacy data into a valid rqid link and clears the migration fields", async () => {
+    const originSkill = makeSkill({ id: "world-bite", name: "Bite", rqid: "i.skill.bite" });
+    const actor = {
+      name: "Actor",
+      type: ActorTypeEnum.Character,
+      items: withItemGet([]),
+    };
+    vi.mocked(fromUuid).mockResolvedValue(originSkill);
+    const weapon = makeWeapon({
+      actor,
+      usage: {
+        oneHand: {
+          skillRqidLink: { rqid: "", name: "" },
+        },
+      },
+    });
+    weapon.flags = {
+      rqg: {
+        [legacyWeaponSkillRefsFlag]: {
+          oneHand: {
+            skillOrigin: "Compendium.world.new-attack-type.Item.bite",
+            skillId: "embedded-bite",
+          },
+        },
+      },
+    };
+
+    await expect(migrateWeaponSkillLinks(weapon, actor as any)).resolves.toMatchObject({
+      system: {
+        usage: {
+          oneHand: {
+            skillRqidLink: {
+              rqid: "i.skill.bite",
+              name: "Bite",
+            },
+          },
+        },
+      },
+      flags: {
+        rqg: {
+          [legacyWeaponSkillRefsFlag]: {
+            "-=oneHand": null,
+          },
+        },
+      },
+    });
+  });
+
+  it("resolves linked skills synchronously from valid embedded rqid links only", () => {
+    const embeddedSkill = makeSkill({ id: "embedded-bite", name: "Bite", rqid: "i.skill.bite" });
+    const actor = {
+      items: withItemGet([embeddedSkill]),
+      getBestEmbeddedDocumentByRqid: vi.fn((rqid: string | undefined) =>
+        rqid === "i.skill.bite" ? embeddedSkill : undefined,
+      ),
+    };
+
+    const weapon = makeWeapon({
+      actor,
+      usage: {
+        oneHand: {
+          skillRqidLink: { rqid: "i.skill.bite", name: "Bite" },
+        },
+      },
+    });
+
+    expect(Weapon.resolveLinkedSkill(weapon, "oneHand")).toBe(embeddedSkill);
+  });
+});

--- a/src/items/weapon-item/weaponSkillLinks.test.ts
+++ b/src/items/weapon-item/weaponSkillLinks.test.ts
@@ -3,12 +3,11 @@ import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import { WeaponDataModel } from "@item-model/weaponDataModel.ts";
 import { ActorTypeEnum } from "../../data-model/actor-data/rqgActorData";
 import {
+  encodeLegacyWeaponSkillReferenceInRqid,
   getLegacyWeaponSkillReference,
   getLegacyWeaponSkillReferenceForUsage,
   isLegacyWeaponSkillReferenceRqid,
-  legacyWeaponSkillRefsFlag,
   parseLegacyWeaponSkillReference,
-  preserveLegacyWeaponSkillReference,
 } from "@item-model/weaponSkillLink.ts";
 import { Weapon } from "./weapon";
 import { migrateWeaponSkillLinks } from "../../system/migrations/migrations-item/migrateWeaponSkillLinks";
@@ -71,35 +70,35 @@ describe("weapon skill link handling", () => {
     vi.mocked(fromUuid).mockResolvedValue(null);
   });
 
-  it("rejects legacy remembered payloads in the weapon rqid schema", () => {
+  it("accepts legacy sentinel payloads in the weapon rqid schema", () => {
     const schema = WeaponDataModel.defineSchema();
     const usageField: any = schema.usage;
     const oneHandField: any = usageField.schema.oneHand;
     const skillRqidLinkField: any = oneHandField.schema.skillRqidLink;
     const validate = skillRqidLinkField.schema.rqid.options.validate as (value: string) => boolean;
 
-    expect(validate("i.skill.[Compendium.world.new-attack-type.Item.bite] / [abc123]")).toBe(false);
+    expect(validate("i.skill.[Compendium.world.new-attack-type.Item.bite] / [abc123]")).toBe(true);
   });
 
-  it("preserves legacy link data in dedicated migration fields", () => {
+  it("encodes legacy link data into the rqid field", () => {
     const usage: Record<string, unknown> = {
       skillOrigin: "Compendium.world.new-attack-type.Item.bite",
       skillId: "abc123",
+      skillRqidLink: { rqid: "", name: "" },
     };
 
-    const preserved = preserveLegacyWeaponSkillReference(usage);
+    encodeLegacyWeaponSkillReferenceInRqid(usage);
 
-    expect(preserved).toEqual({
-      skillOrigin: "Compendium.world.new-attack-type.Item.bite",
-      skillId: "abc123",
-    });
+    expect((usage["skillRqidLink"] as any).rqid).toBe(
+      "i.skill.[Compendium.world.new-attack-type.Item.bite] / [abc123]",
+    );
     expect(getLegacyWeaponSkillReference(usage)).toEqual({
       skillOrigin: "Compendium.world.new-attack-type.Item.bite",
       skillId: "abc123",
     });
   });
 
-  it("moves previously remembered legacy rqids into flags-based preservation input", () => {
+  it("preserves existing sentinel in rqid field", () => {
     const usage: Record<string, unknown> = {
       skillRqidLink: {
         rqid: "i.skill.[Compendium.world.new-attack-type.Item.bite] / [embedded-bite]",
@@ -113,31 +112,20 @@ describe("weapon skill link handling", () => {
       skillId: "embedded-bite",
     });
 
-    const preserved = preserveLegacyWeaponSkillReference(usage);
+    // Encoding again should not change it
+    encodeLegacyWeaponSkillReferenceInRqid(usage);
 
-    expect(preserved).toEqual({
-      skillOrigin: "Compendium.world.new-attack-type.Item.bite",
-      skillId: "embedded-bite",
-    });
-    expect((usage["skillRqidLink"] as any).rqid).toBe("");
+    expect((usage["skillRqidLink"] as any).rqid).toBe(
+      "i.skill.[Compendium.world.new-attack-type.Item.bite] / [embedded-bite]",
+    );
   });
 
-  it("reads preserved legacy references from rqg flags first", () => {
+  it("reads legacy references from system.usage fields", () => {
     const itemData: Record<string, unknown> = {
-      flags: {
-        rqg: {
-          [legacyWeaponSkillRefsFlag]: {
-            oneHand: {
-              skillOrigin: "Compendium.world.new-attack-type.Item.bite",
-              skillId: "embedded-bite",
-            },
-          },
-        },
-      },
       system: {
         usage: {
           ["oneHand"]: {
-            skillOrigin: "Compendium.world.new-attack-type.Item.should-not-be-used",
+            skillOrigin: "Compendium.world.new-attack-type.Item.bite",
             skillId: "other-id",
           },
         },
@@ -146,11 +134,11 @@ describe("weapon skill link handling", () => {
 
     expect(getLegacyWeaponSkillReferenceForUsage(itemData, "oneHand")).toEqual({
       skillOrigin: "Compendium.world.new-attack-type.Item.bite",
-      skillId: "embedded-bite",
+      skillId: "other-id",
     });
   });
 
-  it("migration turns preserved legacy data into a valid rqid link and clears the migration fields", async () => {
+  it("migration turns sentinel rqid into a valid rqid link", async () => {
     const originSkill = makeSkill({ id: "world-bite", name: "Bite", rqid: "i.skill.bite" });
     const actor = {
       name: "Actor",
@@ -162,20 +150,13 @@ describe("weapon skill link handling", () => {
       actor,
       usage: {
         oneHand: {
-          skillRqidLink: { rqid: "", name: "" },
-        },
-      },
-    });
-    weapon.flags = {
-      rqg: {
-        [legacyWeaponSkillRefsFlag]: {
-          oneHand: {
-            skillOrigin: "Compendium.world.new-attack-type.Item.bite",
-            skillId: "embedded-bite",
+          skillRqidLink: {
+            rqid: "i.skill.[Compendium.world.new-attack-type.Item.bite] / [embedded-bite]",
+            name: "",
           },
         },
       },
-    };
+    });
 
     await expect(migrateWeaponSkillLinks(weapon, actor as any)).resolves.toMatchObject({
       system: {
@@ -185,13 +166,6 @@ describe("weapon skill link handling", () => {
               rqid: "i.skill.bite",
               name: "Bite",
             },
-          },
-        },
-      },
-      flags: {
-        rqg: {
-          [legacyWeaponSkillRefsFlag]: {
-            "-=oneHand": null,
           },
         },
       },
@@ -217,5 +191,54 @@ describe("weapon skill link handling", () => {
     });
 
     expect(Weapon.resolveLinkedSkill(weapon, "oneHand")).toBe(embeddedSkill);
+  });
+
+  it("hasLinkedSkillReference returns false for sentinel rqid", () => {
+    const weapon = makeWeapon({
+      usage: {
+        oneHand: {
+          skillRqidLink: {
+            rqid: "i.skill.[Compendium.world.attack.Item.bite] / [abc]",
+            name: "",
+          },
+        },
+      },
+    });
+
+    expect(Weapon.hasLinkedSkillReference(weapon, "oneHand")).toBe(false);
+  });
+
+  it("resolveLinkedSkill returns undefined for sentinel rqid", () => {
+    const actor = {
+      items: withItemGet([]),
+      getBestEmbeddedDocumentByRqid: vi.fn(() => undefined),
+    };
+
+    const weapon = makeWeapon({
+      actor,
+      usage: {
+        oneHand: {
+          skillRqidLink: {
+            rqid: "i.skill.[Compendium.world.attack.Item.bite] / [abc]",
+            name: "",
+          },
+        },
+      },
+    });
+
+    expect(Weapon.resolveLinkedSkill(weapon, "oneHand")).toBeUndefined();
+    expect(actor.getBestEmbeddedDocumentByRqid).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite a valid rqid with a sentinel", () => {
+    const usage: Record<string, unknown> = {
+      skillOrigin: "Compendium.world.new-attack-type.Item.bite",
+      skillId: "abc123",
+      skillRqidLink: { rqid: "i.skill.bite", name: "Bite" },
+    };
+
+    encodeLegacyWeaponSkillReferenceInRqid(usage);
+
+    expect((usage["skillRqidLink"] as any).rqid).toBe("i.skill.bite");
   });
 });

--- a/src/journals/rqgJournalEntry.ts
+++ b/src/journals/rqgJournalEntry.ts
@@ -1,5 +1,6 @@
 import { systemId } from "../system/config";
 import { Rqid } from "../system/api/rqidApi";
+import type { RqidString } from "../system/api/rqidApi";
 import { RqidLink } from "../data-model/shared/rqidLink";
 import { addRqidLinkToSheet } from "../documents/rqidSheetButton";
 
@@ -26,12 +27,12 @@ export class RqgJournalEntry extends JournalEntry {
   /**
    * Only handles embedded Pages
    */
-  public getEmbeddedDocumentsByRqid(rqid: string): JournalEntryPage[] {
+  public getEmbeddedDocumentsByRqid(rqid: RqidString): JournalEntryPage[] {
     // @ts-expect-error pages
     return this.pages.filter((i) => i.getFlag(systemId, "documentRqidFlags.id") === rqid);
   }
 
-  public getBestEmbeddedDocumentByRqid(rqid: string): JournalEntryPage | undefined {
+  public getBestEmbeddedDocumentByRqid(rqid: RqidString): JournalEntryPage | undefined {
     return this.getEmbeddedDocumentsByRqid(rqid).sort(Rqid.compareRqidPrio)[0];
   }
 }

--- a/src/system/api/nameGeneration.ts
+++ b/src/system/api/nameGeneration.ts
@@ -3,6 +3,7 @@ import Foswig from "foswig";
 import { RQG_CONFIG, systemId } from "../config";
 import { localize } from "../util";
 import { Rqid } from "./rqidApi";
+import { isValidRqidString } from "./rqidValidation";
 import {
   type DocumentRqidFlags,
   documentRqidFlags,
@@ -74,6 +75,9 @@ export class nameGeneration {
     }
 
     // Generate a name using Foswig
+    if (!isValidRqidString(rqid)) {
+      return [];
+    }
     const nameBase = await this.GetNameBase({ id: rqid });
 
     if (!nameBase) {
@@ -101,7 +105,7 @@ export class nameGeneration {
         result.push(chain.generate(mergedConstraints));
       } catch (error) {
         warn = true;
-        console.log(nameBaseNotLongEnoughMsg, error);
+        console.log(nameBaseNotLongEnoughMsg, nameBase, error);
       }
     }
     if (warn) {

--- a/src/system/api/rqidApi.ts
+++ b/src/system/api/rqidApi.ts
@@ -16,25 +16,82 @@ import {
 import Document = foundry.abstract.Document;
 import type { SkillItem } from "@item-model/skillDataModel.ts";
 import type { ArmorItem } from "@item-model/armorDataModel.ts";
+import type { RuneItem } from "@item-model/runeDataModel.ts";
+import type { PassionItem } from "@item-model/passionDataModel.ts";
+import type { RuneMagicItem } from "@item-model/runeMagicDataModel.ts";
+import type { WeaponItem } from "@item-model/weaponDataModel.ts";
+import type { GearItem } from "@item-model/gearDataModel.ts";
+import type { HitLocationItem } from "@item-model/hitLocationDataModel.ts";
+import type { CultItem } from "@item-model/cultDataModel.ts";
+import type { HomelandItem } from "@item-model/homelandDataModel.ts";
+import type { OccupationItem } from "@item-model/occupationDataModel.ts";
+import type { SpiritMagicItem } from "@item-model/spiritMagicDataModel.ts";
 import type { RqidEnabledDocument } from "../../global";
-
-// TODO Look into enhancing typing of rqid strings like this
-export type RqidString =
-  | `${string}.${string}.${string}`
-  | `${string}.${string}.${string}.${string}.${string}.${string}`;
 
 // Add a map from item-document-type (the second segment of an `i.xxx.yyy` rqid) to concrete TS types.
 // Extend this map with more concrete item types as you add them.
 type ItemTypeMap = {
   skill: SkillItem;
   armor: ArmorItem;
-  // add: weapon: WeaponItem; etc.
+  rune: RuneItem;
+  passion: PassionItem;
+  runeMagic: RuneMagicItem;
+  weapon: WeaponItem;
+  gear: GearItem;
+  hitLocation: HitLocationItem;
+  cult: CultItem;
+  homeland: HomelandItem;
+  occupation: OccupationItem;
+  spiritMagic: SpiritMagicItem;
 };
+
+type CamelToKebab<S extends string> = S extends `${infer First}${infer Rest}`
+  ? Rest extends Uncapitalize<Rest>
+    ? `${Lowercase<First>}${CamelToKebab<Rest>}`
+    : `${Lowercase<First>}-${CamelToKebab<Rest>}`
+  : S;
+
+type ItemSubtypeMap = {
+  [K in keyof ItemTypeMap as CamelToKebab<K & string>]: ItemTypeMap[K];
+};
+
+const RQID_DOCUMENT_DEFINITIONS = {
+  a: { documentName: "Actor", gameProperty: "actors", iconConfig: "Actor" },
+  c: { documentName: "Card", gameProperty: "cards", iconConfig: "Cards" },
+  i: { documentName: "Item", gameProperty: "items", iconConfig: "Item" },
+  je: { documentName: "JournalEntry", gameProperty: "journal", iconConfig: "JournalEntry" },
+  jp: { documentName: "JournalEntryPage", iconConfig: "JournalEntryPage" },
+  m: { documentName: "Macro", gameProperty: "macros", iconConfig: "Macro" },
+  p: { documentName: "Playlist", gameProperty: "playlists", iconConfig: "Playlist" },
+  rt: { documentName: "RollTable", gameProperty: "tables", iconConfig: "RollTable" },
+  s: { documentName: "Scene", gameProperty: "scenes", iconConfig: "Scene" },
+} as const;
+
+type RqidDocumentName = keyof typeof RQID_DOCUMENT_DEFINITIONS;
+type NonItemRqidDocumentName = Exclude<RqidDocumentName, "i">;
+type ItemRqidString = `i.${keyof ItemSubtypeMap}.${string}`;
+type DocumentRqidString = ItemRqidString | `${NonItemRqidDocumentName}.${string}.${string}`;
+
+/**
+ * A typed rqid string.
+ *
+ * Supports:
+ * - top-level document rqids (`i.skill.jump`, `a.character.sartar`)
+ * - embedded rqids (`a.character.sartar.i.skill.jump`)
+ */
+export type RqidString = DocumentRqidString | `${DocumentRqidString}.${DocumentRqidString}`;
+
+/** Runtime validator for rqid document name (first segment), including item document `i`. */
+export function isRqidDocumentName(value: unknown): value is RqidDocumentName {
+  return typeof value === "string" && Object.hasOwn(RQID_DOCUMENT_DEFINITIONS, value);
+}
 
 // Resolve an item rqid's ItemType segment to a concrete Item subtype
 type ItemRqidToDocument<ItemType extends string> = ItemType extends keyof ItemTypeMap
   ? ItemTypeMap[ItemType]
-  : Item; // fallback to generic Item when specific mapping missing
+  : ItemType extends keyof ItemSubtypeMap
+    ? ItemSubtypeMap[ItemType]
+    : Item; // fallback to generic Item when specific mapping missing
 
 // Map an rqid literal to a narrower Document type
 type RqidToDocument<R extends string> = R extends `i.${infer ItemType}.${string}`
@@ -157,7 +214,7 @@ export class Rqid {
    */
   public static async fromRqidRegex(
     rqidRegex: RegExp | undefined,
-    rqidDocumentName: string | undefined, // like "i", "a", "je"
+    rqidDocumentName: RqidDocumentName | undefined, // like "i", "a", "je"
     lang: string = CONFIG.RQG.fallbackLanguage,
     options: RqidRegexSearchOptions = {},
   ): Promise<RqidEnabledDocument[]> {
@@ -195,7 +252,7 @@ export class Rqid {
    */
   public static async fromRqidRegexBest(
     rqidRegex: RegExp | undefined,
-    rqidDocumentName: string, // like "i", "a", "je"
+    rqidDocumentName: RqidDocumentName, // like "i", "a", "je"
     lang: string = CONFIG.RQG.fallbackLanguage,
   ): Promise<RqidEnabledDocument[]> {
     return this.fromRqidRegex(rqidRegex, rqidDocumentName, lang, {
@@ -321,7 +378,7 @@ export class Rqid {
   /**
    * Given a Document, create a valid rqid string for the document.
    */
-  public static getDefaultRqid(document: RqidEnabledDocument | Document.Any): string {
+  public static getDefaultRqid(document: RqidEnabledDocument | Document.Any): RqidString | "" {
     if (!document.name) {
       return "";
     }
@@ -352,13 +409,13 @@ export class Rqid {
       rqidIdentifier = trimChars(toKebabCase(document.name), "-");
     }
 
-    return `${rqidDocumentString}.${documentSubType}.${rqidIdentifier}`;
+    return `${rqidDocumentString}.${documentSubType}.${rqidIdentifier}` as RqidString;
   }
 
   /**
    * Render the sheet of the documents the rqid points to and brings it to top.
    */
-  public static async renderRqidDocument(rqid: string, anchor?: string): Promise<void> {
+  public static async renderRqidDocument(rqid: RqidString, anchor?: string): Promise<void> {
     const document = await Rqid.fromRqid(rqid);
     if (document == null) {
       return;
@@ -382,7 +439,7 @@ export class Rqid {
    */
   public static async setRqid(
     document: RqidEnabledDocument,
-    newRqid: string,
+    newRqid: RqidString,
     lang: string = CONFIG.RQG.fallbackLanguage,
     priority: number = 0,
   ): Promise<DocumentRqidFlags> {
@@ -486,7 +543,7 @@ export class Rqid {
    */
   private static async documentsFromWorld(
     rqidRegex: RegExp | undefined,
-    rqidDocumentName: string,
+    rqidDocumentName: RqidDocumentName,
     lang: string,
   ): Promise<RqidEnabledDocument[]> {
     if (!rqidRegex) {
@@ -611,7 +668,7 @@ export class Rqid {
    */
   private static async documentsFromPacks(
     rqidRegex: RegExp,
-    rqidDocumentName: string,
+    rqidDocumentName: RqidDocumentName,
     lang: string,
   ): Promise<RqidEnabledDocument[]> {
     if (!rqidRegex) {
@@ -700,17 +757,12 @@ export class Rqid {
     return `<i class="${linkIcon}"></i>`;
   }
 
-  private static readonly documentLinkIconsConfigName = new Map([
-    ["a", "Actor"],
-    ["c", "Cards"],
-    ["i", "Item"],
-    ["je", "JournalEntry"],
-    ["jp", "JournalEntryPage"],
-    ["m", "Macro"],
-    ["p", "Playlist"],
-    ["rt", "RollTable"],
-    ["s", "Scene"],
-  ]);
+  private static readonly documentLinkIconsConfigName = new Map(
+    Object.entries(RQID_DOCUMENT_DEFINITIONS).map(([rqidDocumentName, definition]) => [
+      rqidDocumentName,
+      definition.iconConfig,
+    ]),
+  );
 
   /**
    * Sort a list of indexCandidates on rqid priority - the highest first.
@@ -745,16 +797,16 @@ export class Rqid {
     return game[prop as keyof typeof game] as WorldCollection<Document.WorldType> | undefined;
   }
 
-  private static readonly gamePropertyLookup: { [rqidDocumentName: string]: string } = {
-    a: "actors",
-    c: "cards",
-    i: "items",
-    je: "journal",
-    m: "macros",
-    p: "playlists",
-    rt: "tables",
-    s: "scenes",
-  };
+  private static readonly gamePropertyLookup: { [rqidDocumentName: string]: string } =
+    Object.entries(RQID_DOCUMENT_DEFINITIONS).reduce(
+      (acc: { [rqidDocumentName: string]: string }, [rqidDocumentName, definition]) => {
+        if ("gameProperty" in definition) {
+          acc[rqidDocumentName] = definition.gameProperty;
+        }
+        return acc;
+      },
+      {},
+    );
 
   /**
    *   Translates the first part of a rqid to a Foundry document name (like "Item").
@@ -769,17 +821,14 @@ export class Rqid {
     return documentName;
   }
 
-  private static readonly documentNameLookup: { [rqidDocumentName: string]: string } = {
-    a: "Actor",
-    c: "Card",
-    i: "Item",
-    je: "JournalEntry",
-    jp: "JournalEntryPage", // Only allowed as embedded in JournalEntry
-    m: "Macro",
-    p: "Playlist",
-    rt: "RollTable",
-    s: "Scene",
-  };
+  private static readonly documentNameLookup: { [rqidDocumentName: string]: string } =
+    Object.entries(RQID_DOCUMENT_DEFINITIONS).reduce(
+      (acc: { [rqidDocumentName: string]: string }, [rqidDocumentName, definition]) => {
+        acc[rqidDocumentName] = definition.documentName;
+        return acc;
+      },
+      {},
+    );
 
   /**
    * Get the document type from the rqid if it exists. For example i.skill.act returns "skill".

--- a/src/system/api/rqidValidation.ts
+++ b/src/system/api/rqidValidation.ts
@@ -1,0 +1,51 @@
+import type { RqidString } from "./rqidApi";
+
+const ITEM_SUBTYPES = [
+  "skill",
+  "armor",
+  "rune",
+  "passion",
+  "rune-magic",
+  "weapon",
+  "gear",
+  "hit-location",
+  "cult",
+  "homeland",
+  "occupation",
+  "spirit-magic",
+] as const;
+
+const NON_ITEM_RQID_PREFIX_PATTERN = "(?:a|c|je|jp|m|p|rt|s)";
+const DOC_RQID_PATTERN = `(?:${NON_ITEM_RQID_PREFIX_PATTERN}\\.[^.]*\\.[^.]+|i\\.(${ITEM_SUBTYPES.join("|")})\\.[^.]+)`;
+
+const ITEM_PATTERN = new RegExp(`^i\\.(${ITEM_SUBTYPES.join("|")})\\.[^.]+$`);
+const NON_ITEM_PATTERN = new RegExp(`^${NON_ITEM_RQID_PREFIX_PATTERN}\\.[^.]*\\.[^.]+$`);
+const EMBEDDED_PATTERN = new RegExp(`^${DOC_RQID_PATTERN}\\.${DOC_RQID_PATTERN}$`);
+
+export function isValidRqidString(value: unknown): value is RqidString;
+export function isValidRqidString(
+  value: unknown,
+  options: { allowEmpty: true },
+): value is RqidString | "";
+export function isValidRqidString(value: unknown, options: { allowEmpty?: boolean } = {}): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+  if (value === "") {
+    return options.allowEmpty === true;
+  }
+
+  return !!(
+    value.match(ITEM_PATTERN) ||
+    value.match(NON_ITEM_PATTERN) ||
+    value.match(EMBEDDED_PATTERN)
+  );
+}
+
+/**
+ * Normalize any value to a valid RqidString or undefined.
+ * Empty string and invalid values are treated as "not set".
+ */
+export function toRqidString(value: unknown): RqidString | undefined {
+  return isValidRqidString(value) ? value : undefined;
+}

--- a/src/system/api/rqidValidation.ts
+++ b/src/system/api/rqidValidation.ts
@@ -1,4 +1,5 @@
 import type { RqidString } from "./rqidApi";
+import { isLegacyWeaponSkillReferenceRqid } from "../../data-model/item-data/weaponSkillLink";
 
 const ITEM_SUBTYPES = [
   "skill",
@@ -38,14 +39,18 @@ export function isValidRqidString(value: unknown, options: { allowEmpty?: boolea
   return !!(
     value.match(ITEM_PATTERN) ||
     value.match(NON_ITEM_PATTERN) ||
-    value.match(EMBEDDED_PATTERN)
+    value.match(EMBEDDED_PATTERN) ||
+    isLegacyWeaponSkillReferenceRqid(value)
   );
 }
 
 /**
  * Normalize any value to a valid RqidString or undefined.
- * Empty string and invalid values are treated as "not set".
+ * Empty string, invalid values, and legacy sentinel patterns are treated as "not set".
  */
 export function toRqidString(value: unknown): RqidString | undefined {
+  if (isLegacyWeaponSkillReferenceRqid(value)) {
+    return undefined;
+  }
   return isValidRqidString(value) ? value : undefined;
 }

--- a/src/system/api/rqidValidation.ts
+++ b/src/system/api/rqidValidation.ts
@@ -46,7 +46,7 @@ export function isValidRqidString(value: unknown, options: { allowEmpty?: boolea
 
 /**
  * Normalize any value to a valid RqidString or undefined.
- * Empty string, invalid values, and legacy sentinel patterns are treated as "not set".
+ * Empty string, invalid values, and legacy-encoded rqid patterns are treated as "not set".
  */
 export function toRqidString(value: unknown): RqidString | undefined {
   if (isLegacyWeaponSkillReferenceRqid(value)) {

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -1,3 +1,5 @@
+import type { RqidString } from "./api/rqidApi";
+
 export const RQG_CONFIG = {
   debug: {
     showActorActiveEffectsTab: false,
@@ -6,28 +8,28 @@ export const RQG_CONFIG = {
 
   // Skill items that need special handling
   skillRqid: {
-    dodge: "i.skill.dodge",
-    jump: "i.skill.jump",
-    worship: "i.skill.worship",
-    moveQuietly: "i.skill.move-quietly",
-    spiritCombat: "i.skill.spirit-combat",
+    dodge: "i.skill.dodge" as RqidString,
+    jump: "i.skill.jump" as RqidString,
+    worship: "i.skill.worship" as RqidString,
+    moveQuietly: "i.skill.move-quietly" as RqidString,
+    spiritCombat: "i.skill.spirit-combat" as RqidString,
   },
 
   // Rune items that need special handling
   runeRqid: {
-    magic: "i.rune.magic-condition",
+    magic: "i.rune.magic-condition" as RqidString,
   },
 
   bodytypes: {
     humanoid: [
-      "i.hit-location.head",
-      "i.hit-location.left-arm",
-      "i.hit-location.right-arm",
-      "i.hit-location.chest",
-      "i.hit-location.abdomen",
-      "i.hit-location.left-leg",
-      "i.hit-location.right-leg",
-    ],
+      "i.hit-location.head" as RqidString,
+      "i.hit-location.left-arm" as RqidString,
+      "i.hit-location.right-arm" as RqidString,
+      "i.hit-location.chest" as RqidString,
+      "i.hit-location.abdomen" as RqidString,
+      "i.hit-location.left-leg" as RqidString,
+      "i.hit-location.right-leg" as RqidString,
+    ] as RqidString[],
   },
 
   fallbackLanguage: "en",

--- a/src/system/migrations/migrations-item/migrateWeaponSkillLinks.ts
+++ b/src/system/migrations/migrations-item/migrateWeaponSkillLinks.ts
@@ -7,7 +7,6 @@ import { isDocumentSubType } from "../../util.ts";
 import type { RqgActor } from "@actors/rqgActor.ts";
 import {
   getLegacyWeaponSkillReferenceForUsage,
-  legacyWeaponSkillRefsFlag,
   type LegacyWeaponSkillRef,
 } from "../../../data-model/item-data/weaponSkillLink.ts";
 
@@ -23,14 +22,10 @@ export async function migrateWeaponSkillLinks(
   ) {
     const usageTypes: UsageType[] = ["oneHand", "offHand", "twoHand", "missile"];
     const usageUpdates: Record<string, unknown> = {};
-    const clearLegacyFlags: Record<string, null> = {};
 
     for (const usageType of usageTypes) {
       const usageUpdate = await getUsageMigrationUpdate(itemData, owningActorData, usageType);
-      usageUpdates[usageType] = usageUpdate.usageUpdate;
-      if (usageUpdate.clearLegacyFlag) {
-        clearLegacyFlags[`-=${usageType}`] = null;
-      }
+      usageUpdates[usageType] = usageUpdate;
     }
 
     updateData = {
@@ -38,14 +33,6 @@ export async function migrateWeaponSkillLinks(
         usage: usageUpdates,
       },
     } as any; // Migration uses Foundry's `-=field` delete syntax which doesn't exist in DataModel types
-
-    if (Object.keys(clearLegacyFlags).length > 0) {
-      (updateData as any).flags = {
-        rqg: {
-          [legacyWeaponSkillRefsFlag]: clearLegacyFlags,
-        },
-      };
-    }
   }
   return updateData;
 }
@@ -54,10 +41,10 @@ async function getUsageMigrationUpdate(
   itemData: WeaponItem,
   owningActorData: CharacterActor | undefined,
   usageType: UsageType,
-): Promise<{ usageUpdate: Record<string, unknown>; clearLegacyFlag: boolean }> {
+): Promise<Record<string, unknown>> {
   const legacySkillRef = getLegacyWeaponSkillReferenceForUsage(itemData, usageType);
   if (!legacySkillRef?.skillOrigin && !legacySkillRef?.skillId) {
-    return { usageUpdate: {}, clearLegacyFlag: false };
+    return {};
   }
 
   const currentSkillItem = await findSkillItem(
@@ -75,21 +62,15 @@ async function getUsageMigrationUpdate(
     ui.notifications?.warn(msg, { console: false });
     console.warn("RQG |", msg);
     return {
-      usageUpdate: {
-        [`-=skillOrigin`]: null,
-        [`-=skillId`]: null,
-      },
-      clearLegacyFlag: false,
+      [`-=skillOrigin`]: null,
+      [`-=skillId`]: null,
     };
   }
 
   return {
-    usageUpdate: {
-      [`-=skillOrigin`]: null,
-      [`-=skillId`]: null,
-      skillRqidLink: new RqidLink(currentRqid, currentSkillItem.name ?? ""),
-    },
-    clearLegacyFlag: true,
+    [`-=skillOrigin`]: null,
+    [`-=skillId`]: null,
+    skillRqidLink: new RqidLink(currentRqid, currentSkillItem.name ?? ""),
   };
 }
 

--- a/src/system/migrations/migrations-item/migrateWeaponSkillLinks.ts
+++ b/src/system/migrations/migrations-item/migrateWeaponSkillLinks.ts
@@ -5,8 +5,12 @@ import { ActorTypeEnum, type CharacterActor } from "../../../data-model/actor-da
 import type { RqgItem } from "@items/rqgItem.ts";
 import { isDocumentSubType } from "../../util.ts";
 import type { RqgActor } from "@actors/rqgActor.ts";
+import {
+  getLegacyWeaponSkillReferenceForUsage,
+  legacyWeaponSkillRefsFlag,
+  type LegacyWeaponSkillRef,
+} from "../../../data-model/item-data/weaponSkillLink.ts";
 
-const notFoundString = "NOT-FOUND";
 // Migrate weapon item usage from skillOrigin & skillId to skillRqidLink
 export async function migrateWeaponSkillLinks(
   itemData: RqgItem,
@@ -17,110 +21,90 @@ export async function migrateWeaponSkillLinks(
     isDocumentSubType<WeaponItem>(itemData, ItemTypeEnum.Weapon) &&
     isDocumentSubType<CharacterActor>(owningActorData, ActorTypeEnum.Character)
   ) {
-    const oneHandSkillRqidLink = await getSkillRqidLink(itemData, owningActorData, "oneHand");
-    const offHandSkillRqidLink = await getSkillRqidLink(itemData, owningActorData, "offHand");
-    const twoHandSkillRqidLink = await getSkillRqidLink(itemData, owningActorData, "twoHand");
-    const missileSkillRqidLink = await getSkillRqidLink(itemData, owningActorData, "missile");
+    const usageTypes: UsageType[] = ["oneHand", "offHand", "twoHand", "missile"];
+    const usageUpdates: Record<string, unknown> = {};
+    const clearLegacyFlags: Record<string, null> = {};
+
+    for (const usageType of usageTypes) {
+      const usageUpdate = await getUsageMigrationUpdate(itemData, owningActorData, usageType);
+      usageUpdates[usageType] = usageUpdate.usageUpdate;
+      if (usageUpdate.clearLegacyFlag) {
+        clearLegacyFlags[`-=${usageType}`] = null;
+      }
+    }
 
     updateData = {
       system: {
-        usage: {
-          oneHand: {
-            [`-=skillOrigin`]: null,
-            [`-=skillId`]: null,
-            skillRqidLink: oneHandSkillRqidLink,
-          },
-          offHand: {
-            [`-=skillOrigin`]: null,
-            [`-=skillId`]: null,
-            skillRqidLink: offHandSkillRqidLink,
-          },
-          twoHand: {
-            [`-=skillOrigin`]: null,
-            [`-=skillId`]: null,
-            skillRqidLink: twoHandSkillRqidLink,
-          },
-          missile: {
-            [`-=skillOrigin`]: null,
-            [`-=skillId`]: null,
-            skillRqidLink: missileSkillRqidLink,
-          },
-        },
+        usage: usageUpdates,
       },
     } as any; // Migration uses Foundry's `-=field` delete syntax which doesn't exist in DataModel types
+
+    if (Object.keys(clearLegacyFlags).length > 0) {
+      (updateData as any).flags = {
+        rqg: {
+          [legacyWeaponSkillRefsFlag]: clearLegacyFlags,
+        },
+      };
+    }
   }
   return updateData;
 }
 
-async function getSkillRqidLink(
+async function getUsageMigrationUpdate(
   itemData: WeaponItem,
   owningActorData: CharacterActor | undefined,
   usageType: UsageType,
-): Promise<RqidLink | undefined> {
-  if (
-    itemData.type !== ItemTypeEnum.Weapon.toString() ||
-    (foundry.utils.isEmpty((itemData.system.usage[usageType] as any).skillOrigin) &&
-      itemData.system.usage[usageType].skillRqidLink?.name !== notFoundString)
-  ) {
-    return;
+): Promise<{ usageUpdate: Record<string, unknown>; clearLegacyFlag: boolean }> {
+  const legacySkillRef = getLegacyWeaponSkillReferenceForUsage(itemData, usageType);
+  if (!legacySkillRef?.skillOrigin && !legacySkillRef?.skillId) {
+    return { usageUpdate: {}, clearLegacyFlag: false };
   }
 
-  const currentSkillItem = await findSkillItem(itemData, owningActorData, usageType);
-  if (!currentSkillItem && !(itemData.system as any).usage[usageType].skillOrigin) {
-    return;
-  }
+  const currentSkillItem = await findSkillItem(
+    itemData,
+    owningActorData,
+    usageType,
+    legacySkillRef,
+  );
   const currentRqid = currentSkillItem?.flags?.rqg?.documentRqidFlags?.id;
+
   if (!currentRqid) {
     const msg = owningActorData
-      ? `Weapon item [${
-          itemData.name
-        }] carried by [${owningActorData?.name}] has a linked skill item for ${usageType} use that does not have a rqid. Old link was [${
-          (itemData.system as any).usage[usageType].skillOrigin
-        }]`
-      : `World weapon item [${
-          itemData.name
-        }] has a linked skill item for ${usageType} use that does not have a rqid. Old link was [${
-          (itemData.system as any).usage[usageType].skillOrigin
-        }]`;
+      ? `Weapon item [${itemData.name}] carried by [${owningActorData?.name}] still has an unresolved legacy linked skill for ${usageType} use. Old link was [${legacySkillRef.skillOrigin ?? ""}]`
+      : `World weapon item [${itemData.name}] still has an unresolved legacy linked skill for ${usageType} use. Old link was [${legacySkillRef.skillOrigin ?? ""}]`;
     ui.notifications?.warn(msg, { console: false });
     console.warn("RQG |", msg);
+    return {
+      usageUpdate: {
+        [`-=skillOrigin`]: null,
+        [`-=skillId`]: null,
+      },
+      clearLegacyFlag: false,
+    };
   }
-  return currentRqid
-    ? new RqidLink(currentRqid, currentSkillItem.name ?? "")
-    : new RqidLink(
-        `i.skill.[${(itemData.system as any).usage[usageType].skillOrigin}] / [${
-          (itemData.system as any).usage[usageType].skillId
-        }]`,
-        notFoundString,
-      );
+
+  return {
+    usageUpdate: {
+      [`-=skillOrigin`]: null,
+      [`-=skillId`]: null,
+      skillRqidLink: new RqidLink(currentRqid, currentSkillItem.name ?? ""),
+    },
+    clearLegacyFlag: true,
+  };
 }
 
 async function findSkillItem(
   itemData: WeaponItem,
   owningActorData: CharacterActor | undefined,
   usageType: UsageType,
+  legacySkillRef: LegacyWeaponSkillRef | undefined,
 ): Promise<any | undefined> {
   if (itemData.type !== ItemTypeEnum.Weapon.toString()) {
     return;
   }
 
-  let skillOriginUuid = (itemData.system.usage[usageType] as any).skillOrigin;
-  let skillEmbeddedItemId = (itemData.system.usage[usageType] as any).skillId;
-
-  if (
-    !skillOriginUuid &&
-    (itemData.system.usage[usageType] as any)?.skillRqidLink?.name === notFoundString
-  ) {
-    const notFoundMatch = (itemData.system.usage[usageType] as any)?.skillRqidLink?.rqid.match(
-      /^i\.skill\.\[(?<skillOrigin>.*)] \/ \[(?<itemId>.*)]$/,
-    );
-
-    if (notFoundMatch) {
-      const { skillOrigin, itemId } = notFoundMatch.groups;
-      skillOriginUuid = skillOrigin;
-      skillEmbeddedItemId = itemId;
-    }
-  }
+  const skillOriginUuid = legacySkillRef?.skillOrigin;
+  const skillEmbeddedItemId = legacySkillRef?.skillId;
 
   const skillOriginItem = await fromUuid(skillOriginUuid ?? "");
   if (skillOriginItem) {

--- a/src/system/migrations/migrations-item/relabelRuneMagicCommandCultSpiritRqid.ts
+++ b/src/system/migrations/migrations-item/relabelRuneMagicCommandCultSpiritRqid.ts
@@ -50,24 +50,20 @@ export async function relabelRuneMagicCommandCultSpiritRqid(
   }
 
   if (isDocumentSubType<CultItem>(itemData, ItemTypeEnum.Cult)) {
-    const commandCultSpiritLink = itemData.system.commonRuneMagicRqidLinks.find(
-      (link) => link.rqid === oldRqid,
-    );
+    // Cast to RqidLink[] to allow comparison with legacy hyphenated rqid format
+    const links = itemData.system.commonRuneMagicRqidLinks as RqidLink[];
+    const commandCultSpiritLink = links.find((link) => link.rqid === oldRqid);
     if (commandCultSpiritLink) {
       const newName =
         commandCultSpiritLink.name === oldEnglishName ? newEnglishName : commandCultSpiritLink.name;
 
       const newCommandCultSpiritLink = new RqidLink(newRqid, newName);
       newCommandCultSpiritLink.bonus = undefined;
-      const index = itemData.system.commonRuneMagicRqidLinks.indexOf(commandCultSpiritLink);
-      itemData.system.commonRuneMagicRqidLinks.splice(
-        index,
-        1,
-        newCommandCultSpiritLink as typeof commandCultSpiritLink,
-      );
+      const index = links.indexOf(commandCultSpiritLink);
+      links.splice(index, 1, newCommandCultSpiritLink);
 
       foundry.utils.mergeObject(updateData, {
-        system: { commonRuneMagicRqidLinks: itemData.system.commonRuneMagicRqidLinks },
+        system: { commonRuneMagicRqidLinks: links },
       });
     }
   }

--- a/src/system/migrations/migrations-item/tagSkillNameSkillsWithRqid.ts
+++ b/src/system/migrations/migrations-item/tagSkillNameSkillsWithRqid.ts
@@ -2,6 +2,7 @@ import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import { isDocumentSubType } from "../../util.ts";
 import type { SkillItem } from "@item-model/skillDataModel.ts";
 import type { RqgItem } from "@items/rqgItem.ts";
+import type { RqidString } from "../../api/rqidApi";
 
 // Give the "special" skills a rqid, so they can be referenced by rqid instead of name.
 export async function tagSkillNameSkillsWithRqid(itemData: RqgItem): Promise<Item.UpdateData> {
@@ -14,7 +15,9 @@ export async function tagSkillNameSkillsWithRqid(itemData: RqgItem): Promise<Ite
       flags: {
         rqg: {
           documentRqidFlags: {
-            id: itemData?.flags?.rqg?.documentRqidFlags?.id || name2Rqid.get(itemData.name),
+            id: (itemData?.flags?.rqg?.documentRqidFlags?.id || name2Rqid.get(itemData.name)) as
+              | RqidString
+              | undefined,
             lang: itemData?.flags?.rqg?.documentRqidFlags?.lang || CONFIG.RQG.fallbackLanguage,
             priority: itemData?.flags?.rqg?.documentRqidFlags?.priority || 0,
           },


### PR DESCRIPTION
## Summary

- **Type rqids**: Replaced loose `string` types with `RqidString` throughout — document flags, actor methods, rqid links, context menus, editors, and DataModel fields. Added `RqidLink<R>` generic to constrain rqid links in DataModels (e.g. `RqidLink<`i.rune.${string}`>`).
- **Extracted rqid validation**: New `rqidValidation.ts` with `isValidRqidString()` and `toRqidString()` to centralize validation and type narrowing.
- **Preserved legacy weapon skill links**: Legacy weapon skill references (`skillOrigin`/`skillId`) are encoded as a legacy-encoded rqid (`i.skill.[skillOrigin] / [skillId]`) in `skillRqidLink.rqid` during `migrateData`, where they survive Foundry v14's schema cleaning. `toRqidString()` filters them out so runtime code treats them as unset. The async migration resolves them to real rqids when the skill can be found.
- **Hardened rqid batch editor**: Validates rqids before writing to document flags instead of accepting arbitrary strings.
- **Hardened context menus**: Read description rqid from live item data instead of DOM dataset attributes.
- **Added `isRqidDocumentName()` guard** in rqid editor to prevent invalid prefix lookups.

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — 243 tests pass (10 weapon skill link tests covering encoding, migration, runtime guards, edge cases)
- [x] `pnpm build` — lint + build pass
- [x] Manual: open a world with weapons that have legacy `skillOrigin`/`skillId` fields, verify migration resolves them
- [x] Manual: verify context menu "View Description" works on cult/rune/skill items