### PR TITLE
refactor(combat): replace any with concrete Foundry types

### DIFF
--- a/src/combat/RqgCombatTracker.ts
+++ b/src/combat/RqgCombatTracker.ts
@@ -115,7 +115,9 @@ export class RqgCombatTracker extends CombatTracker {
         callback: async (li: HTMLElement) => {
           const combatant = getCombatant(li);
           if (combatant) {
-            const combatantIds = getCombatantsSharingToken(combatant).map((c: any) => c.id);
+            const combatantIds = getCombatantsSharingToken(combatant)
+              .map((c) => c.id)
+              .filter((id): id is string => id != null);
             if (combatantIds.length > 1) {
               const indexToKeep = combatantIds.indexOf(combatant.id);
               combatantIds.splice(indexToKeep, 1); // Keep the selected combatant

--- a/src/combat/RqgTokenRuler.ts
+++ b/src/combat/RqgTokenRuler.ts
@@ -1,13 +1,16 @@
 import { systemId } from "../system/config";
 import type { TokenRulerSettingsType } from "../applications/settings/tokenRulerSettings.types";
-import type { CharacterActor } from "../data-model/actor-data/rqgActorData";
+import { ActorTypeEnum, type CharacterActor } from "../data-model/actor-data/rqgActorData";
+import { isDocumentSubType } from "../system/util";
 
 export class RqgTokenRuler extends foundry.canvas.placeables.tokens.TokenRuler {
   static init() {
     CONFIG.Token.rulerClass = RqgTokenRuler;
   }
 
-  override _getSegmentStyle(waypoint: any): any {
+  override _getSegmentStyle(
+    waypoint: foundry.canvas.placeables.tokens.TokenRuler.Waypoint,
+  ): Ruler.SegmentStyle {
     const style = super._getSegmentStyle(waypoint);
     this.#rangeValueStyle(style, waypoint);
     return style;
@@ -16,17 +19,21 @@ export class RqgTokenRuler extends foundry.canvas.placeables.tokens.TokenRuler {
   /**
    * Adjusts the grid or segment style based on the token's movement characteristics
    */
-  #rangeValueStyle(style: any, waypoint: any) {
+  #rangeValueStyle(
+    style: Ruler.SegmentStyle,
+    waypoint: foundry.canvas.placeables.tokens.TokenRuler.Waypoint,
+  ) {
     if (!this.token.combatant) {
       // Only show the waypoints for tokens that are in combat.
       style.width = 0;
       return;
     }
     const tokenMovementAction = waypoint.action;
-    const actorAttributes = (this.token.actor as CharacterActor | undefined)?.system?.attributes;
-    if (!actorAttributes) {
+    const actor = this.token.actor;
+    if (!isDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character)) {
       return;
     }
+    const actorAttributes = actor.system.attributes;
     // TODO Duplicated from RqgActor, make more DRY
     const equippedMovementEncumbrancePenalty = Math.min(
       0,

--- a/src/combat/combatant-utils.ts
+++ b/src/combat/combatant-utils.ts
@@ -9,7 +9,7 @@ export function getCombatantsSharingToken(combatant: Combatant.Stored | undefine
   const combatantTokenIds = combatant.actor
     .getDependentTokens({ scenes: scene })
     .map((t: TokenDocument) => t.id);
-  return combatant.parent.combatants.filter((cb: any) => combatantTokenIds.includes(cb.tokenId));
+  return combatant.parent.combatants.filter((cb) => combatantTokenIds.includes(cb.tokenId));
 }
 
 /**

--- a/src/combat/rqgCombat.ts
+++ b/src/combat/rqgCombat.ts
@@ -16,7 +16,7 @@ export class RqgCombat extends Combat {
   /**
    * Reset all combatant SR, remove duplicate combatants and set the turn back to zero
    */
-  override async resetAll({ updateTurn = true } = {}): Promise<any> {
+  override async resetAll({ updateTurn = true } = {}): Promise<this | undefined> {
     const currentId = this.combatant?.id;
     const tokenIds = new Set(); // --- RQG code
     const combatantIdsToDelete = []; // --- RQG code
@@ -32,12 +32,15 @@ export class RqgCombat extends Combat {
       }
       // --- end RQG code ---
     }
-    const update: any = { combatants: this.combatants.toObject() };
+    const update: { combatants: object[]; turn?: number } = {
+      combatants: this.combatants.toObject(),
+    };
     if (updateTurn && currentId) {
       update.turn = this.turns.findIndex((t) => t.id === currentId);
     }
     await this.update(update, { turnEvents: false, diff: false });
     await this.deleteEmbeddedDocuments("Combatant", combatantIdsToDelete);
+    return undefined;
     // --- RQG code
   }
 

--- a/src/combat/rqgCombatant.ts
+++ b/src/combat/rqgCombatant.ts
@@ -6,10 +6,10 @@ export class RqgCombatant extends Combatant {
   }
 
   /** Collect unique actors from combatant documents and re-render their sheets. */
-  private static rerenderActorSheets(documents: any[]): void {
+  private static rerenderActorSheets(documents: Combatant.Implementation[]): void {
     const actors = new Set<RqgActor>();
     for (const combatant of documents) {
-      if (combatant instanceof Combatant && combatant.actor) {
+      if (combatant.actor) {
         actors.add(combatant.actor);
       }
     }
@@ -20,9 +20,9 @@ export class RqgCombatant extends Combatant {
 
   /** @override Rerender actor sheets when a combatant is created to show SR buttons. */
   static override async _onCreateOperation(
-    documents: any[],
-    operation: any,
-    user: any,
+    documents: Combatant.Implementation[],
+    operation: Combatant.Database.OnCreateOperation,
+    user: User.Implementation,
   ): Promise<void> {
     await Combatant._onCreateOperation(documents, operation, user);
     RqgCombatant.rerenderActorSheets(documents);
@@ -34,9 +34,9 @@ export class RqgCombatant extends Combatant {
    * @override
    */
   static override async _preDeleteOperation(
-    _documents: any,
-    operation: any,
-    _user: any,
+    _documents: Combatant.Implementation[],
+    operation: Combatant.Database.PreDeleteOperation,
+    _user: User.Implementation,
   ): Promise<void> {
     const combat = operation.parent;
     for (const id of operation.ids as string[]) {
@@ -55,9 +55,9 @@ export class RqgCombatant extends Combatant {
 
   /** @override Rerender actor sheets after combatant deletion to update SR buttons. */
   static override async _onDeleteOperation(
-    documents: any[],
-    operation: any,
-    user: any,
+    documents: Combatant.Implementation[],
+    operation: Combatant.Database.OnDeleteOperation,
+    user: User.Implementation,
   ): Promise<void> {
     await Combatant._onDeleteOperation(documents, operation, user);
     RqgCombatant.rerenderActorSheets(documents);
@@ -65,9 +65,9 @@ export class RqgCombatant extends Combatant {
 
   /** @override Rerender actor sheets when combatant initiative changes. */
   static override async _onUpdateOperation(
-    documents: any[],
-    operation: any,
-    user: any,
+    documents: Combatant.Implementation[],
+    operation: Combatant.Database.OnUpdateOperation,
+    user: User.Implementation,
   ): Promise<void> {
     await Combatant._onUpdateOperation(documents, operation, user);
     RqgCombatant.rerenderActorSheets(documents);

--- a/src/combat/rqgCombatant.types.ts
+++ b/src/combat/rqgCombatant.types.ts
@@ -1,6 +1,6 @@
 export type NewCombatant = {
-  tokenId: any;
-  sceneId: any;
-  actorId: any;
+  tokenId: string | null | undefined;
+  sceneId: string | null | undefined;
+  actorId: string | null | undefined;
   initiative: number;
 };

--- a/src/combat/rqgToken.ts
+++ b/src/combat/rqgToken.ts
@@ -10,7 +10,7 @@ export class RqgToken extends Token {
     CONFIG.Token.objectClass = RqgToken;
   }
 
-  override _onHoverIn(event: any, options: any): void {
+  override _onHoverIn(event: Canvas.Event.Pointer, options?: PlaceableObject.HoverInOptions): void {
     super._onHoverIn(event, options);
     if (this.combatant) {
       getCombatantsSharingToken(this.combatant).forEach((combatant) => {
@@ -22,7 +22,7 @@ export class RqgToken extends Token {
     }
   }
 
-  override _onHoverOut(event: any) {
+  override _onHoverOut(event: Canvas.Event.Pointer) {
     super._onHoverOut(event);
     if (this.combatant) {
       getCombatantsSharingToken(this.combatant).forEach((combatant: Combatant) => {
@@ -34,7 +34,11 @@ export class RqgToken extends Token {
     }
   }
 
-  protected override _onCreate(data: any, options: any, userId: string): void {
+  protected override _onCreate(
+    data: foundry.data.fields.SchemaField.CreateData<TokenDocument["schema"]["fields"]>,
+    options: TokenDocument.Database.OnCreateOptions,
+    userId: string,
+  ): void {
     super._onCreate(data, options, userId);
     this.actor?.updateTokenEffectFromHealth();
     assertDocumentSubType<CharacterActor>(

--- a/src/system/util.ts
+++ b/src/system/util.ts
@@ -304,7 +304,8 @@ export function isDocumentSubType<
     | RqidEnabledDocument
     | RqgChatMessage
     | ChatMessage
-    | undefined,
+    | undefined
+    | null,
   documentSubTypes: Readonly<
     | (string | ItemTypeEnum | ActorTypeEnum | RqidEnabledDocument | undefined | null)
     | (string | ItemTypeEnum | ActorTypeEnum | RqidEnabledDocument | undefined | null)[]


### PR DESCRIPTION
- Typed combatant lifecycle hook signatures with Combatant.Database.* operation types
- Replaced any casts in RqgTokenRuler with proper Waypoint/SegmentStyle types
- Narrowed actor access in token ruler via isDocumentSubType guard
- Filtered null combatant IDs before duplicate-token removal in tracker
- Typed resetAll return and local update variable in RqgCombat
- Tightened NewCombatant.tokenId/sceneId/actorId from any to string | null | undefined
- Expanded isDocumentSubType to accept null document input