### PR TITLE
Missing features in v2 actor sheet

### DIFF
--- a/src/actors/RqgActorSheetV2.ts
+++ b/src/actors/RqgActorSheetV2.ts
@@ -532,13 +532,10 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       );
     }
 
-    // RQID link click handlers
-    if (this.element instanceof HTMLElement) {
-      void RqidLink.addRqidLinkClickHandlers(this.element);
+    // RQID link open/delete handlers (bind once; delegated handlers survive re-renders)
+    if (options.isFirstRender) {
+      RqidLink.bindHandlers(this.element, this.actor as foundry.abstract.Document.Any);
     }
-
-    // Delete handlers for RQID links (single link and link arrays)
-    RqidLink.addRqidLinkDeleteHandlers(this.element, this.actor as foundry.abstract.Document.Any);
 
     // RQID dropzones (wizard background tab and any other dropzone-enabled fields)
     this.element.querySelectorAll<HTMLElement>("[data-dropzone]").forEach((elem) => {

--- a/src/actors/RqgActorSheetV2.ts
+++ b/src/actors/RqgActorSheetV2.ts
@@ -4,7 +4,6 @@ import { actorHealthStatuses } from "../data-model/actor-data/attributes";
 import { RQG_CONFIG, systemId } from "../system/config";
 import {
   assertDocumentSubType,
-  getDomDataset,
   getRequiredDomDataset,
   hasOwnProperty,
   isDocumentSubType,
@@ -58,6 +57,7 @@ import type { SpiritMagicItem } from "@item-model/spiritMagicDataModel.ts";
 import type { RuneMagicItem } from "@item-model/runeMagicDataModel.ts";
 import type { GearItem } from "@item-model/gearDataModel.ts";
 import { RqgActorSheet } from "./rqgActorSheet";
+import type { RqgActiveEffect } from "../active-effect/rqgActiveEffect.ts";
 import { ActorWizard } from "../applications/actorWizardApplication";
 import { RqgAsyncDialog } from "../applications/rqgAsyncDialog";
 import { actorWizardFlags } from "../data-model/shared/rqgDocumentFlags";
@@ -72,6 +72,13 @@ import type { DeepPartial } from "fvtt-types/utils";
 
 const { HandlebarsApplicationMixin } = foundry.applications.api;
 const ActorSheetV2 = foundry.applications.sheets.ActorSheetV2;
+
+type SingleDoubleClickOptions = {
+  onSingle: () => Promise<void> | void;
+  onDouble?: () => Promise<void> | void;
+  shouldHandleEvent?: (ev: MouseEvent) => boolean;
+  timeout?: number;
+};
 
 export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
   #skillFilterQuery = "";
@@ -101,6 +108,20 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         dropSelector: "[data-item-id].contextmenu.item",
       },
     ],
+    actions: {
+      editItem: RqgActorSheetV2._openItemSheetAction,
+      deleteItem: RqgActorSheetV2._deleteItemAction,
+      sortItems: RqgActorSheetV2._sortItemsAction,
+      addWound: RqgActorSheetV2._addWoundAction,
+      healWound: RqgActorSheetV2._healWoundAction,
+      flipHitLocationSortSetting: RqgActorSheetV2._flipHitLocationSortSettingAction,
+      deleteActiveEffect: RqgActorSheetV2._deleteActiveEffectAction,
+      editActiveEffect: RqgActorSheetV2._editActiveEffectAction,
+      setSR: RqgActorSheetV2._setSRAction,
+      toggleSR: RqgActorSheetV2._toggleSRAction,
+      addPassion: RqgActorSheetV2._addPassionAction,
+      addGear: RqgActorSheetV2._addGearAction,
+    },
   };
 
   static override PARTS: Record<
@@ -153,7 +174,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         label: localize("RQG.ActorCreation.AdventurerCreationHeaderButton"),
         action: "openActorWizard",
         onClick: () => {
-          new ActorWizard(this.actor, {}).render(true);
+          new ActorWizard(this.actor, {}).render({ force: true });
         },
       } as any);
     }
@@ -320,6 +341,35 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
 
   /** Temporary image element used as drag preview */
   private _activeDragPreview: HTMLImageElement | null = null;
+
+  private _bindSingleDoubleClick(
+    el: HTMLElement,
+    { onSingle, onDouble, shouldHandleEvent, timeout }: SingleDoubleClickOptions,
+  ): void {
+    let clickCount = 0;
+    const resolvedTimeout = timeout ?? CONFIG.RQG.dblClickTimeout;
+    const doubleHandler = onDouble ?? onSingle;
+
+    el.addEventListener("click", async (ev: MouseEvent) => {
+      if (shouldHandleEvent && !shouldHandleEvent(ev)) {
+        return;
+      }
+
+      clickCount = Math.max(clickCount, ev.detail);
+
+      if (clickCount >= 2) {
+        await doubleHandler();
+        clickCount = 0;
+      } else if (clickCount === 1) {
+        setTimeout(async () => {
+          if (clickCount === 1) {
+            await onSingle();
+          }
+          clickCount = 0;
+        }, resolvedTimeout);
+      }
+    });
+  }
 
   override async _onRender(
     context: DeepPartial<RqgActorSheetV2Context>,
@@ -488,29 +538,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     }
 
     // Delete handlers for RQID links (single link and link arrays)
-    this.element.querySelectorAll<HTMLElement>("[data-delete-from-property]").forEach((el) => {
-      const deleteRqid = getRequiredDomDataset(el, "delete-rqid");
-      const deleteIndexRaw = getDomDataset(el, "delete-index");
-      const deleteIndex = Number.parseInt(deleteIndexRaw ?? "", 10);
-      const deleteFromPropertyName = getRequiredDomDataset(el, "delete-from-property");
-      el.addEventListener("click", async () => {
-        const deleteFromProperty = foundry.utils.getProperty(
-          this.actor.system as object,
-          deleteFromPropertyName,
-        );
-        const updateKey = `system.${deleteFromPropertyName}`;
-        if (Array.isArray(deleteFromProperty)) {
-          const links = [...(deleteFromProperty as RqidLink[])];
-          const newValueArray =
-            Number.isInteger(deleteIndex) && deleteIndex >= 0 && deleteIndex < links.length
-              ? (links.splice(deleteIndex, 1), links)
-              : links.filter((r) => r.rqid !== deleteRqid);
-          await this.actor.update({ [updateKey]: newValueArray });
-        } else {
-          await this.actor.update({ [updateKey]: "" });
-        }
-      });
-    });
+    RqidLink.addRqidLinkDeleteHandlers(this.element, this.actor as foundry.abstract.Document.Any);
 
     // RQID dropzones (wizard background tab and any other dropzone-enabled fields)
     this.element.querySelectorAll<HTMLElement>("[data-dropzone]").forEach((elem) => {
@@ -563,26 +591,24 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
 
     // --- Combat tab event handlers ---
 
-    // Set comma-separated Token SRs in Combat Tracker
-    this.element.querySelectorAll<HTMLElement>("[data-set-sr]").forEach((el) => {
-      const srValue = getRequiredDomDataset(el, "set-sr");
-      const srToAdd = srValue.split(",").map((v) => Number(v.trim()));
-      el.addEventListener("click", async () => {
-        this._activeInSR = new Set(srToAdd);
-        await this._updateActiveCombatWithSR(this._activeInSR);
-      });
-    });
+    // Roll actor Characteristic
+    this.element.querySelectorAll<HTMLElement>("[data-characteristic-roll]").forEach((el) => {
+      const closestDataCharacteristic = el.closest<HTMLElement>("[data-characteristic]");
+      const characteristicName = closestDataCharacteristic?.dataset["characteristic"];
+      const actorCharacteristics = this.actor.system.characteristics as Record<string, unknown>;
 
-    // Toggle individual SR buttons
-    this.element.querySelectorAll<HTMLElement>("[data-toggle-sr]").forEach((el) => {
-      const sr = Number(getRequiredDomDataset(el, "toggle-sr"));
-      el.addEventListener("click", async () => {
-        if (this._activeInSR.has(sr)) {
-          this._activeInSR.delete(sr);
-        } else {
-          this._activeInSR.add(sr);
-        }
-        await this._updateActiveCombatWithSR(this._activeInSR);
+      if (!characteristicName || !(characteristicName in actorCharacteristics)) {
+        const msg = `Characteristic [${characteristicName}] isn't found on actor [${this.actor.name}].`;
+        ui.notifications?.error(msg);
+        throw new RqgError(msg, this.actor);
+      }
+
+      const typedCharacteristicName =
+        characteristicName as keyof CharacterActor["system"]["characteristics"];
+
+      this._bindSingleDoubleClick(el, {
+        onSingle: () => this.actor.characteristicRoll(typedCharacteristicName),
+        onDouble: () => this.actor.characteristicRollImmediate(typedCharacteristicName),
       });
     });
 
@@ -606,30 +632,6 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
           { _id: updateId, system: { chance: newChance } },
         ]);
       });
-    });
-
-    // Edit Item (open the item sheet)
-    this.element.querySelectorAll<HTMLElement>("[data-item-edit]").forEach((el) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      const item = this.actor.items.get(itemId) as RqgItem | undefined;
-      if (!item?.sheet) {
-        const msg = `Couldn't find itemId [${itemId}] on actor ${this.actor.name} to open item sheet (during setup).`;
-        ui.notifications?.error(msg);
-        throw new RqgError(msg);
-      }
-      el.addEventListener("click", () => item.sheet!.render(true));
-    });
-
-    // Delete Item (remove item from actor)
-    this.element.querySelectorAll<HTMLElement>("[data-item-delete]").forEach((el) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      el.addEventListener("click", () => RqgActorSheet.confirmItemDelete(this.actor, itemId));
-    });
-
-    // Sort Items alphabetically
-    this.element.querySelectorAll<HTMLElement>("[data-sort-items]").forEach((el) => {
-      const itemType = getRequiredDomDataset(el, "sort-items");
-      el.addEventListener("click", () => RqgActorSheetV2.sortItems(this.actor, itemType));
     });
 
     // Cycle the equipped state of a physical item
@@ -683,71 +685,11 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       });
     });
 
-    // Add Passion button
-    this.element.querySelectorAll<HTMLElement>("[data-passion-add]").forEach((el) => {
-      el.addEventListener("click", async () => {
-        const defaultItemIconSettings: any = game.settings?.get(
-          systemId,
-          "defaultItemIconSettings",
-        );
-        const newPassionName = localize("RQG.Item.Passion.PassionEnum.Loyalty");
-        const passion = {
-          name: newPassionName,
-          type: ItemTypeEnum.Passion,
-          img: defaultItemIconSettings[ItemTypeEnum.Passion],
-          system: { passion: newPassionName },
-        };
-        const createdItems = await this.actor.createEmbeddedDocuments("Item", [passion]);
-        (createdItems[0] as RqgItem)?.sheet?.render(true);
-      });
-    });
-
-    // Add Gear buttons
-    this.element.querySelectorAll<HTMLElement>("[data-gear-add]").forEach((el) => {
-      const physicalItemType = getRequiredDomDataset(el, "gear-add") as PhysicalItemType;
-      el.addEventListener("click", async () => {
-        const defaultItemIconSettings: any = game.settings?.get(
-          systemId,
-          "defaultItemIconSettings",
-        );
-
-        const physicalItemType2ItemName = new Map<string, string>([
-          ["unique", "RQG.Actor.Gear.NewGear"],
-          ["currency", "RQG.Actor.Gear.NewCurrency"],
-          ["consumable", "RQG.Actor.Gear.NewConsumable"],
-        ]);
-
-        const name = localize(
-          physicalItemType2ItemName.get(physicalItemType) ?? "RQG.Actor.Gear.NewGear",
-        );
-
-        const newGear = {
-          name: name,
-          type: ItemTypeEnum.Gear,
-          img: defaultItemIconSettings[ItemTypeEnum.Gear],
-          system: { physicalItemType: physicalItemType },
-        };
-        const createdItems = await this.actor.createEmbeddedDocuments("Item", [newGear]);
-        (createdItems[0] as RqgItem)?.sheet?.render(true);
-      });
-    });
-
     // Reputation roll — single click opens dialog, double click rolls immediately
     this.element.querySelectorAll<HTMLElement>("[data-reputation-roll]").forEach((el) => {
-      let clickCount = 0;
-      el.addEventListener("click", async (ev: MouseEvent) => {
-        clickCount = Math.max(clickCount, ev.detail);
-        if (clickCount >= 2) {
-          await this.actor.reputationRollImmediate();
-          clickCount = 0;
-        } else if (clickCount === 1) {
-          setTimeout(async () => {
-            if (clickCount === 1) {
-              await this.actor.reputationRoll();
-            }
-            clickCount = 0;
-          }, 250);
-        }
+      this._bindSingleDoubleClick(el, {
+        onSingle: () => this.actor.reputationRoll(),
+        onDouble: () => this.actor.reputationRollImmediate(),
       });
     });
 
@@ -789,7 +731,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         if (tab) {
           sheet.tabGroups = { ...(sheet.tabGroups ?? {}), sheet: tab };
         }
-        sheet?.render(true);
+        sheet?.render({ force: true });
       });
     });
 
@@ -802,20 +744,9 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         abilityItemTypes,
         "AbilityChance roll couldn't find skillItem",
       );
-      let clickCount = 0;
-      el.addEventListener("click", async (ev: MouseEvent) => {
-        clickCount = Math.max(clickCount, ev.detail);
-        if (clickCount >= 2) {
-          await item.abilityRollImmediate();
-          clickCount = 0;
-        } else if (clickCount === 1) {
-          setTimeout(async () => {
-            if (clickCount === 1) {
-              await item.abilityRoll();
-            }
-            clickCount = 0;
-          }, CONFIG.RQG.dblClickTimeout);
-        }
+      this._bindSingleDoubleClick(el, {
+        onSingle: () => item.abilityRoll(),
+        onDouble: () => item.abilityRollImmediate(),
       });
     });
 
@@ -864,24 +795,15 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         ItemTypeEnum.SpiritMagic,
         `Couldn't find item [${itemId}] to roll Spirit Magic`,
       );
-      let clickCount = 0;
-      el.addEventListener("click", async (ev: MouseEvent) => {
-        clickCount = Math.max(clickCount, ev.detail);
-        if (clickCount >= 2) {
+      this._bindSingleDoubleClick(el, {
+        onSingle: () => item.spiritMagicRoll(),
+        onDouble: () => {
           if (item.system.isVariable && item.system.points > 1) {
-            await item.spiritMagicRoll();
+            return item.spiritMagicRoll();
           } else {
-            await item.spiritMagicRollImmediate();
+            return item.spiritMagicRollImmediate();
           }
-          clickCount = 0;
-        } else if (clickCount === 1) {
-          setTimeout(async () => {
-            if (clickCount === 1) {
-              await item.spiritMagicRoll();
-            }
-            clickCount = 0;
-          }, CONFIG.RQG.dblClickTimeout);
-        }
+        },
       });
     });
 
@@ -894,24 +816,15 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         ItemTypeEnum.RuneMagic,
         `Couldn't find item [${itemId}] to roll Rune Magic`,
       );
-      let clickCount = 0;
-      el.addEventListener("click", async (ev: MouseEvent) => {
-        clickCount = Math.max(clickCount, ev.detail);
-        if (clickCount >= 2) {
+      this._bindSingleDoubleClick(el, {
+        onSingle: () => item.runeMagicRoll(),
+        onDouble: () => {
           if (item.system.points === 1) {
-            await item.runeMagicRollImmediate();
+            return item.runeMagicRollImmediate();
           } else {
-            await item.runeMagicRoll();
+            return item.runeMagicRoll();
           }
-          clickCount = 0;
-        } else if (clickCount === 1) {
-          setTimeout(async () => {
-            if (clickCount === 1) {
-              await item.runeMagicRoll();
-            }
-            clickCount = 0;
-          }, CONFIG.RQG.dblClickTimeout);
-        }
+        },
       });
     });
 
@@ -920,23 +833,10 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       const weaponItemId = getRequiredDomDataset(el, "weapon-item-id");
       const weapon = this.actor.items.get(weaponItemId) as RqgItem | undefined;
       assertDocumentSubType<WeaponItem>(weapon, ItemTypeEnum.Weapon);
-      let clickCount = 0;
-      el.addEventListener("click", async (ev: MouseEvent) => {
-        if ((ev.target as HTMLElement)?.tagName === "SELECT") {
-          return;
-        }
-        clickCount = Math.max(clickCount, ev.detail);
-        if (clickCount >= 2) {
-          await weapon.attack();
-          clickCount = 0;
-        } else if (clickCount === 1) {
-          setTimeout(async () => {
-            if (clickCount === 1) {
-              void weapon.attack();
-            }
-            clickCount = 0;
-          }, CONFIG.RQG.dblClickTimeout);
-        }
+      this._bindSingleDoubleClick(el, {
+        shouldHandleEvent: (ev) => (ev.target as HTMLElement)?.tagName !== "SELECT",
+        onSingle: () => weapon.attack(),
+        onDouble: () => weapon.attack(),
       });
     });
 
@@ -952,18 +852,6 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       el.addEventListener("click", (event) => {
         event.stopPropagation();
       });
-    });
-
-    // Add wound to hit location
-    this.element.querySelectorAll<HTMLElement>("[data-item-add-wound]").forEach((el) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      el.addEventListener("click", () => HitLocationSheet.showAddWoundDialog(this.actor, itemId));
-    });
-
-    // Heal wounds on hit location
-    this.element.querySelectorAll<HTMLElement>("[data-item-heal-wound]").forEach((el) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      el.addEventListener("click", () => HitLocationSheet.showHealWoundDialog(this.actor, itemId));
     });
 
     // Roll Damage
@@ -992,17 +880,204 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         });
       });
     });
+  }
 
-    // Flip hit location sort order
-    this.element
-      .querySelectorAll<HTMLElement>("[data-flip-sort-hitlocation-setting]")
-      .forEach((el) => {
-        el.addEventListener("click", async () => {
-          const currentValue = game.settings?.get(systemId, "sortHitLocationsLowToHigh");
-          await game.settings?.set(systemId, "sortHitLocationsLowToHigh", !currentValue);
-          this.render();
-        });
-      });
+  private static _openItemSheetAction(
+    this: RqgActorSheetV2,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): void {
+    const itemId = target.closest<HTMLElement>("[data-item-id]")?.dataset["itemId"];
+    requireValue(itemId, "No item id found to open item sheet");
+
+    const item = this.actor.items.get(itemId) as RqgItem | undefined;
+    if (!item?.sheet) {
+      const msg = `Couldn't find itemId [${itemId}] on actor ${this.actor.name} to open item sheet.`;
+      ui.notifications?.error(msg);
+      throw new RqgError(msg);
+    }
+    // @ts-expect-error render signature varies between V1/V2 sheet implementations
+    item.sheet.render({ force: true });
+  }
+
+  private static _deleteItemAction(
+    this: RqgActorSheetV2,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): void {
+    const itemId = target.closest<HTMLElement>("[data-item-id]")?.dataset["itemId"];
+    requireValue(itemId, "No item id found to delete item");
+    RqgActorSheet.confirmItemDelete(this.actor, itemId);
+  }
+
+  private static _sortItemsAction(
+    this: RqgActorSheetV2,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): void {
+    const itemType = target.dataset["sortItems"];
+    requireValue(itemType, "No sort item type found");
+    void RqgActorSheetV2.sortItems(this.actor, itemType);
+  }
+
+  private static _addWoundAction(
+    this: RqgActorSheetV2,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): void {
+    const itemId = target.closest<HTMLElement>("[data-item-id]")?.dataset["itemId"];
+    requireValue(itemId, "No hit location item id found to add wound");
+    void HitLocationSheet.showAddWoundDialog(this.actor, itemId);
+  }
+
+  private static _healWoundAction(
+    this: RqgActorSheetV2,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): void {
+    const itemId = target.closest<HTMLElement>("[data-item-id]")?.dataset["itemId"];
+    requireValue(itemId, "No hit location item id found to heal wound");
+    void HitLocationSheet.showHealWoundDialog(this.actor, itemId);
+  }
+
+  private static async _flipHitLocationSortSettingAction(this: RqgActorSheetV2): Promise<void> {
+    const currentValue = game.settings?.get(systemId, "sortHitLocationsLowToHigh");
+    await game.settings?.set(systemId, "sortHitLocationsLowToHigh", !currentValue);
+    this.render({ force: true });
+  }
+
+  private static _editActiveEffectAction(
+    this: RqgActorSheetV2,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): void {
+    const effectRow = target.closest<HTMLElement>("[data-effect-uuid]");
+    const effectUuid = effectRow?.dataset["effectUuid"];
+    requireValue(effectUuid, "No active effect uuid found to edit the effect");
+
+    const effect = fromUuidSync(effectUuid) as RqgActiveEffect | undefined;
+    requireValue(effect, `No active effect id [${effectUuid}] to edit the effect`);
+    new foundry.applications.sheets.ActiveEffectConfig({ document: effect }).render({
+      force: true,
+    });
+  }
+
+  private static async _deleteActiveEffectAction(
+    this: RqgActorSheetV2,
+    event: PointerEvent,
+    target: HTMLElement,
+  ): Promise<void> {
+    event.preventDefault();
+    event.stopPropagation();
+    await this._confirmDeleteActiveEffect(target);
+  }
+
+  private async _confirmDeleteActiveEffect(actionEl: HTMLElement): Promise<void> {
+    const effectRow = actionEl.closest<HTMLElement>("[data-effect-uuid]");
+    const effectUuid = effectRow?.dataset["effectUuid"];
+    requireValue(effectUuid, "No active effect uuid found to delete the effect");
+
+    const effect = fromUuidSync(effectUuid) as RqgActiveEffect | undefined;
+    requireValue(effect, `No active effect id [${effectUuid}] to delete the effect`);
+
+    const title = localize("RQG.Dialog.confirmActiveEffectDeleteDialog.title", {
+      effectName: effect.name,
+    });
+    const content = localize("RQG.Dialog.confirmActiveEffectDeleteDialog.content", {
+      effectName: effect.name,
+    });
+
+    const confirmed = await foundry.applications.api.DialogV2.wait({
+      window: { title },
+      content,
+      buttons: [
+        {
+          action: "confirm",
+          label: localize("RQG.Dialog.Common.btnConfirm"),
+          icon: "fas fa-check",
+          callback: () => true,
+        },
+        {
+          action: "cancel",
+          label: localize("RQG.Dialog.Common.btnCancel"),
+          icon: "fas fa-times",
+          callback: () => false,
+          default: true,
+        },
+      ],
+    });
+
+    if (confirmed) {
+      await effect.delete();
+    }
+  }
+
+  private static async _setSRAction(
+    this: RqgActorSheetV2,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): Promise<void> {
+    const srValue = getRequiredDomDataset(target, "set-sr");
+    const srToAdd = srValue.split(",").map((v) => Number(v.trim()));
+    this._activeInSR = new Set(srToAdd);
+    await this._updateActiveCombatWithSR(this._activeInSR);
+  }
+
+  private static async _toggleSRAction(
+    this: RqgActorSheetV2,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): Promise<void> {
+    const sr = Number(getRequiredDomDataset(target, "toggle-sr"));
+    if (this._activeInSR.has(sr)) {
+      this._activeInSR.delete(sr);
+    } else {
+      this._activeInSR.add(sr);
+    }
+    await this._updateActiveCombatWithSR(this._activeInSR);
+  }
+
+  private static async _addPassionAction(this: RqgActorSheetV2): Promise<void> {
+    const defaultItemIconSettings: any = game.settings?.get(systemId, "defaultItemIconSettings");
+    const newPassionName = localize("RQG.Item.Passion.PassionEnum.Loyalty");
+    const passion = {
+      name: newPassionName,
+      type: ItemTypeEnum.Passion,
+      img: defaultItemIconSettings[ItemTypeEnum.Passion],
+      system: { passion: newPassionName },
+    };
+    const createdItems = await this.actor.createEmbeddedDocuments("Item", [passion]);
+    // @ts-expect-error render signature varies between V1/V2 sheet implementations
+    (createdItems[0] as RqgItem)?.sheet?.render({ force: true });
+  }
+
+  private static async _addGearAction(
+    this: RqgActorSheetV2,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): Promise<void> {
+    const physicalItemType = getRequiredDomDataset(target, "gear-add") as PhysicalItemType;
+    const defaultItemIconSettings: any = game.settings?.get(systemId, "defaultItemIconSettings");
+
+    const physicalItemType2ItemName = new Map<string, string>([
+      ["unique", "RQG.Actor.Gear.NewGear"],
+      ["currency", "RQG.Actor.Gear.NewCurrency"],
+      ["consumable", "RQG.Actor.Gear.NewConsumable"],
+    ]);
+
+    const name = localize(
+      physicalItemType2ItemName.get(physicalItemType) ?? "RQG.Actor.Gear.NewGear",
+    );
+
+    const newGear = {
+      name: name,
+      type: ItemTypeEnum.Gear,
+      img: defaultItemIconSettings[ItemTypeEnum.Gear],
+      system: { physicalItemType: physicalItemType },
+    };
+    const createdItems = await this.actor.createEmbeddedDocuments("Item", [newGear]);
+    // @ts-expect-error render signature varies between V1/V2 sheet implementations
+    (createdItems[0] as RqgItem)?.sheet?.render({ force: true });
   }
 
   /**

--- a/src/actors/RqgActorSheetV2.ts
+++ b/src/actors/RqgActorSheetV2.ts
@@ -1714,4 +1714,57 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         return false;
     }
   }
+
+  protected override async _onDrop(event: DragEvent): Promise<void> {
+    event.preventDefault();
+    this.render(); // Rerender to clear any drag-hover classes
+
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(
+      event,
+    ) as ActorSheet.DropData;
+
+    // Handle compendium drops specially to embed all items from the pack
+    if (data?.type === "Compendium") {
+      if (!this.actor.isOwner) {
+        ui.notifications?.warn(
+          localize("RQG.Actor.Notification.NotActorOwnerWarn", { actorName: this.actor.name }),
+        );
+        return;
+      }
+      await this._onDropCompendium(event, data);
+      return;
+    }
+
+    // For all other types, delegate to parent
+    await super._onDrop(event);
+  }
+
+  private async _onDropCompendium(event: DragEvent, data: ActorSheet.DropData): Promise<RqgItem[]> {
+    if (!this.actor.isOwner) {
+      return [];
+    }
+    const compendiumId = hasOwnProperty(data, "collection") ? data.collection : undefined;
+    if (typeof compendiumId !== "string") {
+      return [];
+    }
+    const pack = game.packs?.get(compendiumId);
+    const packIndex = await pack?.getIndex();
+    if (!packIndex) {
+      return [];
+    }
+    const documents = (await Promise.all(
+      packIndex.map(async (di) => {
+        const doc = await fromUuid(di.uuid);
+        return doc?.toObject();
+      }),
+    )) as Item.Implementation["_source"][];
+
+    const itemDataToCreate = documents.filter(isTruthy);
+    if (itemDataToCreate.length === 0) {
+      return [];
+    }
+
+    const createdItems = await this.actor.createEmbeddedDocuments("Item", itemDataToCreate);
+    return createdItems as RqgItem[];
+  }
 }

--- a/src/actors/RqgActorSheetV2.ts
+++ b/src/actors/RqgActorSheetV2.ts
@@ -1167,6 +1167,16 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
   ): Promise<void> {
     const sheet = this as unknown as RqgActorSheetV2;
     const data = formData.object as Record<string, unknown>;
+
+    const maxHitPoints = sheet.actor.system.attributes.hitPoints.max;
+
+    if (
+      data["system.attributes.hitPoints.value"] == null ||
+      (data["system.attributes.hitPoints.value"] as number) >= (maxHitPoints ?? 0)
+    ) {
+      data["system.attributes.hitPoints.value"] = maxHitPoints;
+    }
+
     await sheet.actor.update(data);
   }
 

--- a/src/actors/_actorsheetV2.scss
+++ b/src/actors/_actorsheetV2.scss
@@ -112,8 +112,8 @@
     [data-damage-roll],
     [data-item-roll],
     [data-item-equipped-toggle],
-    [data-item-heal-wound],
-    [data-item-add-wound],
+    [data-action="healWound"],
+    [data-action="addWound"],
     [data-rqid-link],
     [data-weapon-roll],
     [data-reputation-roll],
@@ -1098,7 +1098,7 @@
         text-align: center;
       }
 
-      [data-item-heal-wound] {
+      [data-action="healWound"] {
         cursor: pointer;
 
         .fa-heart-pulse {
@@ -1238,7 +1238,7 @@
             display: flex;
             justify-content: space-between;
 
-            [data-item-add-wound] {
+            [data-action="addWound"] {
               cursor: pointer;
             }
           }
@@ -1847,7 +1847,7 @@
           text-shadow: none;
         }
 
-        [data-item-edit] {
+        [data-action="editItem"] {
           flex: 1 1 auto;
           font-weight: 600;
 
@@ -1856,7 +1856,7 @@
           }
         }
 
-        [data-item-delete] {
+        [data-action="deleteItem"] {
           flex: 0 0 auto;
         }
       }
@@ -2083,7 +2083,12 @@
 
     // --- Background tab ---
     .background-tab-v2 {
-      display: flex;
+      display: none;
+
+      &.active {
+        display: flex;
+      }
+
       flex-direction: column;
       gap: 1rem;
       padding: 0.5rem;
@@ -2189,6 +2194,103 @@
           font-style: italic;
           opacity: 0.7;
           font-size: 0.9em;
+        }
+      }
+    }
+
+    // --- Active Effects tab ---
+    .tab.activeeffectstesting {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      overflow: auto;
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.9em;
+
+        td,
+        th {
+          padding: 2px 4px;
+          text-align: left;
+          vertical-align: middle;
+        }
+
+        th {
+          font-weight: bold;
+          background: rgb(0 0 0 / 30%);
+        }
+
+        // Constrain narrow columns with fixed widths
+        th:nth-child(1),
+        td:nth-child(1) {
+          width: 50px;
+          text-align: center;
+
+          img {
+            max-width: 100%;
+            height: auto;
+          }
+        }
+
+        th:nth-child(3),
+        td:nth-child(3) {
+          width: 30px;
+          text-align: right;
+        }
+
+        th:nth-child(4),
+        td:nth-child(4) {
+          width: 70px;
+        }
+
+        th:nth-child(5),
+        td:nth-child(5) {
+          width: 70px;
+        }
+
+        th:nth-child(7),
+        td:nth-child(7) {
+          width: 30px;
+          text-align: center;
+        }
+
+        // Nested table for changes - compact layout, expands to fill space
+        td > table {
+          width: 100%;
+          border-collapse: collapse;
+          font-size: 0.95em;
+          margin: 0;
+          table-layout: fixed;
+
+          // Sub-columns: key takes remaining width, type is fixed, value fits 3 chars.
+          td:nth-child(1) {
+            padding: 1px 3px;
+            width: calc(100% - 14ch);
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            text-align: left;
+          }
+
+          td:nth-child(2) {
+            padding: 1px 3px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            width: 11ch;
+          }
+
+          td:nth-child(3) {
+            padding: 1px 3px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            text-align: right;
+            width: 3ch;
+          }
         }
       }
     }

--- a/src/actors/rqgActor.ts
+++ b/src/actors/rqgActor.ts
@@ -47,7 +47,16 @@ import {
 
 import Actor = foundry.documents.Actor;
 
+type HealthTransitionSnapshot = {
+  health: ActorHealthState;
+  hitPoints: number;
+  magicPoints: number;
+};
+
 export class RqgActor extends Actor {
+  private _healthBeforeActorUpdate?: HealthTransitionSnapshot;
+  private _healthBeforeItemUpdate?: HealthTransitionSnapshot;
+
   static init() {
     CONFIG.Actor.documentClass = RqgActor;
     CONFIG.Actor.dataModels["character"] = CharacterDataModel;
@@ -427,8 +436,6 @@ export class RqgActor extends Actor {
         }) + incapacitatingText,
       whisper: usersIdsThatOwnActor(damagedHitLocation!.parent),
     });
-
-    await this.updateTokenEffectFromHealth();
   }
 
   /**
@@ -446,22 +453,102 @@ export class RqgActor extends Actor {
     const newEffect = health2Effect.get(this.system.attributes.health);
 
     for (const status of health2Effect.values()) {
-      const actorHasEffectAlready = this.statuses.has(status?.id);
-      if (newEffect?.id === status.id && !actorHasEffectAlready) {
-        const asOverlay = status.id === "dead";
+      const statusId = status?.id;
+      if (!statusId) {
+        continue;
+      }
+
+      // Check if the effect actually exists on the actor
+      const effectExists = this.effects.some((e) => e.statuses.has(statusId));
+
+      if (newEffect?.id === statusId && !effectExists) {
+        const asOverlay = statusId === "dead";
         // Turn on the new effect
-        await this.toggleStatusEffect(status.id, {
+        await this.toggleStatusEffect(statusId, {
           overlay: asOverlay,
           active: true,
         });
-      } else if (newEffect?.id !== status.id && actorHasEffectAlready) {
+      } else if (newEffect?.id !== statusId && effectExists) {
         // This is not the effect we're applying, but it is on, so we need to turn it off
-        await this.toggleStatusEffect(status.id, {
-          overlay: false,
-          active: false,
-        });
+        try {
+          await this.toggleStatusEffect(statusId, {
+            overlay: false,
+            active: false,
+          });
+        } catch (error) {
+          // In v14, the effect might have been deleted already; silently ignore
+          console.warn(`Failed to toggle off status effect ${statusId}:`, error);
+        }
       }
     }
+  }
+
+  private getHealthTransitionSnapshot(): HealthTransitionSnapshot {
+    assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
+    return {
+      health: this.system.attributes.health,
+      hitPoints: this.system.attributes.hitPoints.value ?? 0,
+      magicPoints: this.system.attributes.magicPoints.value ?? 0,
+    };
+  }
+
+  private isHealthAffectingActorUpdate(changes: Actor.UpdateData): boolean {
+    return (
+      foundry.utils.hasProperty(changes, "system.attributes.hitPoints.value") ||
+      foundry.utils.hasProperty(changes, "system.attributes.magicPoints.value") ||
+      foundry.utils.hasProperty(changes, "system.attributes.health")
+    );
+  }
+
+  private async handleHealthTransition(
+    previous: HealthTransitionSnapshot | undefined,
+    userId: string,
+  ): Promise<void> {
+    if (game.user?.id !== userId || previous == null) {
+      return;
+    }
+
+    const next = this.getHealthTransitionSnapshot();
+    const previousHealth = previous.health;
+    const nextHealth = this.system.attributes.health;
+    if (previousHealth === nextHealth) {
+      return;
+    }
+
+    await this.updateTokenEffectFromHealth();
+
+    const speaker = ChatMessage.getSpeaker({ actor: this, token: this.token ?? undefined });
+    const speakerName = speaker.alias as string;
+    let message: string | undefined;
+
+    if (nextHealth === "dead" && previousHealth !== "dead") {
+      message = localize("RQG.Actor.Health.Transition.DeadFromHitPoints", {
+        actorName: speakerName,
+      }) as string;
+    } else if (nextHealth === "unconscious" && previousHealth !== "unconscious") {
+      const mpDroppedToZero = previous.magicPoints > 0 && next.magicPoints <= 0;
+      const hpDroppedToZero = previous.hitPoints > 0 && next.hitPoints <= 0;
+
+      message =
+        mpDroppedToZero && !hpDroppedToZero
+          ? (localize("RQG.Actor.Health.Transition.UnconsciousFromMagicPoints", {
+              actorName: speakerName,
+            }) as string)
+          : (localize("RQG.Actor.Health.Transition.UnconsciousFromHitPoints", {
+              actorName: speakerName,
+            }) as string);
+    }
+
+    if (!message) {
+      return;
+    }
+
+    await ChatMessage.create({
+      speaker,
+      content: message,
+      whisper: usersIdsThatOwnActor(this),
+      style: CONST.CHAT_MESSAGE_STYLES.WHISPER,
+    });
   }
 
   private findEffect(health: ActorHealthState): CONFIG.StatusEffect {
@@ -617,6 +704,10 @@ export class RqgActor extends Actor {
   ): Promise<boolean | void> {
     assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
 
+    this._healthBeforeActorUpdate = this.isHealthAffectingActorUpdate(changes)
+      ? this.getHealthTransitionSnapshot()
+      : undefined;
+
     const actorDex =
       (changes as DeepPartial<CharacterActor>)?.system?.characteristics?.dexterity?.value ??
       this.system.characteristics.dexterity.value;
@@ -634,6 +725,41 @@ export class RqgActor extends Actor {
       }
     }
     return super._preUpdate(changes, options, user);
+  }
+
+  protected override _preUpdateDescendantDocuments(
+    ...args: Parameters<Actor["_preUpdateDescendantDocuments"]>
+  ): void {
+    const [parent, collection] = args;
+    this._healthBeforeItemUpdate =
+      parent === this && collection === "items" ? this.getHealthTransitionSnapshot() : undefined;
+    super._preUpdateDescendantDocuments(...args);
+  }
+
+  protected override _onUpdate(...args: Parameters<Actor["_onUpdate"]>): void {
+    const [, , userId] = args;
+    const previousHealth = this._healthBeforeActorUpdate;
+    this._healthBeforeActorUpdate = undefined;
+
+    super._onUpdate(...args);
+
+    if (previousHealth != null) {
+      void this.handleHealthTransition(previousHealth, userId);
+    }
+  }
+
+  protected override _onUpdateDescendantDocuments(
+    ...args: Parameters<Actor["_onUpdateDescendantDocuments"]>
+  ): void {
+    const [parent, collection, , , , userId] = args;
+    const previousHealth = this._healthBeforeItemUpdate;
+    this._healthBeforeItemUpdate = undefined;
+
+    super._onUpdateDescendantDocuments(...args);
+
+    if (parent === this && collection === "items" && previousHealth != null) {
+      void this.handleHealthTransition(previousHealth, userId);
+    }
   }
 
   // Return shorthand access to actor data & characteristics

--- a/src/actors/rqgActorSheet.ts
+++ b/src/actors/rqgActorSheet.ts
@@ -786,32 +786,8 @@ export class RqgActorSheet<
     // Handle rqid links
     void RqidLink.addRqidLinkClickHandlersToJQuery(html);
 
-    // Handle deleting RqidLinks from RqidLink Array Properties
-    $(htmlElement!)
-      .find("[data-delete-from-property]")
-      .each((i: number, el: HTMLElement) => {
-        const deleteRqid = getRequiredDomDataset($(el), "delete-rqid");
-        const deleteIndexRaw = getDomDataset($(el), "delete-index");
-        const deleteIndex = Number.parseInt(deleteIndexRaw ?? "", 10);
-        const deleteFromPropertyName = getRequiredDomDataset($(el), "delete-from-property");
-        el.addEventListener("click", async () => {
-          const deleteFromProperty = foundry.utils.getProperty(
-            this.actor.system,
-            deleteFromPropertyName,
-          );
-          const updateKey = `system.${deleteFromPropertyName}`;
-          if (Array.isArray(deleteFromProperty)) {
-            const links = [...(deleteFromProperty as RqidLink[])];
-            const newValueArray =
-              Number.isInteger(deleteIndex) && deleteIndex >= 0 && deleteIndex < links.length
-                ? (links.splice(deleteIndex, 1), links)
-                : links.filter((r) => r.rqid !== deleteRqid);
-            await this.actor.update({ [updateKey]: newValueArray });
-          } else {
-            await this.actor.update({ [updateKey]: "" });
-          }
-        });
-      });
+    // Handle deleting RQID links
+    RqidLink.addRqidLinkDeleteHandlersToJQuery(html, this.actor as foundry.abstract.Document.Any);
 
     // Add Passion button
     htmlElement?.querySelectorAll<HTMLElement>("[data-passion-add]").forEach((el) => {

--- a/src/actors/rqgActorSheet.ts
+++ b/src/actors/rqgActorSheet.ts
@@ -27,7 +27,6 @@ import { characteristicMenuOptions } from "./context-menus/characteristic-contex
 import {
   assertDocumentSubType,
   assertHtmlElement,
-  getDomDataset,
   getHTMLElement,
   getRequiredDomDataset,
   hasOwnProperty,
@@ -38,9 +37,7 @@ import {
   range,
   requireValue,
   RqgError,
-  usersIdsThatOwnActor,
 } from "../system/util";
-import { DamageCalculations } from "../system/damageCalculations";
 import { actorHealthStatuses, LocomotionEnum } from "../data-model/actor-data/attributes";
 import { ActorTypeEnum, type CharacterActor } from "../data-model/actor-data/rqgActorData";
 import { ActorWizard } from "../applications/actorWizardApplication";
@@ -296,7 +293,7 @@ export class RqgActorSheet<
     };
   }
 
-  protected override _updateObject(event: Event, formData: any): Promise<unknown> {
+  protected override async _updateObject(event: Event, formData: any): Promise<unknown> {
     const maxHitPoints = this.actor.system.attributes.hitPoints.max;
 
     if (
@@ -305,42 +302,6 @@ export class RqgActorSheet<
     ) {
       formData["system.attributes.hitPoints.value"] = maxHitPoints;
     }
-
-    // Hack: Temporarily change hp.value to what it will become so getCombinedActorHealth will work
-    const hpTmp = this.actor.system.attributes.hitPoints.value;
-    const mpTmp = this.actor.system.attributes.magicPoints.value;
-
-    this.actor.system.attributes.hitPoints.value = formData["system.attributes.hitPoints.value"];
-    this.actor.system.attributes.magicPoints.value =
-      formData["system.attributes.magicPoints.value"];
-
-    const newHealth = DamageCalculations.getCombinedActorHealth(this.actor);
-    if (newHealth !== this.actor.system.attributes.health) {
-      const speaker = ChatMessage.getSpeaker({ actor: this.actor, token: this.token });
-      const speakerName = speaker.alias;
-      let message;
-      if (newHealth === "dead" && !this.token?.actor?.statuses.has("dead")) {
-        message = `${speakerName} runs out of hitpoints and dies here and now!`;
-      }
-      if (newHealth === "unconscious" && !this.token?.actor?.statuses.has("unconscious")) {
-        message = `${speakerName} faints from lack of hitpoints!`;
-      }
-      if (message) {
-        ChatMessage.create({
-          speaker: speaker,
-          content: message,
-          whisper: usersIdsThatOwnActor(this.actor),
-          style: CONST.CHAT_MESSAGE_STYLES.WHISPER,
-        });
-      }
-    }
-
-    this.actor.system.attributes.hitPoints.value = hpTmp; // Restore hp so the form will work
-    this.actor.system.attributes.magicPoints.value = mpTmp;
-    this.actor.system.attributes.health = newHealth; // "Pre update" the health to make the setTokenEffect call work
-    void this.actor.updateTokenEffectFromHealth();
-
-    formData["system.attributes.health"] = newHealth;
 
     return super._updateObject(event, formData);
   }

--- a/src/actors/sheet-parts-v2/actorSheetV2Combat.hbs
+++ b/src/actors/sheet-parts-v2/actorSheetV2Combat.hbs
@@ -62,8 +62,8 @@
                   </div>
                 </div>
                 <div class="hl-wounds-row">
-                  <div class="health-state break-word" data-item-heal-wound title="{{localize "RQG.Actor.Health.HealWound"}}">{{#if system.woundsString}}<i class="fas fa-heart-pulse"></i> {{system.woundsString}}{{/if}}</div>
-                  <div class="ml-5" title="{{localize "RQG.Actor.Health.AddWound"}}" data-item-add-wound><i class="fas fa-burst"></i></div>
+                  <div class="health-state break-word" data-action="healWound" title="{{localize "RQG.Actor.Health.HealWound"}}">{{#if system.woundsString}}<i class="fas fa-heart-pulse"></i> {{system.woundsString}}{{/if}}</div>
+                  <div class="ml-5" title="{{localize "RQG.Actor.Health.AddWound"}}" data-action="addWound"><i class="fas fa-burst"></i></div>
                 </div>
               </div>
             {{/each}}
@@ -78,7 +78,7 @@
           <div class="grid hit-location item-list">
             <div class="headings"></div>
             <div class="head1-4">
-              <button class="sort" data-flip-sort-hitlocation-setting
+                    <button class="sort" data-action="flipHitLocationSortSetting"
                       data-tooltip="{{localize "RQG.Actor.Health.FlipSortOrder"}}"
                       style="width: 1.3rem; padding-top: 2px; margin-top: -2px;">
                 <i class="fas fa-sort"></i>
@@ -109,10 +109,10 @@
                 {{/unless}}
               </div>
               <div class="hit-location contextmenu item flex-row" data-item-id="{{id}}">
-                <div data-item-heal-wound title="{{localize "RQG.Actor.Health.HealWound"}}" class="flex-1 nowrap health-state">
+                <div data-action="healWound" title="{{localize "RQG.Actor.Health.HealWound"}}" class="flex-1 nowrap health-state">
                   {{#if system.woundsString}}<i class="fas fa-heart-pulse"></i> {{system.woundsString}}{{/if}}
                 </div>
-                <div class="ml-5" title="{{localize "RQG.Actor.Health.AddWound"}}" data-item-add-wound><i class="fas fa-burst"></i></div>
+                <div class="ml-5" title="{{localize "RQG.Actor.Health.AddWound"}}" data-action="addWound"><i class="fas fa-burst"></i></div>
               </div>
             {{/each}}
           </div>
@@ -136,19 +136,19 @@
           {{#if dexSR}}
             <div class="dex">
               {{#each dexSR}}
-                <button type="button" data-toggle-sr="{{this}}" {{#ifIn this @root.activeInSR}}class="active"{{/ifIn}}>{{this}}</button>
+                <button type="button" data-action="toggleSR" data-toggle-sr="{{this}}" {{#ifIn this @root.activeInSR}}class="active"{{/ifIn}}>{{this}}</button>
               {{/each}}
             </div>
           {{/if}}
           {{#if sizSR}}
             <div class="siz">
               {{#each sizSR}}
-                <button type="button" data-toggle-sr="{{this}}" {{#ifIn this @root.activeInSR}}class="active"{{/ifIn}}>{{this}}</button>
+                <button type="button" data-action="toggleSR" data-toggle-sr="{{this}}" {{#ifIn this @root.activeInSR}}class="active"{{/ifIn}}>{{this}}</button>
               {{/each}}
             </div>
           {{/if}}
           {{#each otherSR}}
-            <button type="button" data-toggle-sr="{{this}}" {{#ifIn this @root.activeInSR}}class="active"{{/ifIn}}>{{this}}</button>
+            <button type="button" data-action="toggleSR" data-toggle-sr="{{this}}" {{#ifIn this @root.activeInSR}}class="active"{{/ifIn}}>{{this}}</button>
           {{/each}}
           <i class="ml-5 fa-solid fa-circle-info"
              data-tooltip="<div class='sr-help'>{{localize 'RQG.Actor.Combat.SRTooltip'}}</div>"></i>
@@ -163,7 +163,7 @@
       {{!-- Weapons Grid --}}
       <div class="grid combat item-list">
         <div class="headings"></div>
-        <div class="head1"><button class="sort" data-sort-items="weapon" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
+        <div class="head1"><button class="sort" data-action="sortItems" data-sort-items="weapon" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
         <div class="head2">{{localize "RQG.Actor.Combat.Weapon"}}</div>
         <div class="head3">{{localize "RQG.Actor.Combat.HP"}}</div>
         <div class="head4 text-right">{{localize "RQG.Actor.Combat.Chance"}}</div>
@@ -251,22 +251,21 @@
                         {{#if (eq @key "missile")}}
                           {{#if ../system.rate}}
                             <div class="usage {{#if (and (eq @key "missile") (eq ../system.rate 0))}}missile{{/if}}">
-                              <button type="button" class="sr" data-set-sr="{{max 1 @root.system.attributes.dexStrikeRank}}">{{max 1 @root.system.attributes.dexStrikeRank}}</button>
+                              <button type="button" class="sr" data-action="setSR" data-set-sr="{{max 1 @root.system.attributes.dexStrikeRank}}">{{max 1 @root.system.attributes.dexStrikeRank}}</button>
                             </div>
                           {{else}}
                             <div class="flex-column">
-                              <button type="button" class="sr" data-set-sr="{{@root.unloadedMissileSr}}">
+                              <button type="button" class="sr" data-action="setSR" data-set-sr="{{@root.unloadedMissileSr}}">
                                 {{#each @root.unloadedMissileSrDisplay}}{{{this}}}{{/each}}
                               </button>
-                              <button type="button" class="sr" data-set-sr="{{@root.loadedMissileSr}}">
+                              <button type="button" class="sr" data-action="setSR" data-set-sr="{{@root.loadedMissileSr}}">
                                 {{#each @root.loadedMissileSrDisplay}}{{{this}}}{{/each}}
                               </button>
                             </div>
                           {{/if}}
                         {{else}}
                           <span><button type="button" class="combat sr contextmenu"
-                                        data-tooltip="{{localize "RQG.Actor.Combat.SetSRInCombatTracker"}}"
-                                        data-set-sr="{{sum @root.system.attributes.sizStrikeRank
+                                        data-tooltip="{{localize "RQG.Actor.Combat.SetSRInCombatTracker"}}"                                        data-action="setSR"                                        data-set-sr="{{sum @root.system.attributes.sizStrikeRank
                                                           @root.system.attributes.dexStrikeRank
                                                           strikeRank}}">
                             {{sum @root.system.attributes.sizStrikeRank @root.system.attributes.dexStrikeRank strikeRank}}
@@ -332,8 +331,7 @@
                         {{/if}}
                       {{else}}
                         <span><button type="button" class="combat sr contextmenu"
-                                      data-tooltip="{{localize "RQG.Actor.Combat.SetSRInCombatTracker"}}"
-                                      data-set-sr="{{sum @root.system.attributes.sizStrikeRank
+                                      data-tooltip="{{localize "RQG.Actor.Combat.SetSRInCombatTracker"}}"                                      data-action="setSR"                                      data-set-sr="{{sum @root.system.attributes.sizStrikeRank
                                                         @root.system.attributes.dexStrikeRank
                                                         strikeRank}}">
                           {{sum @root.system.attributes.sizStrikeRank @root.system.attributes.dexStrikeRank strikeRank}}

--- a/src/actors/sheet-parts-v2/actorSheetV2Gear.hbs
+++ b/src/actors/sheet-parts-v2/actorSheetV2Gear.hbs
@@ -16,7 +16,7 @@
         <h2>{{localize "RQG.Actor.Gear.Gear"}}</h2>
         <div class="grid location-row">
           <div class="headings"></div>
-          <div class="head1"><button class="sort" data-sort-items="physical-by-location" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button>{{localize "RQG.Actor.Gear.Name"}}</div>
+          <div class="head1"><button class="sort" data-action="sortItems" data-sort-items="physical-by-location" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button>{{localize "RQG.Actor.Gear.Name"}}</div>
           <div class="head2" style="width:45px">{{localize "RQG.Actor.Gear.EncumbranceAbbr"}}</div>
           <div class="head3"></div>
           <div class="head4" style="width:85px">{{localize "RQG.Actor.Gear.Location"}}</div>
@@ -35,11 +35,11 @@
           <article class="flex-1">
             <h2 class="flex-row">
               <span>{{localize "RQG.Actor.Gear.Gear"}}</span>
-              {{#if @root.isEditable}}<a data-tooltip="{{localize 'RQG.Actor.Gear.AddNewGearUniqueTip'}}" data-gear-add="unique"><i class="fas fa-plus"></i></a>{{/if}}
+              {{#if @root.isEditable}}<a data-tooltip="{{localize 'RQG.Actor.Gear.AddNewGearUniqueTip'}}" data-action="addGear" data-gear-add="unique"><i class="fas fa-plus"></i></a>{{/if}}
             </h2>
             <div class="grid gear gear-no-price item-list">
               <div class="headings"></div>
-              <div class="head1"><button class="sort" data-sort-items="gear" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
+              <div class="head1"><button class="sort" data-action="sortItems" data-sort-items="gear" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
               <div class="head2">{{localize "RQG.Actor.Gear.Name"}}</div>
               <div class="head3"></div>
               <div class="head4"><span class="text-right">{{localize "RQG.Actor.Gear.EncumbranceAbbr"}}</span></div>
@@ -72,7 +72,7 @@
             <article>
               <h2 class="flex-row">
                 <span>{{localize "RQG.Actor.Gear.Currency"}}</span>
-                {{#if @root.isEditable}}<a data-tooltip="{{localize 'RQG.Actor.Gear.AddNewGearCurrencyTip'}}" data-gear-add="currency"><i class="fas fa-plus"></i></a>{{/if}}
+                {{#if @root.isEditable}}<a data-tooltip="{{localize 'RQG.Actor.Gear.AddNewGearCurrencyTip'}}" data-action="addGear" data-gear-add="currency"><i class="fas fa-plus"></i></a>{{/if}}
               </h2>
               <div class="grid gear item-list">
                 <div class="headings"></div>
@@ -124,7 +124,7 @@
             <article>
               <h2 class="flex-row">
                 <span>{{localize "RQG.Actor.Gear.Consumables"}}</span>
-                {{#if @root.isEditable}}<a data-tooltip="{{localize 'RQG.Actor.Gear.AddNewGearConsumablesTip'}}" data-gear-add="consumable"><i class="fas fa-plus"></i></a>{{/if}}
+                {{#if @root.isEditable}}<a data-tooltip="{{localize 'RQG.Actor.Gear.AddNewGearConsumablesTip'}}" data-action="addGear" data-gear-add="consumable"><i class="fas fa-plus"></i></a>{{/if}}
               </h2>
               <div class="grid gear gear-no-price item-list">
                 <div class="headings"></div>
@@ -165,7 +165,7 @@
           <h2>{{localize "RQG.Actor.Gear.WeaponsAndShields"}}</h2>
           <div class="grid weapon item-list">
             <div class="headings"></div>
-            <div class="head1"><button class="sort" data-sort-items="weapon" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
+            <div class="head1"><button class="sort" data-action="sortItems" data-sort-items="weapon" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
             <div class="head2">{{localize "RQG.Actor.Gear.Name"}}</div>
             <div class="head3">{{localize "RQG.Actor.Gear.Skill"}}</div>
             <div class="head4"><span class="text-center">{{localize "RQG.Actor.Gear.Range"}}</span></div>
@@ -292,7 +292,7 @@
           <h2>{{localize "RQG.Actor.Gear.Armor"}}</h2>
           <div class="grid armor item-list">
             <div class="headings"></div>
-            <div class="head1"><button class="sort" data-sort-items="armor" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
+            <div class="head1"><button class="sort" data-action="sortItems" data-sort-items="armor" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
             <div class="head2">{{localize "RQG.Actor.Gear.Name"}}</div>
             <div class="head3"><span class="text-right">{{localize "RQG.Actor.Gear.Absorbs"}}</span></div>
             <div class="head4">{{localize "RQG.Actor.Gear.HitLocations"}}</div>

--- a/src/actors/sheet-parts-v2/actorSheetV2Header.hbs
+++ b/src/actors/sheet-parts-v2/actorSheetV2Header.hbs
@@ -69,7 +69,7 @@
              {{#if (and (eq key "power") @root.powWarning)}}
                data-tooltip="{{localize 'RQG.Actor.Characteristics.PowWarningTip'}}"
              {{/if}}>
-          <label class="resource-label norse characteristic contextmenu">
+          <label class="resource-label norse characteristic contextmenu" data-characteristic-roll>
             {{localize (concat 'RQG.Actor.Characteristics.' key)}}
           </label>
           {{#if @root.editMode}}
@@ -78,7 +78,9 @@
                    min="0" max="99"
                    value="{{characteristic.value}}">
           {{else}}
-            <div class="value characteristic contextmenu">{{characteristic.value}}</div>
+            <div class="value characteristic contextmenu" data-characteristic-roll>
+              {{characteristic.value}}
+            </div>
           {{/if}}
           <input type="text" name="system.characteristics.{{key}}.formula"
                  class="characteristic contextmenu"

--- a/src/actors/sheet-parts-v2/actorSheetV2Passions.hbs
+++ b/src/actors/sheet-parts-v2/actorSheetV2Passions.hbs
@@ -1,9 +1,9 @@
 <section class="tab passions-tab-v2" data-group="primary" data-tab="passions">
 
   <h2>
-    <button class="sort" data-sort-items="passion" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button>
+    <button class="sort" data-action="sortItems" data-sort-items="passion" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button>
     {{localize "RQG.Actor.Passion.Passions"}}
-    {{#if @root.isEditable}}<a class="passion-add-btn" data-passion-add data-tooltip="{{localize 'RQG.Actor.Passion.AddNewPassionTip'}}"><i class="fas fa-plus"></i></a>{{/if}}
+    {{#if @root.isEditable}}<a class="passion-add-btn" data-action="addPassion" data-tooltip="{{localize 'RQG.Actor.Passion.AddNewPassionTip'}}"><i class="fas fa-plus"></i></a>{{/if}}
   </h2>
 
   <div class="passions-list">

--- a/src/actors/sheet-parts-v2/actorSheetV2RuneMagic.hbs
+++ b/src/actors/sheet-parts-v2/actorSheetV2RuneMagic.hbs
@@ -4,10 +4,10 @@
   {{#each embeddedItems.runeMagic}}
     {{#unless system.cultId}}
       <div class="unassigned-rune-magic" data-item-id="{{id}}">
-        <a data-tooltip="{{localize "RQG.Actor.RuneMagic.EditRuneMagicSpellTitle"}}" data-item-edit>
+        <a data-tooltip="{{localize "RQG.Actor.RuneMagic.EditRuneMagicSpellTitle"}}" data-action="editItem">
           <i class="fas fa-edit"></i>{{localize "RQG.Actor.RuneMagic.ChooseCultForRuneSpell" name=name}}
         </a>
-        <a data-tooltip="{{localize "RQG.Actor.RuneMagic.DeleteRuneMagicSpellTitle"}}" data-item-delete>
+        <a data-tooltip="{{localize "RQG.Actor.RuneMagic.DeleteRuneMagicSpellTitle"}}" data-action="deleteItem">
           <i class="fas fa-trash"></i>
         </a>
       </div>
@@ -104,7 +104,7 @@
       {{#if hasAccessToRuneMagic}}
         <div class="grid runemagic item-list">
           <div class="headings"></div>
-          <div class="head1"><button class="sort" data-sort-items="runeMagic" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
+          <div class="head1"><button class="sort" data-action="sortItems" data-sort-items="runeMagic" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
           <div class="head2">{{localize "RQG.Actor.RuneMagic.RuneSpell"}}</div>
           <div class="head3">{{localize "RQG.Actor.RuneMagic.SpellSummary"}}</div>
           <div class="head4">{{localize "RQG.Actor.RuneMagic.Chance"}}</div>

--- a/src/actors/sheet-parts-v2/actorSheetV2SpiritMagic.hbs
+++ b/src/actors/sheet-parts-v2/actorSheetV2SpiritMagic.hbs
@@ -25,7 +25,7 @@
 
   <div class="grid spiritmagic item-list">
     <div class="headings"></div>
-    <div class="head1"><button class="sort" data-sort-items="spiritMagic" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
+    <div class="head1"><button class="sort" data-action="sortItems" data-sort-items="spiritMagic" data-tooltip="{{localize "RQG.UI.SortItems"}}"><i class="fas fa-arrow-down-a-z"></i></button></div>
     <div class="head2">{{localize "RQG.Actor.SpiritMagic.Name"}}</div>
       <div class="head3">{{localize "RQG.Actor.SpiritMagic.SpellSummary"}}</div>
        <div class="head4">{{localize "RQG.Actor.SpiritMagic.SpellFocus"}}</div>

--- a/src/actors/sheet-parts/activeeffects-debug-tab.hbs
+++ b/src/actors/sheet-parts/activeeffects-debug-tab.hbs
@@ -12,13 +12,13 @@
   </tr>
   </thead>
   {{#each effects}}
-  <tr data-effect-uuid="{{uuid}}">
-    <td data-actor-effect-edit><img class="effect-img" src="{{img}}"></td>
+  <tr data-effect-uuid="{{uuid}}" data-action="editActiveEffect">
+    <td><img class="effect-img" src="{{img}}"></td>
     <td>{{name}}<br>{{toAnchor parent.uuid}}</td>
-    <td data-actor-effect-edit>{{yes-no disabled}}</td>
-    <td data-actor-effect-edit>{{duration.startTime}}</td>
-    <td data-actor-effect-edit>{{duration.seconds}}</td>
-    <td data-actor-effect-edit>
+    <td>{{yes-no disabled}}</td>
+    <td>{{duration.startTime}}</td>
+    <td>{{duration.seconds}}</td>
+    <td>
       <table>
       {{#each changes}}
         <tbody>
@@ -31,7 +31,7 @@
       {{/each}}
       </table>
     </td>
-    <td class="text-right"><a data-tooltip="Delete Effect" data-actor-effect-delete><i class="fas fa-trash"></i></a></td>
+    <td class="text-right"><a data-tooltip="Delete Effect" data-action="deleteActiveEffect"><i class="fas fa-trash"></i></a></td>
     </tr>
   {{/each}}
 </table>

--- a/src/applications/actorWizardApplication.ts
+++ b/src/applications/actorWizardApplication.ts
@@ -522,6 +522,7 @@ export class ActorWizard extends ActorWizardBase {
     // RQID link click handlers
     if (this.element instanceof HTMLElement) {
       void RqidLink.addRqidLinkClickHandlers(this.element);
+      RqidLink.addRqidLinkDeleteHandlers(this.element, this.actor as foundry.abstract.Document.Any);
     }
   }
 

--- a/src/applications/actorWizardApplication.ts
+++ b/src/applications/actorWizardApplication.ts
@@ -519,10 +519,9 @@ export class ActorWizard extends ActorWizardBase {
       });
     });
 
-    // RQID link click handlers
-    if (this.element instanceof HTMLElement) {
-      void RqidLink.addRqidLinkClickHandlers(this.element);
-      RqidLink.addRqidLinkDeleteHandlers(this.element, this.actor as foundry.abstract.Document.Any);
+    // RQID link open/delete handlers (bind once)
+    if (options.isFirstRender) {
+      RqidLink.bindHandlers(this.element, this.actor as foundry.abstract.Document.Any);
     }
   }
 

--- a/src/data-model/shared/rqidLink.ts
+++ b/src/data-model/shared/rqidLink.ts
@@ -2,6 +2,8 @@ import { Rqid } from "../../system/api/rqidApi";
 import { isValidRqidString } from "../../system/api/rqidValidation";
 import { getDomDataset, getRequiredDomDataset } from "../../system/util";
 
+type RqidDocument = foundry.abstract.Document.Any;
+
 export class RqidLink<R extends string = string> {
   /** The rqid to link to */
   readonly rqid: R;
@@ -21,7 +23,82 @@ export class RqidLink<R extends string = string> {
    * @deprecated Use addRqidLinkClickHandlers with HTMLElement for AppV2/native sheets.
    */
   static async addRqidLinkClickHandlersToJQuery(jQuery: JQuery): Promise<void> {
-    await RqidLink.addRqidLinkClickHandlers(jQuery[0] as HTMLElement);
+    RqidLink.bindHandlers(jQuery[0] as HTMLElement);
+  }
+
+  /**
+   * Handle RQID link deletion for legacy AppV1/JQuery sheets.
+   *
+   * @deprecated Use bindHandlers with HTMLElement for AppV2/native sheets.
+   */
+  static addRqidLinkDeleteHandlersToJQuery(jQuery: JQuery, document: RqidDocument): void {
+    RqidLink.bindHandlers(jQuery[0] as HTMLElement, document);
+  }
+
+  /**
+   * Bind delegated handlers for RQID link open/delete behavior.
+   * Uses one-time flags on the root element to avoid duplicate listeners on re-render.
+   */
+  static bindHandlers(html: HTMLElement, document?: RqidDocument): void {
+    if (html.dataset["rqidLinkOpenBound"] !== "true") {
+      html.dataset["rqidLinkOpenBound"] = "true";
+      html.addEventListener("click", (ev: MouseEvent) => {
+        if (!(ev.target instanceof Element)) {
+          return;
+        }
+
+        const linkEl = ev.target.closest<HTMLElement>("[data-rqid-link]");
+        if (!linkEl || ev.target instanceof HTMLInputElement) {
+          return;
+        }
+
+        const rqid = getDomDataset(linkEl, "rqid-link");
+        const targetRqidLink = getDomDataset(ev, "rqid-link");
+        const targetUuid = getDomDataset(ev, "uuid");
+        if (!rqid || targetUuid || targetRqidLink !== rqid) {
+          return; // exclude inputs and embedded uuid & rqid links
+        }
+
+        if (isValidRqidString(rqid)) {
+          const anchor = getDomDataset(linkEl, "anchor");
+          void Rqid.renderRqidDocument(rqid, anchor);
+        }
+      });
+    }
+
+    if (document && html.dataset["rqidLinkDeleteBound"] !== "true") {
+      html.dataset["rqidLinkDeleteBound"] = "true";
+      html.addEventListener("click", (ev: MouseEvent) => {
+        if (!(ev.target instanceof Element)) {
+          return;
+        }
+
+        const deleteEl = ev.target.closest<HTMLElement>("[data-delete-from-property]");
+        if (!deleteEl || !html.contains(deleteEl)) {
+          return;
+        }
+
+        ev.preventDefault();
+        ev.stopPropagation();
+        void RqidLink.deleteRqidLink(deleteEl, document);
+      });
+    }
+
+    if (document && html.dataset["rqidLinkBonusBound"] !== "true") {
+      html.dataset["rqidLinkBonusBound"] = "true";
+      html.addEventListener("change", (ev: Event) => {
+        if (!(ev.target instanceof HTMLInputElement)) {
+          return;
+        }
+
+        const bonusEl = ev.target.closest<HTMLInputElement>("[data-edit-bonus-property-name]");
+        if (!bonusEl || !html.contains(bonusEl)) {
+          return;
+        }
+
+        void RqidLink.updateRqidLinkBonus(bonusEl, document);
+      });
+    }
   }
 
   /**
@@ -29,59 +106,87 @@ export class RqidLink<R extends string = string> {
    * For embedded items the update is routed through the parent actor's updateEmbeddedDocuments;
    * for all other documents (actors, top-level items) document.update() is used directly.
    */
-  static addRqidLinkDeleteHandlers(
-    html: HTMLElement,
-    document: foundry.abstract.Document.Any,
-  ): void {
-    html.querySelectorAll<HTMLElement>("[data-delete-from-property]").forEach((el) => {
-      const deleteRqid = getRequiredDomDataset(el, "delete-rqid");
-      const deleteIndexRaw = getDomDataset(el, "delete-index");
-      const deleteIndex = Number.parseInt(deleteIndexRaw ?? "", 10);
-      const deleteFromPropertyName = getRequiredDomDataset(el, "delete-from-property");
-      el.addEventListener("click", async () => {
-        const deleteFromProperty = foundry.utils.getProperty(
-          (document as any).system as object,
-          deleteFromPropertyName,
-        );
-        const updateKey = `system.${deleteFromPropertyName}`;
-        let newValue: RqidLink[] | null = null;
-        if (Array.isArray(deleteFromProperty)) {
-          const links = [...(deleteFromProperty as RqidLink[])];
-          if (Number.isInteger(deleteIndex) && deleteIndex >= 0 && deleteIndex < links.length) {
-            links.splice(deleteIndex, 1);
-            newValue = links;
-          } else {
-            newValue = links.filter((r) => r.rqid !== deleteRqid);
-          }
-        }
-        if ((document as any).isEmbedded && (document as any).actor) {
-          await (document as any).actor.updateEmbeddedDocuments("Item", [
-            { _id: document.id, [updateKey]: newValue },
-          ]);
-        } else {
-          await (document as any).update({ [updateKey]: newValue });
-        }
-      });
-    });
+  static addRqidLinkDeleteHandlers(html: HTMLElement, document: RqidDocument): void {
+    RqidLink.bindHandlers(html, document);
+  }
+
+  /**
+   * Handle RQID link bonus editing for legacy AppV1/JQuery sheets.
+   *
+   * @deprecated Use bindHandlers with HTMLElement for AppV2/native sheets.
+   */
+  static addRqidLinkBonusHandlersToJQuery(jQuery: JQuery, document: RqidDocument): void {
+    RqidLink.bindHandlers(jQuery[0] as HTMLElement, document);
   }
 
   static async addRqidLinkClickHandlers(html: HTMLElement): Promise<void> {
-    html.querySelectorAll("[data-rqid-link]").forEach((el: Element) => {
-      const rqid = getDomDataset(el, "rqid-link");
-      const anchor = getDomDataset(el, "anchor");
-      if (rqid) {
-        el.addEventListener("click", async (ev) => {
-          const targetRqidLink = getDomDataset(ev, "rqid-link");
-          const targetUuid = getDomDataset(ev, "uuid");
+    RqidLink.bindHandlers(html);
+  }
 
-          if (ev.target instanceof HTMLInputElement || targetUuid || targetRqidLink !== rqid) {
-            return; // exclude inputs and embedded uuid & rqid links
-          }
-          if (isValidRqidString(rqid)) {
-            await Rqid.renderRqidDocument(rqid, anchor);
-          }
-        });
+  private static async deleteRqidLink(el: HTMLElement, document: RqidDocument): Promise<void> {
+    const deleteRqid = getRequiredDomDataset(el, "delete-rqid");
+    const deleteIndexRaw = getDomDataset(el, "delete-index");
+    const deleteIndex = Number.parseInt(deleteIndexRaw ?? "", 10);
+    const deleteFromPropertyName = getRequiredDomDataset(el, "delete-from-property");
+
+    const deleteFromProperty = foundry.utils.getProperty(
+      (document as any).system as object,
+      deleteFromPropertyName,
+    );
+
+    const updateKey = `system.${deleteFromPropertyName}`;
+    let newValue: RqidLink[] | null = null;
+    if (Array.isArray(deleteFromProperty)) {
+      const links = [...(deleteFromProperty as RqidLink[])];
+      if (Number.isInteger(deleteIndex) && deleteIndex >= 0 && deleteIndex < links.length) {
+        links.splice(deleteIndex, 1);
+        newValue = links;
+      } else {
+        newValue = links.filter((r) => r.rqid !== deleteRqid);
       }
-    });
+    }
+
+    if ((document as any).isEmbedded && (document as any).actor) {
+      await (document as any).actor.updateEmbeddedDocuments("Item", [
+        { _id: document.id, [updateKey]: newValue },
+      ]);
+      return;
+    }
+
+    await (document as any).update({ [updateKey]: newValue });
+  }
+
+  private static async updateRqidLinkBonus(
+    el: HTMLInputElement,
+    document: RqidDocument,
+  ): Promise<void> {
+    const editRqid = getRequiredDomDataset(el, "rqid");
+    const editPropertyName = getRequiredDomDataset(el, "edit-bonus-property-name");
+    const sourceProperty = foundry.utils.getProperty(
+      (document as any).system as object,
+      editPropertyName,
+    );
+
+    const parsedBonus = Number(el.value);
+    const bonus = Number.isFinite(parsedBonus) ? parsedBonus : null;
+
+    let updateProperty: RqidLink | RqidLink[] | null = null;
+    if (Array.isArray(sourceProperty)) {
+      updateProperty = [...(sourceProperty as RqidLink[])].map((rqidLink) =>
+        rqidLink.rqid === editRqid ? { ...rqidLink, bonus } : rqidLink,
+      );
+    } else if (sourceProperty) {
+      updateProperty = { ...(sourceProperty as RqidLink), bonus };
+    }
+
+    const updateKey = `system.${editPropertyName}`;
+    if ((document as any).isEmbedded && (document as any).actor) {
+      await (document as any).actor.updateEmbeddedDocuments("Item", [
+        { _id: document.id, [updateKey]: updateProperty },
+      ]);
+      return;
+    }
+
+    await (document as any).update({ [updateKey]: updateProperty });
   }
 }

--- a/src/data-model/shared/rqidLink.ts
+++ b/src/data-model/shared/rqidLink.ts
@@ -1,6 +1,6 @@
 import { Rqid } from "../../system/api/rqidApi";
 import { isValidRqidString } from "../../system/api/rqidValidation";
-import { getDomDataset } from "../../system/util";
+import { getDomDataset, getRequiredDomDataset } from "../../system/util";
 
 export class RqidLink<R extends string = string> {
   /** The rqid to link to */
@@ -22,6 +22,47 @@ export class RqidLink<R extends string = string> {
    */
   static async addRqidLinkClickHandlersToJQuery(jQuery: JQuery): Promise<void> {
     await RqidLink.addRqidLinkClickHandlers(jQuery[0] as HTMLElement);
+  }
+
+  /**
+   * Bind click handlers on [data-delete-from-property] elements to delete RqidLinks.
+   * For embedded items the update is routed through the parent actor's updateEmbeddedDocuments;
+   * for all other documents (actors, top-level items) document.update() is used directly.
+   */
+  static addRqidLinkDeleteHandlers(
+    html: HTMLElement,
+    document: foundry.abstract.Document.Any,
+  ): void {
+    html.querySelectorAll<HTMLElement>("[data-delete-from-property]").forEach((el) => {
+      const deleteRqid = getRequiredDomDataset(el, "delete-rqid");
+      const deleteIndexRaw = getDomDataset(el, "delete-index");
+      const deleteIndex = Number.parseInt(deleteIndexRaw ?? "", 10);
+      const deleteFromPropertyName = getRequiredDomDataset(el, "delete-from-property");
+      el.addEventListener("click", async () => {
+        const deleteFromProperty = foundry.utils.getProperty(
+          (document as any).system as object,
+          deleteFromPropertyName,
+        );
+        const updateKey = `system.${deleteFromPropertyName}`;
+        let newValue: RqidLink[] | null = null;
+        if (Array.isArray(deleteFromProperty)) {
+          const links = [...(deleteFromProperty as RqidLink[])];
+          if (Number.isInteger(deleteIndex) && deleteIndex >= 0 && deleteIndex < links.length) {
+            links.splice(deleteIndex, 1);
+            newValue = links;
+          } else {
+            newValue = links.filter((r) => r.rqid !== deleteRqid);
+          }
+        }
+        if ((document as any).isEmbedded && (document as any).actor) {
+          await (document as any).actor.updateEmbeddedDocuments("Item", [
+            { _id: document.id, [updateKey]: newValue },
+          ]);
+        } else {
+          await (document as any).update({ [updateKey]: newValue });
+        }
+      });
+    });
   }
 
   static async addRqidLinkClickHandlers(html: HTMLElement): Promise<void> {

--- a/src/items/RqgItemSheet.ts
+++ b/src/items/RqgItemSheet.ts
@@ -188,84 +188,16 @@ export class RqgItemSheet<
     // Handle rqid links
     void RqidLink.addRqidLinkClickHandlersToJQuery($(this.form!));
 
-    // Handle deleting RqidLinks from RqidLink Array Properties
-    $(this.form!)
-      .find("[data-delete-from-property]")
-      .each((i: number, el: HTMLElement) => {
-        const deleteRqid = getRequiredDomDataset($(el), "delete-rqid");
-        const deleteIndexRaw = getDomDataset($(el), "delete-index");
-        const deleteIndex = Number.parseInt(deleteIndexRaw ?? "", 10);
-        const deleteFromPropertyName = getRequiredDomDataset($(el), "delete-from-property");
-        el.addEventListener("click", async () => {
-          const deleteFromProperty = foundry.utils.getProperty(
-            this.item.system as object,
-            deleteFromPropertyName,
-          );
-          const updateKey = `system.${deleteFromPropertyName}`;
-          if (Array.isArray(deleteFromProperty)) {
-            const links = [...(deleteFromProperty as RqidLink[])];
-            const newValueArray =
-              Number.isInteger(deleteIndex) && deleteIndex >= 0 && deleteIndex < links.length
-                ? (links.splice(deleteIndex, 1), links)
-                : links.filter((r) => r.rqid !== deleteRqid);
-            // @ts-expect-error isEmbedded
-            if (this.isEmbedded) {
-              await this.actor?.updateEmbeddedDocuments("Item", [
-                { _id: this.item.id, [updateKey]: newValueArray },
-              ]);
-            } else {
-              await this.item.update({ [updateKey]: newValueArray });
-            }
-          } else {
-            // @ts-expect-error isEmbedded
-            if (this.isEmbedded) {
-              await this.actor?.updateEmbeddedDocuments("Item", [
-                { _id: this.item.id, [updateKey]: "" },
-              ]);
-            } else {
-              await this.item.update({ [updateKey]: "" });
-            }
-          }
-        });
-      });
+    // Handle deleting RQID links
+    RqidLink.addRqidLinkDeleteHandlersToJQuery(
+      $(this.form!),
+      this.item as foundry.abstract.Document.Any,
+    );
 
-    $(this.form!)
-      .find("[data-edit-bonus-property-name]")
-      .each((i: number, el: HTMLElement) => {
-        const editRqid = getRequiredDomDataset($(el), "rqid");
-        const editPropertyName = getRequiredDomDataset($(el), "edit-bonus-property-name");
-        el.addEventListener("change", async () => {
-          const updateProperty = foundry.utils.getProperty(
-            this.item.system as object,
-            editPropertyName,
-          );
-          const updateKey = `system.${editPropertyName}`;
-          if (Array.isArray(updateProperty)) {
-            const updateRqidLink = (updateProperty as RqidLink[]).find(
-              (rqidLink) => rqidLink.rqid === editRqid,
-            );
-            if (updateRqidLink) {
-              updateRqidLink.bonus = Number((el as HTMLInputElement).value);
-            }
-            if (this.item.isEmbedded) {
-              await this.item.actor?.updateEmbeddedDocuments("Item", [
-                { _id: this.item.id, [updateKey]: updateProperty },
-              ]);
-            } else {
-              await this.item.update({ [updateKey]: updateProperty });
-            }
-          } else {
-            (updateProperty as RqidLink).bonus = Number((el as HTMLInputElement).value);
-            if (this.item.isEmbedded) {
-              await this.actor?.updateEmbeddedDocuments("Item", [
-                { _id: this.item.id, [updateKey]: updateProperty },
-              ]);
-            } else {
-              await this.item.update({ [updateKey]: updateProperty });
-            }
-          }
-        });
-      });
+    RqidLink.addRqidLinkBonusHandlersToJQuery(
+      $(this.form!),
+      this.item as foundry.abstract.Document.Any,
+    );
   }
 
   _onDragEnter(event: DragEvent): void {

--- a/src/items/RqgItemSheetV2.ts
+++ b/src/items/RqgItemSheetV2.ts
@@ -246,37 +246,10 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
     });
 
     // Delete an entry from an RqidLink array property
-    this.element.querySelectorAll<HTMLElement>("[data-delete-from-property]").forEach((el) => {
-      const deleteRqid = getRequiredDomDataset(el, "delete-rqid");
-      const deleteIndexRaw = getDomDataset(el, "delete-index");
-      const deleteIndex = Number.parseInt(deleteIndexRaw ?? "", 10);
-      const deleteFromPropertyName = getRequiredDomDataset(el, "delete-from-property");
-      el.addEventListener("click", async () => {
-        const deleteFromProperty = foundry.utils.getProperty(
-          this.document.system as object,
-          deleteFromPropertyName,
-        );
-        const isArray = Array.isArray(deleteFromProperty);
-        let newValue: RqidLink[] | string = "";
-        if (isArray) {
-          const links = [...(deleteFromProperty as RqidLink[])];
-          if (Number.isInteger(deleteIndex) && deleteIndex >= 0 && deleteIndex < links.length) {
-            links.splice(deleteIndex, 1);
-            newValue = links;
-          } else {
-            newValue = links.filter((r) => r.rqid !== deleteRqid);
-          }
-        }
-        const updateKey = `system.${deleteFromPropertyName}`;
-        if (this.document.isEmbedded) {
-          await this.document.actor?.updateEmbeddedDocuments("Item", [
-            { _id: this.document.id, [updateKey]: newValue },
-          ]);
-        } else {
-          await this.document.update({ [updateKey]: newValue });
-        }
-      });
-    });
+    RqidLink.addRqidLinkDeleteHandlers(
+      this.element,
+      this.document as foundry.abstract.Document.Any,
+    );
 
     // Edit the bonus field on an RqidLink
     this.element

--- a/src/items/RqgItemSheetV2.ts
+++ b/src/items/RqgItemSheetV2.ts
@@ -125,9 +125,9 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
     // RQID header button (AppV2 version)
     await addRqidLinkToSheet(this as unknown as DocumentSheet<any, any>);
 
-    // RQID link click handlers in the sheet body
-    if (this.element instanceof HTMLElement) {
-      void RqidLink.addRqidLinkClickHandlers(this.element);
+    // RQID link open/delete handlers in the sheet body (bind once)
+    if (options.isFirstRender) {
+      RqidLink.bindHandlers(this.element, this.document as foundry.abstract.Document.Any);
     }
 
     // Drag-drop (register element-level listeners only on first render to avoid duplicates)
@@ -244,44 +244,6 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
         (fromUuidSync(effectUuid) as any)?.delete();
       });
     });
-
-    // Delete an entry from an RqidLink array property
-    RqidLink.addRqidLinkDeleteHandlers(
-      this.element,
-      this.document as foundry.abstract.Document.Any,
-    );
-
-    // Edit the bonus field on an RqidLink
-    this.element
-      .querySelectorAll<HTMLInputElement>("[data-edit-bonus-property-name]")
-      .forEach((el) => {
-        const editRqid = getRequiredDomDataset(el, "rqid");
-        const editPropertyName = getRequiredDomDataset(el, "edit-bonus-property-name");
-        el.addEventListener("change", async () => {
-          const updateProperty = foundry.utils.getProperty(
-            this.document.system as object,
-            editPropertyName,
-          );
-          if (Array.isArray(updateProperty)) {
-            const linkToEdit = (updateProperty as RqidLink[]).find(
-              (rqidLink) => rqidLink.rqid === editRqid,
-            );
-            if (linkToEdit) {
-              linkToEdit.bonus = Number(el.value);
-            }
-          } else {
-            (updateProperty as RqidLink).bonus = Number(el.value);
-          }
-          const updateKey = `system.${editPropertyName}`;
-          if (this.document.isEmbedded) {
-            await this.document.actor?.updateEmbeddedDocuments("Item", [
-              { _id: this.document.id, [updateKey]: updateProperty },
-            ]);
-          } else {
-            await this.document.update({ [updateKey]: updateProperty });
-          }
-        });
-      });
   }
 
   _onDragEnter(event: DragEvent): void {

--- a/src/items/hit-location-item/hitLocationSheet.ts
+++ b/src/items/hit-location-item/hitLocationSheet.ts
@@ -223,20 +223,6 @@ export class HitLocationSheet extends RqgItemSheet {
       await actor.update(actorUpdates as any);
     }
 
-    if (actor.isToken) {
-      await actor.updateTokenEffectFromHealth();
-    } else {
-      const activeTokens = actor.getActiveTokens(true, false);
-      const currentScene = game.scenes?.current;
-      if (currentScene && activeTokens.length) {
-        // TODO could be a bug if the actor has tokens in multiple scenes maybe. then getting activeTokens[0] could be wrong. Should check that the scene match?
-        const token = currentScene.getEmbeddedDocument("Token", activeTokens[0]?.id ?? "", {});
-        if (token) {
-          await actor.updateTokenEffectFromHealth();
-        }
-      }
-    }
-
     for (const update of usefulLegs) {
       if (update != null && update._id != null) {
         // TODO make sure usefulLegs only contain real data

--- a/src/items/hit-location-item/hitLocationSheetV2.ts
+++ b/src/items/hit-location-item/hitLocationSheetV2.ts
@@ -239,19 +239,6 @@ export class HitLocationSheetV2 extends RqgItemSheetV2 {
       await actor.update(actorUpdates as any);
     }
 
-    if (actor.isToken) {
-      await actor.updateTokenEffectFromHealth();
-    } else {
-      const activeTokens = actor.getActiveTokens(true, false);
-      const currentScene = game.scenes?.current;
-      if (currentScene && activeTokens.length) {
-        const token = currentScene.getEmbeddedDocument("Token", activeTokens[0]?.id ?? "", {});
-        if (token) {
-          await actor.updateTokenEffectFromHealth();
-        }
-      }
-    }
-
     for (const update of usefulLegs) {
       if (update != null && update._id != null) {
         const item = actor.items.get(update._id);

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -651,6 +651,10 @@
         "content": "Are you sure you want to delete the {itemType} named {itemName}?",
         "contentCult": "Are you sure you want to delete the {itemType} named {itemName}? This will also delete all of the {runeMagicSpell} items associated with this {itemType}."
       },
+      "confirmActiveEffectDeleteDialog": {
+        "title": "Delete Active Effect: {effectName}",
+        "content": "Are you sure you want to delete the Active Effect named {effectName}?"
+      },
       "improveAbilityDialog": {
         "title": "Improvement for {typeLocName} \"{name}\"",
         "titleChar": "Improvement for Characteristic \"{name}\"",

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -298,7 +298,12 @@
         "AddWound": "Add Wound",
         "NoHitLocations": "This character does not have any hit locations, please add some.",
         "FlipSortOrder": "Reverse the order of the hit locations",
-        "HitLocationDiceDoNotAddUp": "⚠ The hit locations dice does not cover the range 1-20. They cover this [{dice}]."
+        "HitLocationDiceDoNotAddUp": "⚠ The hit locations dice does not cover the range 1-20. They cover this [{dice}].",
+        "Transition": {
+          "DeadFromHitPoints": "{actorName} runs out of hitpoints and dies here and now!",
+          "UnconsciousFromMagicPoints": "{actorName} faints from lack of magic points!",
+          "UnconsciousFromHitPoints": "{actorName} faints from lack of hitpoints!"
+        }
       },
       "Nav": {
         "Combat": "Combat",


### PR DESCRIPTION
- move major actor sheet interactions to ApplicationV2 DEFAULT_OPTIONS.actions
- update item/sheet render calls to v14 force-render pattern
- extract rqid delete handling into shared RqidLink helper
- reuse shared rqid delete handler in actor sheet v2, item sheet v2, and actor wizard
- include related v2 template/scss/i18n updates
- fix magic point faint message

closes: #879 