### PR TITLE
Move derived value calc into data model for character

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ["coverage/", "src/assets/packs/", "**/dist/"],
+    ignores: ["coverage/", "src/assets/packs/", "**/dist/", "playwright-report/", "test-results/"],
   },
   ...compat
     .extends(

--- a/src/actors/rqgActor.prepareDerivedData.test.ts
+++ b/src/actors/rqgActor.prepareDerivedData.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RqgActor } from "./rqgActor";
+import { ActorTypeEnum } from "../data-model/actor-data/rqgActorData";
+import * as itemLifecycleStrategy from "../items/itemLifecycleStrategy";
+import { DamageCalculations } from "../system/damageCalculations";
+
+function createCharacterActor(): any {
+  const actor = new RqgActor({ name: "Test Actor", type: ActorTypeEnum.Character }) as any;
+  actor.type = ActorTypeEnum.Character;
+  actor.items = [] as any;
+  actor.system = {
+    characteristics: {
+      strength: { value: 20 },
+      constitution: { value: 12 },
+      size: { value: 13 },
+      dexterity: { value: 15 },
+      intelligence: { value: 12 },
+      power: { value: 15 },
+      charisma: { value: 11 },
+    },
+    attributes: {
+      move: {
+        currentLocomotion: "walk",
+        walk: { value: 8, carryingFactor: 1 },
+        value: 0,
+        equipped: 0,
+        travel: 0,
+      },
+      encumbrance: { max: 0, equipped: 0, travel: 0 },
+      health: "healthy",
+      hitPoints: { value: 10, max: 10 },
+      magicPoints: { value: 5, max: 5 },
+    },
+    skillCategoryModifiers: {
+      agility: 5,
+      communication: 1,
+      knowledge: 2,
+      magic: 3,
+      manipulation: 5,
+      perception: 4,
+      stealth: 5,
+      meleeWeapons: 6,
+      missileWeapons: 7,
+      shields: 8,
+      naturalWeapons: 9,
+      otherSkills: 10,
+    },
+  } as any;
+  return actor;
+}
+
+describe("RqgActor.prepareDerivedData", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("applies encumbrance penalty after composed skill modifiers and updates derived fields", () => {
+    const actor = createCharacterActor();
+    const item = { type: "skill" } as any;
+    actor.items = [item] as any;
+    actor.actorCharacteristics = vi.fn().mockReturnValue({ str: 20, con: 12 });
+    actor.calcMaxEncumbrance = vi.fn().mockReturnValue(3);
+    actor.calcTravelEncumbrance = vi.fn().mockReturnValue(4);
+    actor.calcEquippedEncumbrance = vi.fn().mockReturnValue(5);
+
+    const itemPrepareSpy = vi
+      .spyOn(itemLifecycleStrategy, "handleActorPrepareDerivedData")
+      .mockImplementation(() => undefined);
+    const healthSpy = vi
+      .spyOn(DamageCalculations, "getCombinedActorHealth")
+      .mockReturnValue("shock" as any);
+
+    actor.prepareDerivedData();
+
+    expect(actor.system.attributes.encumbrance).toStrictEqual({
+      max: 3,
+      travel: 4,
+      equipped: 5,
+    });
+    expect(actor.system.skillCategoryModifiers).toStrictEqual({
+      agility: -5,
+      communication: 1,
+      knowledge: 2,
+      magic: 3,
+      manipulation: -5,
+      perception: 4,
+      stealth: -5,
+      meleeWeapons: -4,
+      missileWeapons: -3,
+      shields: -2,
+      naturalWeapons: -1,
+      otherSkills: 10,
+    });
+    expect(actor.system.attributes.move.value).toBe(8);
+    expect(actor.system.attributes.move.equipped).toBe(6);
+    expect(actor.system.attributes.move.travel).toBe(7);
+    expect(itemPrepareSpy).toHaveBeenCalledWith(item);
+    expect(healthSpy).toHaveBeenCalledWith(actor);
+    expect(actor.system.attributes.health).toBe("shock");
+  });
+
+  it("uses current characteristic values when computing encumbrance max", () => {
+    const actor = createCharacterActor();
+    const healthSpy = vi
+      .spyOn(DamageCalculations, "getCombinedActorHealth")
+      .mockReturnValue("healthy" as any);
+
+    actor.prepareDerivedData();
+
+    expect(actor.system.attributes.encumbrance.max).toBe(16);
+    expect(actor.system.attributes.encumbrance.equipped).toBe(0);
+    expect(actor.system.attributes.encumbrance.travel).toBe(0);
+    expect(actor.system.attributes.move.equipped).toBe(8);
+    expect(actor.system.attributes.move.travel).toBe(8);
+    expect(healthSpy).toHaveBeenCalledWith(actor);
+  });
+});

--- a/src/actors/rqgActor.ts
+++ b/src/actors/rqgActor.ts
@@ -34,6 +34,7 @@ import { RqgItem } from "@items/rqgItem.ts";
 
 import type { HitLocationItem } from "@item-model/hitLocationDataModel.ts";
 import { CharacterDataModel } from "../data-model/actor-data/characterDataModel";
+import { applyEquippedEncumbrancePenalty } from "../data-model/actor-data/derivedCharacterValues";
 
 import type { DeepPartial } from "fvtt-types/utils";
 import { physicalItemTypes } from "@item-model/IPhysicalItem.ts";
@@ -246,7 +247,8 @@ export class RqgActor extends Actor {
     assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
     const attributes = this.system.attributes;
     const { str, con } = this.actorCharacteristics();
-    const skillCategoryModifiers = this.system.skillCategoryModifiers;
+    const baseSkillCategoryModifiers =
+      this.system.baseSkillCategoryModifiers ?? this.system.skillCategoryModifiers;
 
     attributes.encumbrance = {
       max: this.calcMaxEncumbrance(
@@ -263,17 +265,15 @@ export class RqgActor extends Actor {
       (attributes.encumbrance.max || 0) - (attributes.encumbrance.equipped || 0),
     );
 
+    this.system.skillCategoryModifiers = applyEquippedEncumbrancePenalty(
+      baseSkillCategoryModifiers,
+      equippedMovementEncumbrancePenalty,
+    );
+
     attributes.move.value =
       this.system.attributes.move?.[attributes.move?.currentLocomotion]?.value || 0;
 
     attributes.move.equipped = attributes.move.value + equippedMovementEncumbrancePenalty;
-    skillCategoryModifiers.agility += equippedMovementEncumbrancePenalty * 5;
-    skillCategoryModifiers.manipulation += equippedMovementEncumbrancePenalty * 5;
-    skillCategoryModifiers.stealth += equippedMovementEncumbrancePenalty * 5;
-    skillCategoryModifiers.meleeWeapons += equippedMovementEncumbrancePenalty * 5;
-    skillCategoryModifiers.missileWeapons += equippedMovementEncumbrancePenalty * 5;
-    skillCategoryModifiers.naturalWeapons += equippedMovementEncumbrancePenalty * 5;
-    skillCategoryModifiers.shields += equippedMovementEncumbrancePenalty * 5;
 
     const travelMovementEncumbrancePenalty = Math.min(
       0,

--- a/src/actors/rqgActor.ts
+++ b/src/actors/rqgActor.ts
@@ -34,7 +34,6 @@ import { RqgItem } from "@items/rqgItem.ts";
 
 import type { HitLocationItem } from "@item-model/hitLocationDataModel.ts";
 import { CharacterDataModel } from "../data-model/actor-data/characterDataModel";
-import { getCharacteristicDerivedValues } from "../data-model/actor-data/derivedCharacterValues";
 
 import type { DeepPartial } from "fvtt-types/utils";
 import { physicalItemTypes } from "@item-model/IPhysicalItem.ts";
@@ -246,19 +245,8 @@ export class RqgActor extends Actor {
     super.prepareDerivedData();
     assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
     const attributes = this.system.attributes;
-    const { str, con, siz, dex, int, pow, cha } = this.actorCharacteristics();
-    const characteristicDerived = getCharacteristicDerivedValues({
-      str,
-      con,
-      siz,
-      dex,
-      int,
-      pow,
-      cha,
-      isCreature: this.system.attributes.isCreature,
-    });
-    const skillCategoryModifiers = (this.system.skillCategoryModifiers =
-      characteristicDerived.skillCategoryModifiers);
+    const { str, con } = this.actorCharacteristics();
+    const skillCategoryModifiers = this.system.skillCategoryModifiers;
 
     attributes.encumbrance = {
       max: this.calcMaxEncumbrance(
@@ -294,12 +282,6 @@ export class RqgActor extends Actor {
     attributes.move.travel = attributes.move.value + travelMovementEncumbrancePenalty;
 
     this.items.forEach((item) => handleActorPrepareDerivedData(item as RqgItem));
-
-    attributes.dexStrikeRank = characteristicDerived.dexStrikeRank;
-    attributes.sizStrikeRank = characteristicDerived.sizStrikeRank;
-    attributes.damageBonus = characteristicDerived.damageBonus;
-    attributes.healingRate = characteristicDerived.healingRate;
-    attributes.spiritCombatDamage = characteristicDerived.spiritCombatDamage;
 
     attributes.health = DamageCalculations.getCombinedActorHealth(this);
   }

--- a/src/actors/rqgActor.ts
+++ b/src/actors/rqgActor.ts
@@ -34,6 +34,7 @@ import { RqgItem } from "@items/rqgItem.ts";
 
 import type { HitLocationItem } from "@item-model/hitLocationDataModel.ts";
 import { CharacterDataModel } from "../data-model/actor-data/characterDataModel";
+import { getCharacteristicDerivedValues } from "../data-model/actor-data/derivedCharacterValues";
 
 import type { DeepPartial } from "fvtt-types/utils";
 import { physicalItemTypes } from "@item-model/IPhysicalItem.ts";
@@ -246,16 +247,18 @@ export class RqgActor extends Actor {
     assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
     const attributes = this.system.attributes;
     const { str, con, siz, dex, int, pow, cha } = this.actorCharacteristics();
+    const characteristicDerived = getCharacteristicDerivedValues({
+      str,
+      con,
+      siz,
+      dex,
+      int,
+      pow,
+      cha,
+      isCreature: this.system.attributes.isCreature,
+    });
     const skillCategoryModifiers = (this.system.skillCategoryModifiers =
-      RqgCalculations.skillCategoryModifiers(
-        str,
-        siz,
-        dex,
-        int,
-        pow,
-        cha,
-        this.system.attributes.isCreature,
-      ));
+      characteristicDerived.skillCategoryModifiers);
 
     attributes.encumbrance = {
       max: this.calcMaxEncumbrance(
@@ -292,11 +295,11 @@ export class RqgActor extends Actor {
 
     this.items.forEach((item) => handleActorPrepareDerivedData(item as RqgItem));
 
-    attributes.dexStrikeRank = RqgCalculations.dexSR(dex);
-    attributes.sizStrikeRank = RqgCalculations.sizSR(siz);
-    attributes.damageBonus = RqgCalculations.damageBonus(str, siz);
-    attributes.healingRate = RqgCalculations.healingRate(con);
-    attributes.spiritCombatDamage = RqgCalculations.spiritCombatDamage(pow, cha);
+    attributes.dexStrikeRank = characteristicDerived.dexStrikeRank;
+    attributes.sizStrikeRank = characteristicDerived.sizStrikeRank;
+    attributes.damageBonus = characteristicDerived.damageBonus;
+    attributes.healingRate = characteristicDerived.healingRate;
+    attributes.spiritCombatDamage = characteristicDerived.spiritCombatDamage;
 
     attributes.health = DamageCalculations.getCombinedActorHealth(this);
   }

--- a/src/actors/rqgActor.ts
+++ b/src/actors/rqgActor.ts
@@ -1,4 +1,3 @@
-import { RqgCalculations } from "../system/rqgCalculations";
 import { ActorTypeEnum, type CharacterActor } from "../data-model/actor-data/rqgActorData";
 import { ItemTypeEnum, type PhysicalItem } from "@item-model/itemTypes.ts";
 import { RqgActorSheet } from "./rqgActorSheet";
@@ -221,21 +220,13 @@ export class RqgActor extends Actor {
   }
 
   /**
-   * First prepare any derived data which is actor-specific and does not depend on Items or Active Effects
+   * Prepare embedded documents (items, effects).
+   * Note: hitPoints.max is now set in CharacterDataModel.prepareDerivedData() with support for AE effects
    */
-  override prepareBaseData(): void {
-    super.prepareBaseData();
-    assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
-    // Set this here before Active effects to allow POW crystals to boost it.
-    this.system.attributes.magicPoints.max = this.system.characteristics.power.value;
-  }
-
   override prepareEmbeddedDocuments(): void {
     super.prepareEmbeddedDocuments();
     assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
 
-    const { con, siz, pow } = this.actorCharacteristics();
-    this.system.attributes.hitPoints.max = RqgCalculations.hitPoints(con, siz, pow);
     this.items.forEach((item) => handleActorPrepareEmbeddedDocuments(item as RqgItem));
   }
 
@@ -247,8 +238,6 @@ export class RqgActor extends Actor {
     assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
     const attributes = this.system.attributes;
     const { str, con } = this.actorCharacteristics();
-    const baseSkillCategoryModifiers =
-      this.system.baseSkillCategoryModifiers ?? this.system.skillCategoryModifiers;
 
     attributes.encumbrance = {
       max: this.calcMaxEncumbrance(
@@ -265,8 +254,9 @@ export class RqgActor extends Actor {
       (attributes.encumbrance.max || 0) - (attributes.encumbrance.equipped || 0),
     );
 
+    // Apply encumbrance penalty to the composed skill modifiers (base + effects from DataModel)
     this.system.skillCategoryModifiers = applyEquippedEncumbrancePenalty(
-      baseSkillCategoryModifiers,
+      this.system.skillCategoryModifiers,
       equippedMovementEncumbrancePenalty,
     );
 

--- a/src/actors/rqgActorSheetDataPrep.test.ts
+++ b/src/actors/rqgActorSheetDataPrep.test.ts
@@ -227,13 +227,13 @@ describe("getPowCrystals", () => {
       {
         name: "Crystal A",
         changes: [
-          { key: "system.attributes.magicPoints.max", value: "3" },
+          { key: "system.effect.magicPoints.max", value: "3" },
           { key: "system.attributes.hitPoints.max", value: "2" },
         ],
       },
       {
         name: "Crystal B",
-        changes: [{ key: "system.attributes.magicPoints.max", value: 1 }],
+        changes: [{ key: "system.effect.magicPoints.max", value: 1 }],
       },
     ];
 
@@ -241,6 +241,18 @@ describe("getPowCrystals", () => {
       { name: "Crystal A", size: 3 },
       { name: "Crystal B", size: 1 },
     ]);
+  });
+
+  it("ignores legacy magicPoints.max active-effect paths", () => {
+    const actor = actorWithItems([]);
+    actor.appliedEffects = [
+      {
+        name: "Legacy Crystal",
+        changes: [{ key: "system.attributes.magicPoints.max", value: "2" }],
+      },
+    ];
+
+    expect(getPowCrystals(actor)).toEqual([]);
   });
 });
 

--- a/src/actors/rqgActorSheetDataPrep.ts
+++ b/src/actors/rqgActorSheetDataPrep.ts
@@ -219,17 +219,17 @@ export function getSpiritMagicPointSum(actor: CharacterActor): number {
  * @returns Array of POW crystals with name and size
  */
 export function getPowCrystals(actor: CharacterActor): { name: string; size: number }[] {
+  const magicPointEffectKey = "system.effect.magicPoints.max";
+
   return (
     actor.appliedEffects &&
     actor.appliedEffects
-      .filter(
-        (e) => e.changes.find((c) => c.key === "system.attributes.magicPoints.max") != undefined,
-      )
+      .filter((e) => e.changes.find((c) => c.key === magicPointEffectKey) != undefined)
       .map((e) => {
         return {
           name: e.name ?? "",
           size: e.changes
-            .filter((c) => c.key === "system.attributes.magicPoints.max")
+            .filter((c) => c.key === magicPointEffectKey)
             .reduce((acc: number, c) => acc + Number(c.value), 0),
         };
       })

--- a/src/applications/rqid-batch-editor/rqidBatchEditor.ts
+++ b/src/applications/rqid-batch-editor/rqidBatchEditor.ts
@@ -364,20 +364,19 @@ export class RqidBatchEditor extends foundry.appv1.api.FormApplication<
           continue;
         }
 
+        const tokenItemDeltaUpdates: ItemRqidUpdate[] = [];
         tokenItemUpdates.forEach((itemUpdate) => {
-          const tokenUpdate: {
-            _id: string | null;
-            delta: { _id: string | null | undefined; items: object[] };
-          } = { _id: token.id, delta: { _id: token.delta?.id, items: [] } };
           const item = token.actor!.items.get(itemUpdate.itemId);
           if (!item) {
             console.error("RQG | Could not find item on token with id", itemUpdate.itemId);
             return;
           }
+
           const newRqid = itemNames2Rqid.get(itemUpdate.name);
           if (!newRqid) {
             return;
           }
+
           const rqidFlags: DocumentRqidFlags = {
             id: isValidRqidString(newRqid) ? newRqid : ("" as RqidString),
             lang:
@@ -385,13 +384,19 @@ export class RqidBatchEditor extends foundry.appv1.api.FormApplication<
             priority: itemUpdate.documentRqidFlags.priority ?? 0,
           };
 
-          const itemData = item.toObject();
-          tokenUpdate.delta.items.push(itemData);
-          foundry.utils.setProperty(itemData, "flags.rqg.documentRqidFlags", rqidFlags);
-          if (tokenUpdate.delta.items.length) {
-            sceneUpdates.tokens.push(tokenUpdate);
+          const embeddedItemUpdate = RqidBatchEditor.getItemUpdate(itemUpdate, rqidFlags);
+          if (embeddedItemUpdate) {
+            tokenItemDeltaUpdates.push(embeddedItemUpdate);
           }
         });
+
+        if (tokenItemDeltaUpdates.length > 0) {
+          const tokenUpdate: {
+            _id: string | null;
+            delta: { _id: string | null | undefined; items: ItemRqidUpdate[] };
+          } = { _id: token.id, delta: { _id: token.delta?.id, items: tokenItemDeltaUpdates } };
+          sceneUpdates.tokens.push(tokenUpdate);
+        }
       }
       await scene.update(sceneUpdates);
       RqidBatchEditor.updateProgress(++progress, changesCount, "Update Scenes");

--- a/src/data-model/actor-data/characterDataModel.prepareDerivedData.test.ts
+++ b/src/data-model/actor-data/characterDataModel.prepareDerivedData.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import { CharacterDataModel } from "./characterDataModel";
+import { getCharacteristicDerivedValues } from "./derivedCharacterValues";
+import { RqgCalculations } from "../../system/rqgCalculations";
+
+function buildSystem() {
+  return {
+    characteristics: {
+      strength: { value: 13 },
+      constitution: { value: 11 },
+      size: { value: 13 },
+      dexterity: { value: 15 },
+      intelligence: { value: 12 },
+      power: { value: 15 },
+      charisma: { value: 11 },
+    },
+    attributes: {
+      isCreature: false,
+      magicPoints: { max: 0 },
+      hitPoints: { max: 0 },
+    },
+    effect: {
+      magicPoints: { max: 0 },
+      hitPoints: { max: 0 },
+      skillCategoryModifiers: {
+        agility: 0,
+        communication: 0,
+        knowledge: 0,
+        magic: 0,
+        manipulation: 0,
+        perception: 0,
+        stealth: 0,
+        meleeWeapons: 0,
+        missileWeapons: 0,
+        shields: 0,
+        naturalWeapons: 0,
+        otherSkills: 0,
+      },
+    },
+    baseSkillCategoryModifiers: {
+      agility: 0,
+      communication: 0,
+      knowledge: 0,
+      magic: 0,
+      manipulation: 0,
+      perception: 0,
+      stealth: 0,
+      meleeWeapons: 0,
+      missileWeapons: 0,
+      shields: 0,
+      naturalWeapons: 0,
+      otherSkills: 0,
+    },
+    skillCategoryModifiers: {
+      agility: 0,
+      communication: 0,
+      knowledge: 0,
+      magic: 0,
+      manipulation: 0,
+      perception: 0,
+      stealth: 0,
+      meleeWeapons: 0,
+      missileWeapons: 0,
+      shields: 0,
+      naturalWeapons: 0,
+      otherSkills: 0,
+    },
+  };
+}
+
+describe("CharacterDataModel.prepareDerivedData", () => {
+  it("composes base skill modifiers with effect deltas", () => {
+    const model = new CharacterDataModel({});
+    const system = buildSystem();
+    system.effect.skillCategoryModifiers.agility = 2;
+    system.effect.skillCategoryModifiers.magic = -1;
+
+    Object.assign(model as object, system);
+    model.prepareDerivedData();
+
+    const expectedBase = getCharacteristicDerivedValues({
+      str: system.characteristics.strength.value,
+      con: system.characteristics.constitution.value,
+      siz: system.characteristics.size.value,
+      dex: system.characteristics.dexterity.value,
+      int: system.characteristics.intelligence.value,
+      pow: system.characteristics.power.value,
+      cha: system.characteristics.charisma.value,
+      isCreature: system.attributes.isCreature,
+    }).skillCategoryModifiers;
+
+    const baseSkillCategoryModifiers = (model as unknown as { baseSkillCategoryModifiers: unknown })
+      .baseSkillCategoryModifiers;
+    const skillCategoryModifiers = (
+      model as unknown as {
+        skillCategoryModifiers: { agility: number; magic: number };
+      }
+    ).skillCategoryModifiers;
+
+    expect(baseSkillCategoryModifiers).toStrictEqual(expectedBase);
+    expect(skillCategoryModifiers.agility).toBe(expectedBase.agility + 2);
+    expect(skillCategoryModifiers.magic).toBe(expectedBase.magic - 1);
+  });
+
+  it("uses current-cycle effect deltas for resource max values", () => {
+    const model = new CharacterDataModel({});
+    const system = buildSystem();
+    const baseHitPoints =
+      RqgCalculations.hitPoints(
+        system.characteristics.constitution.value,
+        system.characteristics.size.value,
+        system.characteristics.power.value,
+      ) ?? 0;
+
+    Object.assign(model as object, system);
+
+    system.effect.magicPoints.max = 3;
+    system.effect.hitPoints.max = 2;
+    model.prepareDerivedData();
+
+    const cycleOneAttributes = (
+      model as unknown as {
+        attributes: { magicPoints: { max: number }; hitPoints: { max: number } };
+      }
+    ).attributes;
+
+    expect(cycleOneAttributes.magicPoints.max).toBe(18);
+    expect(cycleOneAttributes.hitPoints.max).toBe(baseHitPoints + 2);
+
+    // Simulate the next prepare cycle using a different effects state.
+    system.effect.magicPoints.max = 2;
+    system.effect.hitPoints.max = 1;
+    model.prepareDerivedData();
+
+    const cycleTwoAttributes = (
+      model as unknown as {
+        attributes: { magicPoints: { max: number }; hitPoints: { max: number } };
+      }
+    ).attributes;
+
+    expect(cycleTwoAttributes.magicPoints.max).toBe(17);
+    expect(cycleTwoAttributes.hitPoints.max).toBe(baseHitPoints + 1);
+  });
+
+  it("uses current characteristic values for derived outputs", () => {
+    const model = new CharacterDataModel({});
+    const system = buildSystem();
+
+    const baselineBase = getCharacteristicDerivedValues({
+      str: system.characteristics.strength.value,
+      con: system.characteristics.constitution.value,
+      siz: system.characteristics.size.value,
+      dex: system.characteristics.dexterity.value,
+      int: system.characteristics.intelligence.value,
+      pow: system.characteristics.power.value,
+      cha: system.characteristics.charisma.value,
+      isCreature: system.attributes.isCreature,
+    }).skillCategoryModifiers;
+
+    const baselineMagicPointsMax = system.characteristics.power.value;
+    const baselineHitPointsMax =
+      RqgCalculations.hitPoints(
+        system.characteristics.constitution.value,
+        system.characteristics.size.value,
+        system.characteristics.power.value,
+      ) ?? 0;
+
+    // Simulate characteristic-targeting ActiveEffects having already updated the
+    // prepared characteristic values before derived composition runs.
+    system.characteristics.constitution.value = 14;
+    system.characteristics.power.value = 18;
+
+    Object.assign(model as object, system);
+    model.prepareDerivedData();
+
+    const expectedBase = getCharacteristicDerivedValues({
+      str: system.characteristics.strength.value,
+      con: system.characteristics.constitution.value,
+      siz: system.characteristics.size.value,
+      dex: system.characteristics.dexterity.value,
+      int: system.characteristics.intelligence.value,
+      pow: system.characteristics.power.value,
+      cha: system.characteristics.charisma.value,
+      isCreature: system.attributes.isCreature,
+    }).skillCategoryModifiers;
+
+    const expectedHitPoints =
+      RqgCalculations.hitPoints(
+        system.characteristics.constitution.value,
+        system.characteristics.size.value,
+        system.characteristics.power.value,
+      ) ?? 0;
+
+    const preparedModel = model as unknown as {
+      baseSkillCategoryModifiers: { magic: number };
+      attributes: {
+        magicPoints: { max: number };
+        hitPoints: { max: number };
+      };
+    };
+
+    expect(expectedBase.magic).toBeGreaterThan(baselineBase.magic);
+    expect(expectedHitPoints).toBeGreaterThan(baselineHitPointsMax);
+    expect(system.characteristics.power.value).toBeGreaterThan(baselineMagicPointsMax);
+    expect(preparedModel.baseSkillCategoryModifiers.magic).toBe(expectedBase.magic);
+    expect(preparedModel.attributes.magicPoints.max).toBe(system.characteristics.power.value);
+    expect(preparedModel.attributes.hitPoints.max).toBe(expectedHitPoints);
+  });
+});

--- a/src/data-model/actor-data/characterDataModel.schema.test.ts
+++ b/src/data-model/actor-data/characterDataModel.schema.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { CharacterDataModel } from "./characterDataModel";
+
+type DataSchema = foundry.data.fields.DataSchema;
+
+function getNestedSchema(field: unknown): DataSchema {
+  const maybeSchema = (field as { schema?: DataSchema; fields?: DataSchema }) ?? {};
+  return (maybeSchema.schema ?? maybeSchema.fields ?? {}) as DataSchema;
+}
+
+describe("CharacterDataModel accumulator schema", () => {
+  it("declares resource effect accumulators as non-persisted numeric fields", () => {
+    const schema = CharacterDataModel.defineSchema();
+    const effect = getNestedSchema(schema.effect);
+    const magicPoints = getNestedSchema(effect["magicPoints"]);
+    const hitPoints = getNestedSchema(effect["hitPoints"]);
+
+    const magicPointsMax = magicPoints["max"] as { options?: Record<string, unknown> };
+    const hitPointsMax = hitPoints["max"] as { options?: Record<string, unknown> };
+
+    expect(magicPointsMax.options?.["persisted"]).toBe(false);
+    expect(magicPointsMax.options?.["initial"]).toBe(0);
+
+    expect(hitPointsMax.options?.["persisted"]).toBe(false);
+    expect(hitPointsMax.options?.["initial"]).toBe(0);
+  });
+
+  it("declares skill category effect accumulators as non-persisted zero-initialized fields", () => {
+    const schema = CharacterDataModel.defineSchema();
+    const effect = getNestedSchema(schema.effect);
+    const skillFromEffects = getNestedSchema(effect["skillCategoryModifiers"]);
+
+    const categories = [
+      "agility",
+      "communication",
+      "knowledge",
+      "magic",
+      "manipulation",
+      "perception",
+      "stealth",
+      "meleeWeapons",
+      "missileWeapons",
+      "shields",
+      "naturalWeapons",
+      "otherSkills",
+    ] as const;
+
+    for (const category of categories) {
+      const categoryField = skillFromEffects[category] as {
+        options?: Record<string, unknown>;
+      };
+      expect(categoryField.options?.["persisted"]).toBe(false);
+      expect(categoryField.options?.["initial"]).toBe(0);
+    }
+  });
+});

--- a/src/data-model/actor-data/characterDataModel.ts
+++ b/src/data-model/actor-data/characterDataModel.ts
@@ -4,6 +4,8 @@ import { resourceSchemaField } from "../shared/resourceSchemaField";
 import { actorHealthStatuses, LocomotionEnum } from "./attributes";
 import { enumChoices } from "../shared/enumChoices";
 import type { SkillCategories } from "./skillCategories";
+import { getCharacteristicDerivedValues } from "./derivedCharacterValues";
+import type { CharacterActor } from "./rqgActorData";
 
 const { BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
@@ -96,5 +98,30 @@ export class CharacterDataModel extends RqgActorDataModel<
         }),
       }),
     } as const;
+  }
+
+  override prepareDerivedData(): void {
+    super.prepareDerivedData();
+
+    const system = this as unknown as CharacterActor["system"];
+    const characteristics = system.characteristics;
+
+    const characteristicDerived = getCharacteristicDerivedValues({
+      str: characteristics.strength.value,
+      con: characteristics.constitution.value,
+      siz: characteristics.size.value,
+      dex: characteristics.dexterity.value,
+      int: characteristics.intelligence.value,
+      pow: characteristics.power.value,
+      cha: characteristics.charisma.value,
+      isCreature: system.attributes.isCreature,
+    });
+
+    system.skillCategoryModifiers = characteristicDerived.skillCategoryModifiers;
+    system.attributes.dexStrikeRank = characteristicDerived.dexStrikeRank;
+    system.attributes.sizStrikeRank = characteristicDerived.sizStrikeRank;
+    system.attributes.damageBonus = characteristicDerived.damageBonus;
+    system.attributes.healingRate = characteristicDerived.healingRate;
+    system.attributes.spiritCombatDamage = characteristicDerived.spiritCombatDamage;
   }
 }

--- a/src/data-model/actor-data/characterDataModel.ts
+++ b/src/data-model/actor-data/characterDataModel.ts
@@ -31,7 +31,10 @@ type CharacterSchema = ReturnType<typeof CharacterDataModel.defineSchema>;
 
 export class CharacterDataModel extends RqgActorDataModel<
   CharacterSchema,
-  { skillCategoryModifiers: SkillCategories }
+  {
+    skillCategoryModifiers: SkillCategories;
+    baseSkillCategoryModifiers: SkillCategories;
+  }
 > {
   static override defineSchema() {
     return {
@@ -117,6 +120,7 @@ export class CharacterDataModel extends RqgActorDataModel<
       isCreature: system.attributes.isCreature,
     });
 
+    system.baseSkillCategoryModifiers = characteristicDerived.skillCategoryModifiers;
     system.skillCategoryModifiers = characteristicDerived.skillCategoryModifiers;
     system.attributes.dexStrikeRank = characteristicDerived.dexStrikeRank;
     system.attributes.sizStrikeRank = characteristicDerived.sizStrikeRank;

--- a/src/data-model/actor-data/characterDataModel.ts
+++ b/src/data-model/actor-data/characterDataModel.ts
@@ -6,6 +6,7 @@ import { enumChoices } from "../shared/enumChoices";
 import type { SkillCategories } from "./skillCategories";
 import { getCharacteristicDerivedValues } from "./derivedCharacterValues";
 import type { CharacterActor } from "./rqgActorData";
+import { RqgCalculations } from "../../system/rqgCalculations";
 
 const { BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
@@ -99,6 +100,87 @@ export class CharacterDataModel extends RqgActorDataModel<
           initial: "healthy",
           choices: enumChoices(actorHealthStatuses, "RQG.Actor.Attributes.Health."),
         }),
+        magicPointsMaxFromEffects: new NumberField({
+          integer: true,
+          nullable: false,
+          initial: 0,
+          persisted: false,
+        }),
+        hitPointsMaxFromEffects: new NumberField({
+          integer: true,
+          nullable: false,
+          initial: 0,
+          persisted: false,
+        }),
+        skillCategoryModifiersFromEffects: new SchemaField({
+          agility: new NumberField({
+            integer: true,
+            nullable: false,
+            initial: 0,
+            persisted: false,
+          }),
+          communication: new NumberField({
+            integer: true,
+            nullable: false,
+            initial: 0,
+            persisted: false,
+          }),
+          knowledge: new NumberField({
+            integer: true,
+            nullable: false,
+            initial: 0,
+            persisted: false,
+          }),
+          magic: new NumberField({ integer: true, nullable: false, initial: 0, persisted: false }),
+          manipulation: new NumberField({
+            integer: true,
+            nullable: false,
+            initial: 0,
+            persisted: false,
+          }),
+          perception: new NumberField({
+            integer: true,
+            nullable: false,
+            initial: 0,
+            persisted: false,
+          }),
+          stealth: new NumberField({
+            integer: true,
+            nullable: false,
+            initial: 0,
+            persisted: false,
+          }),
+          meleeWeapons: new NumberField({
+            integer: true,
+            nullable: false,
+            initial: 0,
+            persisted: false,
+          }),
+          missileWeapons: new NumberField({
+            integer: true,
+            nullable: false,
+            initial: 0,
+            persisted: false,
+          }),
+          shields: new NumberField({
+            integer: true,
+            nullable: false,
+            initial: 0,
+            persisted: false,
+          }),
+          naturalWeapons: new NumberField({
+            integer: true,
+            nullable: false,
+            initial: 0,
+            persisted: false,
+          }),
+          otherSkills: new NumberField({
+            integer: true,
+            nullable: false,
+            initial: 0,
+            persisted: false,
+          }),
+        }),
       }),
     } as const;
   }
@@ -121,11 +203,75 @@ export class CharacterDataModel extends RqgActorDataModel<
     });
 
     system.baseSkillCategoryModifiers = characteristicDerived.skillCategoryModifiers;
-    system.skillCategoryModifiers = characteristicDerived.skillCategoryModifiers;
+
+    // Compose skill modifiers: base + effects + encumbrance penalties
+    const effectsModifiers = system.attributes.skillCategoryModifiersFromEffects ?? {
+      agility: 0,
+      communication: 0,
+      knowledge: 0,
+      magic: 0,
+      manipulation: 0,
+      perception: 0,
+      stealth: 0,
+      meleeWeapons: 0,
+      missileWeapons: 0,
+      shields: 0,
+      naturalWeapons: 0,
+      otherSkills: 0,
+    };
+
+    const baseWithEffects = {
+      agility: characteristicDerived.skillCategoryModifiers.agility + effectsModifiers.agility,
+      communication:
+        characteristicDerived.skillCategoryModifiers.communication + effectsModifiers.communication,
+      knowledge:
+        characteristicDerived.skillCategoryModifiers.knowledge + effectsModifiers.knowledge,
+      magic: characteristicDerived.skillCategoryModifiers.magic + effectsModifiers.magic,
+      manipulation:
+        characteristicDerived.skillCategoryModifiers.manipulation + effectsModifiers.manipulation,
+      perception:
+        characteristicDerived.skillCategoryModifiers.perception + effectsModifiers.perception,
+      stealth: characteristicDerived.skillCategoryModifiers.stealth + effectsModifiers.stealth,
+      meleeWeapons:
+        characteristicDerived.skillCategoryModifiers.meleeWeapons + effectsModifiers.meleeWeapons,
+      missileWeapons:
+        characteristicDerived.skillCategoryModifiers.missileWeapons +
+        effectsModifiers.missileWeapons,
+      shields: characteristicDerived.skillCategoryModifiers.shields + effectsModifiers.shields,
+      naturalWeapons:
+        characteristicDerived.skillCategoryModifiers.naturalWeapons +
+        effectsModifiers.naturalWeapons,
+      otherSkills:
+        characteristicDerived.skillCategoryModifiers.otherSkills + effectsModifiers.otherSkills,
+    };
+
+    system.skillCategoryModifiers = baseWithEffects;
+
     system.attributes.dexStrikeRank = characteristicDerived.dexStrikeRank;
     system.attributes.sizStrikeRank = characteristicDerived.sizStrikeRank;
     system.attributes.damageBonus = characteristicDerived.damageBonus;
     system.attributes.healingRate = characteristicDerived.healingRate;
     system.attributes.spiritCombatDamage = characteristicDerived.spiritCombatDamage;
+
+    // Calculate resource max values with effects deltas
+    const { con, siz, pow } = {
+      con: characteristics.constitution.value,
+      siz: characteristics.size.value,
+      pow: characteristics.power.value,
+    };
+
+    // Note: Non-persisted fields are used to allow AE to target these values
+    // (Requires Foundry v14+)
+    const systemAny = system as any;
+    if (systemAny.attributes.magicPoints) {
+      const magicPointsFromEffects = (systemAny.attributes.magicPointsMaxFromEffects ??
+        0) as number;
+      systemAny.attributes.magicPoints.max = (pow ?? 0) + magicPointsFromEffects;
+    }
+    if (systemAny.attributes.hitPoints) {
+      const hitPointsFromEffects = (systemAny.attributes.hitPointsMaxFromEffects ?? 0) as number;
+      const baseHitPoints = RqgCalculations.hitPoints(con ?? 0, siz ?? 0, pow ?? 0) ?? 0;
+      systemAny.attributes.hitPoints.max = baseHitPoints + hitPointsFromEffects;
+    }
   }
 }

--- a/src/data-model/actor-data/characterDataModel.ts
+++ b/src/data-model/actor-data/characterDataModel.ts
@@ -100,19 +100,16 @@ export class CharacterDataModel extends RqgActorDataModel<
           initial: "healthy",
           choices: enumChoices(actorHealthStatuses, "RQG.Actor.Attributes.Health."),
         }),
-        magicPointsMaxFromEffects: new NumberField({
-          integer: true,
-          nullable: false,
-          initial: 0,
-          persisted: false,
+      }),
+
+      effect: new SchemaField({
+        magicPoints: new SchemaField({
+          max: new NumberField({ integer: true, nullable: false, initial: 0, persisted: false }),
         }),
-        hitPointsMaxFromEffects: new NumberField({
-          integer: true,
-          nullable: false,
-          initial: 0,
-          persisted: false,
+        hitPoints: new SchemaField({
+          max: new NumberField({ integer: true, nullable: false, initial: 0, persisted: false }),
         }),
-        skillCategoryModifiersFromEffects: new SchemaField({
+        skillCategoryModifiers: new SchemaField({
           agility: new NumberField({
             integer: true,
             nullable: false,
@@ -204,21 +201,9 @@ export class CharacterDataModel extends RqgActorDataModel<
 
     system.baseSkillCategoryModifiers = characteristicDerived.skillCategoryModifiers;
 
-    // Compose skill modifiers: base + effects + encumbrance penalties
-    const effectsModifiers = system.attributes.skillCategoryModifiersFromEffects ?? {
-      agility: 0,
-      communication: 0,
-      knowledge: 0,
-      magic: 0,
-      manipulation: 0,
-      perception: 0,
-      stealth: 0,
-      meleeWeapons: 0,
-      missileWeapons: 0,
-      shields: 0,
-      naturalWeapons: 0,
-      otherSkills: 0,
-    };
+    // Non-persisted fields are reinitialized each prepare cycle by Foundry v14.
+    // Keep composition strict here so schema regressions are visible in tests.
+    const effectsModifiers = system.effect.skillCategoryModifiers;
 
     const baseWithEffects = {
       agility: characteristicDerived.skillCategoryModifiers.agility + effectsModifiers.agility,
@@ -260,16 +245,15 @@ export class CharacterDataModel extends RqgActorDataModel<
       pow: characteristics.power.value,
     };
 
-    // Note: Non-persisted fields are used to allow AE to target these values
-    // (Requires Foundry v14+)
+    // ActiveEffect deltas are accumulated in non-persisted fields that Foundry
+    // reinitializes per cycle before effects are applied.
     const systemAny = system as any;
     if (systemAny.attributes.magicPoints) {
-      const magicPointsFromEffects = (systemAny.attributes.magicPointsMaxFromEffects ??
-        0) as number;
+      const magicPointsFromEffects = (systemAny.effect.magicPoints.max ?? 0) as number;
       systemAny.attributes.magicPoints.max = (pow ?? 0) + magicPointsFromEffects;
     }
     if (systemAny.attributes.hitPoints) {
-      const hitPointsFromEffects = (systemAny.attributes.hitPointsMaxFromEffects ?? 0) as number;
+      const hitPointsFromEffects = (systemAny.effect.hitPoints.max ?? 0) as number;
       const baseHitPoints = RqgCalculations.hitPoints(con ?? 0, siz ?? 0, pow ?? 0) ?? 0;
       systemAny.attributes.hitPoints.max = baseHitPoints + hitPointsFromEffects;
     }

--- a/src/data-model/actor-data/derivedCharacterValues.test.ts
+++ b/src/data-model/actor-data/derivedCharacterValues.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getCharacteristicDerivedValues } from "./derivedCharacterValues";
+import {
+  applyEquippedEncumbrancePenalty,
+  getCharacteristicDerivedValues,
+} from "./derivedCharacterValues";
 
 describe("getCharacteristicDerivedValues", () => {
   it("computes expected values for an average non-creature", () => {
@@ -66,5 +69,65 @@ describe("getCharacteristicDerivedValues", () => {
       shields: 0,
       otherSkills: 0,
     });
+  });
+});
+
+describe("applyEquippedEncumbrancePenalty", () => {
+  it("applies penalties only to affected categories", () => {
+    const base = {
+      agility: 10,
+      communication: 5,
+      knowledge: 6,
+      magic: 7,
+      manipulation: 8,
+      perception: 9,
+      stealth: 4,
+      meleeWeapons: 3,
+      missileWeapons: 2,
+      naturalWeapons: 1,
+      shields: 0,
+      otherSkills: 11,
+    };
+
+    const result = applyEquippedEncumbrancePenalty(base, -2);
+
+    expect(result).toStrictEqual({
+      agility: 0,
+      communication: 5,
+      knowledge: 6,
+      magic: 7,
+      manipulation: -2,
+      perception: 9,
+      stealth: -6,
+      meleeWeapons: -7,
+      missileWeapons: -8,
+      naturalWeapons: -9,
+      shields: -10,
+      otherSkills: 11,
+    });
+  });
+
+  it("does not mutate base modifiers", () => {
+    const base = {
+      agility: 5,
+      communication: 1,
+      knowledge: 1,
+      magic: 1,
+      manipulation: 5,
+      perception: 1,
+      stealth: 5,
+      meleeWeapons: 5,
+      missileWeapons: 5,
+      naturalWeapons: 5,
+      shields: 5,
+      otherSkills: 1,
+    };
+
+    const result = applyEquippedEncumbrancePenalty(base, -1);
+
+    expect(base.agility).toBe(5);
+    expect(base.manipulation).toBe(5);
+    expect(base.stealth).toBe(5);
+    expect(result.agility).toBe(0);
   });
 });

--- a/src/data-model/actor-data/derivedCharacterValues.test.ts
+++ b/src/data-model/actor-data/derivedCharacterValues.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { getCharacteristicDerivedValues } from "./derivedCharacterValues";
+
+describe("getCharacteristicDerivedValues", () => {
+  it("computes expected values for an average non-creature", () => {
+    const result = getCharacteristicDerivedValues({
+      str: 13,
+      con: 11,
+      siz: 13,
+      dex: 15,
+      int: 12,
+      pow: 15,
+      cha: 11,
+      isCreature: false,
+    });
+
+    expect(result.dexStrikeRank).toBe(2);
+    expect(result.sizStrikeRank).toBe(2);
+    expect(result.damageBonus).toBe("1d4");
+    expect(result.healingRate).toBe(2);
+    expect(result.spiritCombatDamage).toBe("1d6+1");
+    expect(result.skillCategoryModifiers).toStrictEqual({
+      agility: 5,
+      communication: 0,
+      knowledge: 0,
+      magic: 5,
+      manipulation: 5,
+      perception: 0,
+      stealth: 0,
+      meleeWeapons: 5,
+      missileWeapons: 5,
+      naturalWeapons: 5,
+      shields: 5,
+      otherSkills: 0,
+    });
+  });
+
+  it("returns defaults for missing characteristics and creature modifiers", () => {
+    const result = getCharacteristicDerivedValues({
+      str: undefined,
+      con: undefined,
+      siz: undefined,
+      dex: undefined,
+      int: undefined,
+      pow: undefined,
+      cha: undefined,
+      isCreature: true,
+    });
+
+    expect(result.dexStrikeRank).toBeUndefined();
+    expect(result.sizStrikeRank).toBeUndefined();
+    expect(result.damageBonus).toBe("0");
+    expect(result.healingRate).toBe(0);
+    expect(result.spiritCombatDamage).toBe("0");
+    expect(result.skillCategoryModifiers).toStrictEqual({
+      agility: 0,
+      communication: 0,
+      knowledge: 0,
+      magic: 0,
+      manipulation: 0,
+      perception: 0,
+      stealth: 0,
+      meleeWeapons: 0,
+      missileWeapons: 0,
+      naturalWeapons: 0,
+      shields: 0,
+      otherSkills: 0,
+    });
+  });
+});

--- a/src/data-model/actor-data/derivedCharacterValues.ts
+++ b/src/data-model/actor-data/derivedCharacterValues.ts
@@ -43,3 +43,20 @@ export function getCharacteristicDerivedValues(
     skillCategoryModifiers,
   };
 }
+
+export function applyEquippedEncumbrancePenalty(
+  base: SkillCategories,
+  equippedMovementEncumbrancePenalty: number,
+): SkillCategories {
+  const delta = equippedMovementEncumbrancePenalty * 5;
+  return {
+    ...base,
+    agility: base.agility + delta,
+    manipulation: base.manipulation + delta,
+    stealth: base.stealth + delta,
+    meleeWeapons: base.meleeWeapons + delta,
+    missileWeapons: base.missileWeapons + delta,
+    naturalWeapons: base.naturalWeapons + delta,
+    shields: base.shields + delta,
+  };
+}

--- a/src/data-model/actor-data/derivedCharacterValues.ts
+++ b/src/data-model/actor-data/derivedCharacterValues.ts
@@ -1,0 +1,45 @@
+import { RqgCalculations } from "../../system/rqgCalculations";
+import type { SkillCategories } from "./skillCategories";
+
+export type CharacteristicDerivedInput = {
+  str: number | null | undefined;
+  con: number | null | undefined;
+  siz: number | null | undefined;
+  dex: number | null | undefined;
+  int: number | null | undefined;
+  pow: number | null | undefined;
+  cha: number | null | undefined;
+  isCreature: boolean;
+};
+
+export type CharacteristicDerivedValues = {
+  dexStrikeRank: number | null | undefined;
+  sizStrikeRank: number | null | undefined;
+  damageBonus: string;
+  healingRate: number;
+  spiritCombatDamage: string;
+  skillCategoryModifiers: SkillCategories;
+};
+
+export function getCharacteristicDerivedValues(
+  input: CharacteristicDerivedInput,
+): CharacteristicDerivedValues {
+  const skillCategoryModifiers = RqgCalculations.skillCategoryModifiers(
+    input.str,
+    input.siz,
+    input.dex,
+    input.int,
+    input.pow,
+    input.cha,
+    input.isCreature,
+  ) as SkillCategories;
+
+  return {
+    dexStrikeRank: RqgCalculations.dexSR(input.dex),
+    sizStrikeRank: RqgCalculations.sizSR(input.siz),
+    damageBonus: RqgCalculations.damageBonus(input.str, input.siz),
+    healingRate: RqgCalculations.healingRate(input.con),
+    spiritCombatDamage: RqgCalculations.spiritCombatDamage(input.pow, input.cha),
+    skillCategoryModifiers,
+  };
+}

--- a/src/data-model/actor-data/rqgActorData.ts
+++ b/src/data-model/actor-data/rqgActorData.ts
@@ -10,15 +10,20 @@ import type { RqgActor } from "@actors/rqgActor.ts";
  * These are NOT part of the DataModel schema — they are computed at runtime.
  * We add them via intersection so that `CharacterActor` reflects the full runtime shape.
  */
-interface DerivedAttributes {
+interface ItemDependentDerivedAttributes {
   encumbrance: { max: number; travel: number; equipped: number };
   move: { value: number; equipped: number; travel: number };
+}
+
+interface CharacteristicDerivedAttributes {
   dexStrikeRank: number | null | undefined;
   sizStrikeRank: number | null | undefined;
   damageBonus: string;
   healingRate: number | undefined;
   spiritCombatDamage: string;
 }
+
+type DerivedAttributes = ItemDependentDerivedAttributes & CharacteristicDerivedAttributes;
 
 // Narrowed actor type for subtype "character"
 export type CharacterActor = RqgActor & {

--- a/src/data-model/actor-data/rqgActorData.ts
+++ b/src/data-model/actor-data/rqgActorData.ts
@@ -4,6 +4,7 @@ export const ActorTypeEnum = {
 export type ActorTypeEnum = (typeof ActorTypeEnum)[keyof typeof ActorTypeEnum];
 
 import type { RqgActor } from "@actors/rqgActor.ts";
+import type { SkillCategories } from "./skillCategories";
 
 /**
  * Derived attribute fields that `prepareDerivedData()` adds under `system.attributes`.
@@ -27,7 +28,10 @@ type DerivedAttributes = ItemDependentDerivedAttributes & CharacteristicDerivedA
 
 // Narrowed actor type for subtype "character"
 export type CharacterActor = RqgActor & {
-  system: Actor.SystemOfType<"character"> & { attributes: DerivedAttributes };
+  system: Actor.SystemOfType<"character"> & {
+    attributes: DerivedAttributes;
+    baseSkillCategoryModifiers: SkillCategories;
+  };
 };
 
 import Actor = foundry.documents.Actor;

--- a/src/data-model/actor-data/rqgActorData.ts
+++ b/src/data-model/actor-data/rqgActorData.ts
@@ -22,9 +22,6 @@ interface CharacteristicDerivedAttributes {
   damageBonus: string;
   healingRate: number | undefined;
   spiritCombatDamage: string;
-  magicPointsMaxFromEffects: number;
-  hitPointsMaxFromEffects: number;
-  skillCategoryModifiersFromEffects: SkillCategories;
 }
 
 type DerivedAttributes = ItemDependentDerivedAttributes & CharacteristicDerivedAttributes;
@@ -34,6 +31,11 @@ export type CharacterActor = RqgActor & {
   system: Actor.SystemOfType<"character"> & {
     attributes: DerivedAttributes;
     baseSkillCategoryModifiers: SkillCategories;
+    effect: {
+      magicPoints: { max: number };
+      hitPoints: { max: number };
+      skillCategoryModifiers: SkillCategories;
+    };
   };
 };
 

--- a/src/data-model/actor-data/rqgActorData.ts
+++ b/src/data-model/actor-data/rqgActorData.ts
@@ -22,6 +22,9 @@ interface CharacteristicDerivedAttributes {
   damageBonus: string;
   healingRate: number | undefined;
   spiritCombatDamage: string;
+  magicPointsMaxFromEffects: number;
+  hitPointsMaxFromEffects: number;
+  skillCategoryModifiersFromEffects: SkillCategories;
 }
 
 type DerivedAttributes = ItemDependentDerivedAttributes & CharacteristicDerivedAttributes;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -54,6 +54,8 @@ declare global {
     }>;
   }
 
+  type ActiveEffectChangeType = Exclude<keyof typeof CONST.ACTIVE_EFFECT_CHANGE_TYPES, "subtract">;
+
   interface Game {
     dice3d?: Dice3D;
   }

--- a/src/items/RqgItemSheet.ts
+++ b/src/items/RqgItemSheet.ts
@@ -143,12 +143,8 @@ export class RqgItemSheet<
             {
               name: localize("RQG.Foundry.ActiveEffect.NewActiveEffectName"),
               img: "icons/svg/aura.svg",
-              changes: [
-                {
-                  key: "",
-                  value: "",
-                },
-              ],
+              // change.type is the string key from CONST.ACTIVE_EFFECT_CHANGE_TYPES, not the numeric priority value
+              changes: [{ key: "", type: "add", value: "" } as any],
               transfer: true,
               disabled: false,
             },

--- a/src/items/RqgItemSheet.ts
+++ b/src/items/RqgItemSheet.ts
@@ -139,12 +139,19 @@ export class RqgItemSheet<
           return; // The item is not in the world (ie it's in a compendium)
         }
         el.addEventListener("click", async () => {
+          const initialChange: ActiveEffect.ChangeData = {
+            key: "",
+            // @ts-expect-error TEMP(v14-types) legacy ActiveEffect change shape
+            type: "add",
+            value: "",
+          };
+
           const effect = new ActiveEffect(
             {
               name: localize("RQG.Foundry.ActiveEffect.NewActiveEffectName"),
               img: "icons/svg/aura.svg",
               // change.type is the string key from CONST.ACTIVE_EFFECT_CHANGE_TYPES, not the numeric priority value
-              changes: [{ key: "", type: "add", value: "" } as any],
+              changes: [initialChange],
               transfer: true,
               disabled: false,
             },

--- a/src/items/RqgItemSheet.ts
+++ b/src/items/RqgItemSheet.ts
@@ -146,20 +146,19 @@ export class RqgItemSheet<
             value: "",
           };
 
-          const effect = new ActiveEffect(
-            {
-              name: localize("RQG.Foundry.ActiveEffect.NewActiveEffectName"),
-              img: "icons/svg/aura.svg",
+          const effectData = {
+            name: localize("RQG.Foundry.ActiveEffect.NewActiveEffectName"),
+            img: "icons/svg/aura.svg",
+            transfer: true,
+            disabled: false,
+            system: {
               // change.type is the string key from CONST.ACTIVE_EFFECT_CHANGE_TYPES, not the numeric priority value
               changes: [initialChange],
-              transfer: true,
-              disabled: false,
             },
-            item,
-          );
+          };
 
           const e = await item
-            .createEmbeddedDocuments("ActiveEffect", [effect.toObject()])
+            .createEmbeddedDocuments("ActiveEffect", [effectData])
             .catch((reason: any) => {
               ui.notifications?.error(
                 localize("RQG.Item.Notification.CantCreateActiveEffect", {

--- a/src/items/RqgItemSheetV2.ts
+++ b/src/items/RqgItemSheetV2.ts
@@ -206,12 +206,19 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
         return;
       }
       el.addEventListener("click", async () => {
+        const initialChange: ActiveEffect.ChangeData = {
+          key: "",
+          // @ts-expect-error TEMP(v14-types) legacy ActiveEffect change shape
+          type: "add",
+          value: "",
+        };
+
         const effect = new ActiveEffect(
           {
             name: localize("RQG.Foundry.ActiveEffect.NewActiveEffectName"),
             img: "icons/svg/aura.svg",
             // change.type is the string key from CONST.ACTIVE_EFFECT_CHANGE_TYPES, not the numeric priority value
-            changes: [{ key: "", type: "add", value: "" } as any],
+            changes: [initialChange],
             transfer: true,
             disabled: false,
           },

--- a/src/items/RqgItemSheetV2.ts
+++ b/src/items/RqgItemSheetV2.ts
@@ -213,19 +213,18 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
           value: "",
         };
 
-        const effect = new ActiveEffect(
-          {
-            name: localize("RQG.Foundry.ActiveEffect.NewActiveEffectName"),
-            img: "icons/svg/aura.svg",
+        const effectData = {
+          name: localize("RQG.Foundry.ActiveEffect.NewActiveEffectName"),
+          img: "icons/svg/aura.svg",
+          transfer: true,
+          disabled: false,
+          system: {
             // change.type is the string key from CONST.ACTIVE_EFFECT_CHANGE_TYPES, not the numeric priority value
             changes: [initialChange],
-            transfer: true,
-            disabled: false,
           },
-          item,
-        );
+        };
         const created = await item
-          .createEmbeddedDocuments("ActiveEffect", [effect.toObject()])
+          .createEmbeddedDocuments("ActiveEffect", [effectData])
           .catch((reason: unknown) => {
             ui.notifications?.error(
               localize("RQG.Item.Notification.CantCreateActiveEffect", {

--- a/src/items/RqgItemSheetV2.ts
+++ b/src/items/RqgItemSheetV2.ts
@@ -210,7 +210,8 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
           {
             name: localize("RQG.Foundry.ActiveEffect.NewActiveEffectName"),
             img: "icons/svg/aura.svg",
-            changes: [{ key: "", value: "" }],
+            // change.type is the string key from CONST.ACTIVE_EFFECT_CHANGE_TYPES, not the numeric priority value
+            changes: [{ key: "", type: "add", value: "" } as any],
             transfer: true,
             disabled: false,
           },

--- a/src/system/migrations/applyMigrations.ts
+++ b/src/system/migrations/applyMigrations.ts
@@ -8,6 +8,9 @@ export type ItemMigration = (
   owningActorData?: RqgActor,
 ) => Promise<Item.UpdateData>;
 export type ActorMigration = (actorData: RqgActor) => Actor.UpdateData;
+export type ActiveEffectMigration = (
+  effectData: ActiveEffect.Implementation,
+) => Promise<ActiveEffect.UpdateData>;
 
 interface ActorMigrationResult {
   actorUpdateData: Actor.UpdateData;
@@ -22,6 +25,7 @@ export async function applyMigrations(
   itemMigrations: ItemMigration[],
   actorMigrations: ActorMigration[],
   migrationNotification?: any,
+  activeEffectMigrations: ActiveEffectMigration[] = [],
 ): Promise<MigrationResult> {
   const migrationResult: MigrationResult = {
     errorCount: 0,
@@ -32,7 +36,12 @@ export async function applyMigrations(
   await migrateWorldActors(itemMigrations, actorMigrations, migrationResult);
   await migrateWorldItems(itemMigrations, migrationResult);
   await migrateWorldScenes(itemMigrations, actorMigrations, migrationResult);
-  await migrateWorldCompendiumPacks(itemMigrations, actorMigrations, migrationResult);
+  await migrateWorldCompendiumPacks(
+    itemMigrations,
+    actorMigrations,
+    activeEffectMigrations,
+    migrationResult,
+  );
   console.timeEnd("RQG | ⏱ World Migrations took (ms)");
 
   if (!migrationNotification) {
@@ -61,7 +70,7 @@ async function migrateWorldActors(
   for (const actor of actorArray) {
     try {
       const { actorUpdateData, itemUpdateData } = await getActorMigrationUpdates(
-        actor.toObject() as any,
+        actor as unknown as RqgActor,
         itemMigrations,
         actorMigrations,
       );
@@ -106,7 +115,11 @@ async function migrateWorldItems(
   console.log(`%cRQG | ${migrationMsg}`, "font-size: 16px");
   for (const item of itemArray) {
     try {
-      const updateData = await getItemMigrationUpdates((item as any).toObject(), itemMigrations);
+      const updateData = await getItemMigrationUpdates(
+        item as unknown as RqgItem,
+        itemMigrations,
+        undefined,
+      );
       if (!foundry.utils.isEmpty(updateData)) {
         console.log(`RQG | Migrating Item document ${item.name}`, updateData);
         // @ts-expect-error enforceTypes TODO it does exists
@@ -156,6 +169,7 @@ async function migrateWorldScenes(
 async function migrateWorldCompendiumPacks(
   itemMigrations: ItemMigration[],
   actorMigrations: ActorMigration[],
+  activeEffectMigrations: ActiveEffectMigration[],
   migrationResult: MigrationResult,
 ): Promise<void> {
   const packs = game.packs?.contents.filter((p) => p.metadata.packageName !== systemId) ?? []; // Exclude system packs
@@ -174,10 +188,16 @@ async function migrateWorldCompendiumPacks(
       if (pack.metadata.packageType !== "world") {
         continue;
       }
-      if (!["Actor", "Item", "Scene"].includes(pack.metadata.type)) {
+      if (!["Actor", "Item", "Scene", "ActiveEffect"].includes(pack.metadata.type)) {
         continue;
       }
-      await migrateCompendium(pack, itemMigrations, actorMigrations, migrationResult);
+      await migrateCompendium(
+        pack,
+        itemMigrations,
+        actorMigrations,
+        activeEffectMigrations,
+        migrationResult,
+      );
     } catch (err: any) {
       migrationResult.errorCount += 1;
       err.message = `RQG | Failed migration for Compendium ${pack.collection}: ${err.message}`;
@@ -198,10 +218,11 @@ async function migrateCompendium(
   pack: CompendiumCollection.Any,
   itemMigrations: ItemMigration[],
   actorMigrations: ActorMigration[],
+  activeEffectMigrations: ActiveEffectMigration[],
   migrationResult: MigrationResult,
 ): Promise<void> {
   const documentType: string = pack.metadata.type;
-  if (!["Actor", "Item", "Scene"].includes(documentType)) {
+  if (!["Actor", "Item", "Scene", "ActiveEffect"].includes(documentType)) {
     return;
   }
 
@@ -246,6 +267,12 @@ async function migrateCompendium(
         }
         case "Item":
           updateData = await getItemMigrationUpdates(doc as RqgItem, itemMigrations);
+          break;
+        case "ActiveEffect":
+          updateData = await getActiveEffectMigrationUpdates(
+            doc as unknown as ActiveEffect.Implementation,
+            activeEffectMigrations,
+          );
           break;
         case "Scene":
           await migrateSceneTokenActors(
@@ -345,6 +372,22 @@ async function getItemMigrationUpdates(
       performDeletions: false,
     }) as Item.UpdateData; // TODO can mergeObject be made to return the correct type?
   }
+
+  return updateData;
+}
+
+/* -------------------------------------------- */
+
+async function getActiveEffectMigrationUpdates(
+  effect: ActiveEffect.Implementation,
+  activeEffectMigrations: ActiveEffectMigration[],
+): Promise<ActiveEffect.UpdateData> {
+  let updateData: ActiveEffect.UpdateData = {};
+  for (const fn of activeEffectMigrations) {
+    updateData = foundry.utils.mergeObject(updateData, await fn(effect), {
+      performDeletions: false,
+    }) as ActiveEffect.UpdateData;
+  }
   return updateData;
 }
 
@@ -372,7 +415,7 @@ async function migrateSceneTokenActors(
 
     try {
       const { actorUpdateData, itemUpdateData } = await getActorMigrationUpdates(
-        actor.toObject() as any,
+        actor as unknown as RqgActor,
         itemMigrations,
         actorMigrations,
       );

--- a/src/system/migrations/migrateWorld.ts
+++ b/src/system/migrations/migrateWorld.ts
@@ -17,9 +17,6 @@ import { relabelRuneMagicCommandCultSpiritRqid } from "./migrations-item/relabel
 import { migrateActorActiveEffectPaths } from "./migrations-actor/migrateActorActiveEffectPaths";
 import { migrateItemActiveEffectPaths } from "./migrations-item/migrateItemActiveEffectPaths";
 import { migrateActiveEffectActiveEffectPaths } from "./migrations-effect/migrateActiveEffectActiveEffectPaths";
-import { migrateItemActiveEffectTypes } from "./migrations-item/migrateItemActiveEffectTypes";
-import { migrateActorActiveEffectTypes } from "./migrations-actor/migrateActorActiveEffectTypes";
-import { migrateActiveEffectActiveEffectTypes } from "./migrations-effect/migrateActiveEffectActiveEffectTypes";
 
 /**
  * Perform a system migration for the entire World, applying migrations for what is in it
@@ -119,15 +116,10 @@ export async function applyDefaultWorldMigrations(
     migrateWeaponSkillLinks,
     migrateRuneItemType,
     relabelRuneMagicCommandCultSpiritRqid,
-    migrateItemActiveEffectTypes,
     migrateItemActiveEffectPaths,
   ];
-  const worldActorMigrations: ActorMigration[] = actorMigrations ?? [
-    migrateActorActiveEffectTypes,
-    migrateActorActiveEffectPaths,
-  ];
+  const worldActorMigrations: ActorMigration[] = actorMigrations ?? [migrateActorActiveEffectPaths];
   const worldActiveEffectMigrations: ActiveEffectMigration[] = activeEffectMigrations ?? [
-    migrateActiveEffectActiveEffectTypes,
     migrateActiveEffectActiveEffectPaths,
   ];
 

--- a/src/system/migrations/migrateWorld.ts
+++ b/src/system/migrations/migrateWorld.ts
@@ -17,6 +17,9 @@ import { relabelRuneMagicCommandCultSpiritRqid } from "./migrations-item/relabel
 import { migrateActorActiveEffectPaths } from "./migrations-actor/migrateActorActiveEffectPaths";
 import { migrateItemActiveEffectPaths } from "./migrations-item/migrateItemActiveEffectPaths";
 import { migrateActiveEffectActiveEffectPaths } from "./migrations-effect/migrateActiveEffectActiveEffectPaths";
+import { migrateItemActiveEffectTypes } from "./migrations-item/migrateItemActiveEffectTypes";
+import { migrateActorActiveEffectTypes } from "./migrations-actor/migrateActorActiveEffectTypes";
+import { migrateActiveEffectActiveEffectTypes } from "./migrations-effect/migrateActiveEffectActiveEffectTypes";
 
 /**
  * Perform a system migration for the entire World, applying migrations for what is in it
@@ -116,10 +119,15 @@ export async function applyDefaultWorldMigrations(
     migrateWeaponSkillLinks,
     migrateRuneItemType,
     relabelRuneMagicCommandCultSpiritRqid,
+    migrateItemActiveEffectTypes,
     migrateItemActiveEffectPaths,
   ];
-  const worldActorMigrations: ActorMigration[] = actorMigrations ?? [migrateActorActiveEffectPaths];
+  const worldActorMigrations: ActorMigration[] = actorMigrations ?? [
+    migrateActorActiveEffectTypes,
+    migrateActorActiveEffectPaths,
+  ];
   const worldActiveEffectMigrations: ActiveEffectMigration[] = activeEffectMigrations ?? [
+    migrateActiveEffectActiveEffectTypes,
     migrateActiveEffectActiveEffectPaths,
   ];
 

--- a/src/system/migrations/migrateWorld.ts
+++ b/src/system/migrations/migrateWorld.ts
@@ -1,6 +1,7 @@
 import { localize } from "../util";
 import {
   type ActorMigration,
+  type ActiveEffectMigration,
   applyMigrations,
   type ItemMigration,
   type MigrationResult,
@@ -13,6 +14,9 @@ import { ItemTypeEnum } from "@item-model/itemTypes.ts";
 import { RqidBatchEditor } from "../../applications/rqid-batch-editor/rqidBatchEditor";
 import { migrateRuneItemType } from "./migrations-item/migrateRuneItemType";
 import { relabelRuneMagicCommandCultSpiritRqid } from "./migrations-item/relabelRuneMagicCommandCultSpiritRqid";
+import { migrateActorActiveEffectPaths } from "./migrations-actor/migrateActorActiveEffectPaths";
+import { migrateItemActiveEffectPaths } from "./migrations-item/migrateItemActiveEffectPaths";
+import { migrateActiveEffectActiveEffectPaths } from "./migrations-effect/migrateActiveEffectActiveEffectPaths";
 
 /**
  * Perform a system migration for the entire World, applying migrations for what is in it
@@ -101,6 +105,7 @@ export async function applyDefaultWorldMigrations(
   itemMigrations: ItemMigration[] | undefined = undefined,
   actorMigrations: ActorMigration[] | undefined = undefined,
   migrationNotification?: any,
+  activeEffectMigrations: ActiveEffectMigration[] | undefined = undefined,
 ): Promise<MigrationResult> {
   if (!game.user?.isGM) {
     ui.notifications?.info(localize("RQG.Notification.Error.GMOnlyOperation"));
@@ -111,8 +116,17 @@ export async function applyDefaultWorldMigrations(
     migrateWeaponSkillLinks,
     migrateRuneItemType,
     relabelRuneMagicCommandCultSpiritRqid,
+    migrateItemActiveEffectPaths,
   ];
-  const worldActorMigrations: ActorMigration[] = actorMigrations ?? [];
+  const worldActorMigrations: ActorMigration[] = actorMigrations ?? [migrateActorActiveEffectPaths];
+  const worldActiveEffectMigrations: ActiveEffectMigration[] = activeEffectMigrations ?? [
+    migrateActiveEffectActiveEffectPaths,
+  ];
 
-  return await applyMigrations(worldItemMigrations, worldActorMigrations, migrationNotification);
+  return await applyMigrations(
+    worldItemMigrations,
+    worldActorMigrations,
+    migrationNotification,
+    worldActiveEffectMigrations,
+  );
 }

--- a/src/system/migrations/migrations-actor/migrateActorActiveEffectPaths.test.ts
+++ b/src/system/migrations/migrations-actor/migrateActorActiveEffectPaths.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { migrateActorActiveEffectPaths } from "./migrateActorActiveEffectPaths";
+import type { RqgActor } from "@actors/rqgActor.ts";
+
+describe("migrateActorActiveEffectPaths", () => {
+  beforeEach(() => {
+    // Mock console.log to avoid noise
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("should migrate legacy actor effect paths", () => {
+    const mockActor = {
+      name: "Test Actor",
+      id: "actor-1",
+      effects: new Map([
+        [
+          "effect-1",
+          {
+            id: "effect-1",
+            name: "Test Effect",
+            system: {
+              changes: [{ key: "system.attributes.magicPoints.max", type: "add", value: 5 }],
+            },
+          },
+        ],
+      ]),
+      items: new Map(),
+    };
+
+    const updateData = migrateActorActiveEffectPaths(mockActor as unknown as RqgActor);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.magicPointsMaxFromEffects",
+    );
+  });
+
+  it("should migrate hitPoints.max to hitPointsMaxFromEffects", () => {
+    const mockActor = {
+      name: "Test Actor",
+      id: "actor-1",
+      effects: new Map([
+        [
+          "effect-1",
+          {
+            id: "effect-1",
+            name: "Test Effect",
+            system: {
+              changes: [{ key: "system.attributes.hitPoints.max", type: "add", value: 10 }],
+            },
+          },
+        ],
+      ]),
+      items: new Map(),
+    };
+
+    const updateData = migrateActorActiveEffectPaths(mockActor as unknown as RqgActor);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.hitPointsMaxFromEffects",
+    );
+  });
+
+  it("should skip already migrated effects", () => {
+    const migratedEffect = {
+      id: "effect-1",
+      name: "Test Effect",
+      system: {
+        changes: [{ key: "system.attributes.magicPointsMaxFromEffects", type: "add", value: 5 }],
+      },
+    };
+
+    const mockActor = {
+      name: "Test Actor",
+      id: "actor-1",
+      effects: new Map([["effect-1", migratedEffect]]),
+      items: new Map(),
+    };
+
+    const updateData = migrateActorActiveEffectPaths(mockActor as unknown as RqgActor);
+
+    // Should not include effects in updateData if nothing changed
+    expect(updateData.effects).toBeUndefined();
+  });
+
+  it("should only migrate ADD-type changes", () => {
+    const mockActor = {
+      name: "Test Actor",
+      id: "actor-1",
+      effects: new Map([
+        [
+          "effect-1",
+          {
+            id: "effect-1",
+            name: "Test Effect",
+            system: {
+              changes: [
+                { key: "system.attributes.magicPoints.max", type: "add", value: 5 }, // ADD type - should migrate
+                { key: "system.attributes.hitPoints.max", type: "multiply", value: 10 }, // Non-ADD type - should not migrate
+              ],
+            },
+          },
+        ],
+      ]),
+      items: new Map(),
+    };
+
+    const updateData = migrateActorActiveEffectPaths(mockActor as unknown as RqgActor);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.magicPointsMaxFromEffects",
+    );
+    expect((updateData.effects as any[])?.[0].system.changes[1].key).toBe(
+      "system.attributes.hitPoints.max", // Unchanged
+    );
+  });
+
+  it("should not migrate effects on embedded items", () => {
+    const mockActor = {
+      name: "Test Actor",
+      id: "actor-1",
+      effects: new Map(),
+      items: new Map([
+        [
+          "item-1",
+          {
+            id: "item-1",
+            name: "Test Item",
+            effects: new Map([
+              [
+                "effect-1",
+                {
+                  id: "effect-1",
+                  name: "Item Effect",
+                  changes: [{ key: "system.attributes.magicPoints.max", type: "add", value: 3 }],
+                },
+              ],
+            ]),
+          },
+        ],
+      ]),
+    };
+
+    const updateData = migrateActorActiveEffectPaths(mockActor as unknown as RqgActor);
+
+    expect((updateData as any)._itemEffectUpdates).toBeUndefined();
+    expect(updateData.effects).toBeUndefined();
+  });
+
+  it("should return empty updateData if nothing to migrate", () => {
+    const mockActor = {
+      name: "Test Actor",
+      id: "actor-1",
+      effects: new Map([
+        [
+          "effect-1",
+          {
+            id: "effect-1",
+            name: "Test Effect",
+            system: {
+              changes: [{ key: "system.other.field", type: "add", value: 5 }],
+            },
+          },
+        ],
+      ]),
+      items: new Map(),
+    };
+
+    const updateData = migrateActorActiveEffectPaths(mockActor as unknown as RqgActor);
+
+    expect(updateData.effects).toBeUndefined();
+  });
+
+  it("should migrate legacy paths when actor effects are provided as an array", () => {
+    const mockActor = {
+      name: "Actor Data",
+      id: "actor-array-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Legacy Actor Effect",
+          system: {
+            changes: [{ key: "system.attributes.hitPoints.max", type: "add", value: 3 }],
+          },
+        },
+      ],
+      items: [],
+    };
+
+    const updateData = migrateActorActiveEffectPaths(mockActor as unknown as RqgActor);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.hitPointsMaxFromEffects",
+    );
+  });
+});

--- a/src/system/migrations/migrations-actor/migrateActorActiveEffectPaths.test.ts
+++ b/src/system/migrations/migrations-actor/migrateActorActiveEffectPaths.test.ts
@@ -31,11 +31,11 @@ describe("migrateActorActiveEffectPaths", () => {
 
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.magicPointsMaxFromEffects",
+      "system.effect.magicPoints.max",
     );
   });
 
-  it("should migrate hitPoints.max to hitPointsMaxFromEffects", () => {
+  it("should migrate hitPoints.max to system.effect.hitPoints.max", () => {
     const mockActor = {
       name: "Test Actor",
       id: "actor-1",
@@ -58,7 +58,7 @@ describe("migrateActorActiveEffectPaths", () => {
 
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.hitPointsMaxFromEffects",
+      "system.effect.hitPoints.max",
     );
   });
 
@@ -67,7 +67,7 @@ describe("migrateActorActiveEffectPaths", () => {
       id: "effect-1",
       name: "Test Effect",
       system: {
-        changes: [{ key: "system.attributes.magicPointsMaxFromEffects", type: "add", value: 5 }],
+        changes: [{ key: "system.effect.magicPoints.max", type: "add", value: 5 }],
       },
     };
 
@@ -110,7 +110,7 @@ describe("migrateActorActiveEffectPaths", () => {
 
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.magicPointsMaxFromEffects",
+      "system.effect.magicPoints.max",
     );
     expect((updateData.effects as any[])?.[0].system.changes[1].key).toBe(
       "system.attributes.hitPoints.max", // Unchanged
@@ -193,7 +193,7 @@ describe("migrateActorActiveEffectPaths", () => {
 
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.hitPointsMaxFromEffects",
+      "system.effect.hitPoints.max",
     );
   });
 });

--- a/src/system/migrations/migrations-actor/migrateActorActiveEffectPaths.ts
+++ b/src/system/migrations/migrations-actor/migrateActorActiveEffectPaths.ts
@@ -29,7 +29,33 @@ export const migrateActorActiveEffectPaths: ActorMigration = (
     const migratedEffects = migrateEffectArray(originalEffects);
 
     if (effectArraysChanged(originalEffects, migratedEffects)) {
-      updateData.effects = toPersistedEffectArray(migratedEffects) as any; // Type coercion needed for UpdateData
+      const effectUpdates = originalEffects.flatMap((effect, index) => {
+        const migrated = migratedEffects[index];
+        if (migrated === effect) {
+          return [];
+        }
+
+        const persisted = toPersistedEffectArray([migrated])[0] as any;
+        const effectId =
+          persisted?._id ?? persisted?.id ?? (effect as any)?._id ?? (effect as any)?.id;
+        if (!effectId) {
+          return [];
+        }
+
+        return [
+          {
+            _id: effectId,
+            system: {
+              changes: persisted?.system?.changes ?? [],
+            },
+          },
+        ];
+      });
+
+      if (effectUpdates.length > 0) {
+        updateData.effects = effectUpdates as any; // Type coercion needed for UpdateData
+      }
+
       originalEffects.forEach((effect, index) => {
         if (migratedEffects[index] !== effect) {
           console.log(`RQG | Migrated AE paths on effect "${effect.name}" for actor ${actor.name}`);

--- a/src/system/migrations/migrations-actor/migrateActorActiveEffectPaths.ts
+++ b/src/system/migrations/migrations-actor/migrateActorActiveEffectPaths.ts
@@ -1,0 +1,42 @@
+import type { ActorMigration } from "../applyMigrations";
+import type { RqgActor } from "@actors/rqgActor.ts";
+import {
+  migrateEffectArray,
+  effectArraysChanged,
+  toPersistedEffectArray,
+} from "../shared-ae-migration-utils";
+
+/**
+ * ActorMigration: Process actor-owned effects only
+ *
+ * BG: PR4 moved derived values into non-persisted DataModel fields with v14 AE support.
+ * This migration rewrites effects targeting the old paths to the new ones so they continue
+ * to function correctly.
+ *
+ * NOTE: Embedded item effects are migrated by item migrations in applyMigrations.
+ */
+export const migrateActorActiveEffectPaths: ActorMigration = (
+  actor: RqgActor,
+): Actor.UpdateData => {
+  const updateData: Actor.UpdateData = {};
+  const rawEffects = (actor as any).effects;
+  const originalEffects = Array.isArray(rawEffects)
+    ? rawEffects
+    : Array.from(rawEffects?.values?.() ?? []);
+
+  // Migrate actor-owned effects
+  if (originalEffects.length > 0) {
+    const migratedEffects = migrateEffectArray(originalEffects);
+
+    if (effectArraysChanged(originalEffects, migratedEffects)) {
+      updateData.effects = toPersistedEffectArray(migratedEffects) as any; // Type coercion needed for UpdateData
+      originalEffects.forEach((effect) => {
+        if (migratedEffects.some((migrated) => migrated !== effect)) {
+          console.log(`RQG | Migrated AE paths on effect "${effect.name}" for actor ${actor.name}`);
+        }
+      });
+    }
+  }
+
+  return updateData;
+};

--- a/src/system/migrations/migrations-actor/migrateActorActiveEffectPaths.ts
+++ b/src/system/migrations/migrations-actor/migrateActorActiveEffectPaths.ts
@@ -30,8 +30,8 @@ export const migrateActorActiveEffectPaths: ActorMigration = (
 
     if (effectArraysChanged(originalEffects, migratedEffects)) {
       updateData.effects = toPersistedEffectArray(migratedEffects) as any; // Type coercion needed for UpdateData
-      originalEffects.forEach((effect) => {
-        if (migratedEffects.some((migrated) => migrated !== effect)) {
+      originalEffects.forEach((effect, index) => {
+        if (migratedEffects[index] !== effect) {
           console.log(`RQG | Migrated AE paths on effect "${effect.name}" for actor ${actor.name}`);
         }
       });

--- a/src/system/migrations/migrations-actor/migrateActorActiveEffectTypes.test.ts
+++ b/src/system/migrations/migrations-actor/migrateActorActiveEffectTypes.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { RqgActor } from "@actors/rqgActor.ts";
+import { migrateActorActiveEffectTypes } from "./migrateActorActiveEffectTypes";
+
+describe("migrateActorActiveEffectTypes", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("should normalize malformed custom.20 type to custom on actor-owned effects", () => {
+    const mockActor = {
+      name: "Malformed Type Actor",
+      id: "actor-malformed-type-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Malformed Type Effect",
+          system: {
+            changes: [
+              {
+                key: "system.attributes.magicPoints.max",
+                type: "custom.20",
+                value: "5",
+              },
+            ],
+          },
+        },
+      ],
+      items: [],
+    };
+
+    const updateData = migrateActorActiveEffectTypes(mockActor as unknown as RqgActor);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].type).toBe("custom");
+  });
+});

--- a/src/system/migrations/migrations-actor/migrateActorActiveEffectTypes.ts
+++ b/src/system/migrations/migrations-actor/migrateActorActiveEffectTypes.ts
@@ -1,0 +1,31 @@
+import type { ActorMigration } from "../applyMigrations";
+import type { RqgActor } from "@actors/rqgActor.ts";
+import {
+  effectArraysChanged,
+  migrateEffectTypeArray,
+  toPersistedEffectArray,
+} from "../shared-ae-migration-utils";
+
+/**
+ * ActorMigration: Repair malformed ActiveEffect change.type values on actor-owned effects.
+ */
+export const migrateActorActiveEffectTypes: ActorMigration = (
+  actor: RqgActor,
+): Actor.UpdateData => {
+  const updateData: Actor.UpdateData = {};
+  const rawEffects = (actor as any).effects;
+  const originalEffects = Array.isArray(rawEffects)
+    ? rawEffects
+    : Array.from(rawEffects?.values?.() ?? []);
+
+  if (originalEffects.length > 0) {
+    const migratedEffects = migrateEffectTypeArray(originalEffects);
+
+    if (effectArraysChanged(originalEffects, migratedEffects)) {
+      updateData.effects = toPersistedEffectArray(migratedEffects) as any;
+      console.log(`RQG | Repaired AE change.type values for actor ${actor.name}`);
+    }
+  }
+
+  return updateData;
+};

--- a/src/system/migrations/migrations-effect/migrateActiveEffectActiveEffectPaths.ts
+++ b/src/system/migrations/migrations-effect/migrateActiveEffectActiveEffectPaths.ts
@@ -1,5 +1,5 @@
 import type { ActiveEffectMigration } from "../applyMigrations";
-import { migrateEffectChanges } from "../shared-ae-migration-utils";
+import { migrateEffectTypesAndPaths } from "../shared-ae-migration-utils";
 
 /**
  * ActiveEffectMigration: Process standalone ActiveEffect documents in compendium packs
@@ -16,7 +16,7 @@ export const migrateActiveEffectActiveEffectPaths: ActiveEffectMigration = async
   const updateData: ActiveEffect.UpdateData = {};
   const effectAsAny = effect as any;
 
-  if (migrateEffectChanges(effectAsAny)) {
+  if (migrateEffectTypesAndPaths(effectAsAny)) {
     console.log(`RQG | Migrated AE paths on compendium effect "${effect.name}"`);
     if (Array.isArray(effectAsAny.system?.changes)) {
       updateData.system = {

--- a/src/system/migrations/migrations-effect/migrateActiveEffectActiveEffectPaths.ts
+++ b/src/system/migrations/migrations-effect/migrateActiveEffectActiveEffectPaths.ts
@@ -1,0 +1,29 @@
+import type { ActiveEffectMigration } from "../applyMigrations";
+import { migrateEffectChanges } from "../shared-ae-migration-utils";
+
+/**
+ * ActiveEffectMigration: Process standalone ActiveEffect documents in compendium packs
+ *
+ * BG: PR4 moved derived values into non-persisted DataModel fields with v14 AE support.
+ * This migration rewrites the legacy path on the effect's own changes array.
+ *
+ * In v14, ActiveEffect is a first-class compendium document type. These documents are
+ * standalone — not embedded in an Actor or Item — and require their own migration pass.
+ */
+export const migrateActiveEffectActiveEffectPaths: ActiveEffectMigration = async (
+  effect: ActiveEffect.Implementation,
+): Promise<ActiveEffect.UpdateData> => {
+  const updateData: ActiveEffect.UpdateData = {};
+  const effectAsAny = effect as any;
+
+  if (migrateEffectChanges(effectAsAny)) {
+    console.log(`RQG | Migrated AE paths on compendium effect "${effect.name}"`);
+    if (Array.isArray(effectAsAny.system?.changes)) {
+      updateData.system = {
+        changes: effectAsAny.system.changes,
+      } as any;
+    }
+  }
+
+  return updateData;
+};

--- a/src/system/migrations/migrations-effect/migrateActiveEffectActiveEffectTypes.ts
+++ b/src/system/migrations/migrations-effect/migrateActiveEffectActiveEffectTypes.ts
@@ -1,0 +1,21 @@
+import type { ActiveEffectMigration } from "../applyMigrations";
+import { migrateEffectChangeTypes } from "../shared-ae-migration-utils";
+
+/**
+ * ActiveEffectMigration: Repair malformed change.type values on standalone ActiveEffect docs.
+ */
+export const migrateActiveEffectActiveEffectTypes: ActiveEffectMigration = async (
+  effect: ActiveEffect.Implementation,
+): Promise<ActiveEffect.UpdateData> => {
+  const updateData: ActiveEffect.UpdateData = {};
+  const effectAsAny = effect as any;
+
+  if (migrateEffectChangeTypes(effectAsAny) && Array.isArray(effectAsAny.system?.changes)) {
+    updateData.system = {
+      changes: effectAsAny.system.changes,
+    } as any;
+    console.log(`RQG | Repaired AE change.type values on compendium effect "${effect.name}"`);
+  }
+
+  return updateData;
+};

--- a/src/system/migrations/migrations-item/migrateItemActiveEffectPaths.test.ts
+++ b/src/system/migrations/migrations-item/migrateItemActiveEffectPaths.test.ts
@@ -30,8 +30,32 @@ describe("migrateItemActiveEffectPaths", () => {
 
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.magicPointsMaxFromEffects",
+      "system.effect.magicPoints.max",
     );
+  });
+
+  it("should migrate hitPoints.max to system.effect.hitPoints.max and normalize value", async () => {
+    const mockItem = {
+      name: "Hit Points Item",
+      id: "item-hp-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Hit Points Effect",
+          system: {
+            changes: [{ key: "system.attributes.hitPoints.max", type: "add", value: "10" }],
+          },
+        },
+      ],
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.effect.hitPoints.max",
+    );
+    expect((updateData.effects as any[])?.[0].system.changes[0].value).toBe(10);
   });
 
   it("should skip already migrated effects", async () => {
@@ -39,7 +63,7 @@ describe("migrateItemActiveEffectPaths", () => {
       id: "effect-1",
       name: "Test Effect",
       system: {
-        changes: [{ key: "system.attributes.magicPointsMaxFromEffects", type: "add", value: 5 }],
+        changes: [{ key: "system.effect.magicPoints.max", type: "add", value: 5 }],
       },
     };
 
@@ -79,7 +103,7 @@ describe("migrateItemActiveEffectPaths", () => {
 
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.magicPointsMaxFromEffects",
+      "system.effect.magicPoints.max",
     );
     expect((updateData.effects as any[])?.[0].system.changes[1].key).toBe(
       "system.attributes.hitPoints.max", // Unchanged
@@ -128,7 +152,7 @@ describe("migrateItemActiveEffectPaths", () => {
 
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.magicPointsMaxFromEffects",
+      "system.effect.magicPoints.max",
     );
   });
 
@@ -143,7 +167,7 @@ describe("migrateItemActiveEffectPaths", () => {
           system: {
             changes: [
               {
-                key: "system.attributes.magicPointsMaxFromEffects",
+                key: "system.effect.magicPoints.max",
                 type: "add",
                 value: undefined,
               },
@@ -213,7 +237,7 @@ describe("migrateItemActiveEffectPaths", () => {
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].effect).toBeUndefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.magicPointsMaxFromEffects",
+      "system.effect.magicPoints.max",
     );
   });
 
@@ -243,7 +267,7 @@ describe("migrateItemActiveEffectPaths", () => {
 
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.magicPointsMaxFromEffects",
+      "system.effect.magicPoints.max",
     );
   });
 
@@ -277,7 +301,7 @@ describe("migrateItemActiveEffectPaths", () => {
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0]._id).toBe("effect-1");
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.magicPointsMaxFromEffects",
+      "system.effect.magicPoints.max",
     );
   });
 
@@ -306,7 +330,7 @@ describe("migrateItemActiveEffectPaths", () => {
 
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.magicPointsMaxFromEffects",
+      "system.effect.magicPoints.max",
     );
   });
 
@@ -342,7 +366,7 @@ describe("migrateItemActiveEffectPaths", () => {
 
     expect(updateData.effects).toBeDefined();
     expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
-      "system.attributes.magicPointsMaxFromEffects",
+      "system.effect.magicPoints.max",
     );
     expect(Array.isArray(mockItem.effects)).toBe(true);
     expect((mockItem.effects as any[])[0].changes).toEqual([

--- a/src/system/migrations/migrations-item/migrateItemActiveEffectPaths.test.ts
+++ b/src/system/migrations/migrations-item/migrateItemActiveEffectPaths.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { migrateItemActiveEffectPaths } from "./migrateItemActiveEffectPaths";
+import type { RqgItem } from "@items/rqgItem.ts";
+
+describe("migrateItemActiveEffectPaths", () => {
+  beforeEach(() => {
+    // Mock console.log to avoid noise
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("should migrate legacy item effect paths", async () => {
+    const mockItem = {
+      name: "Test Item",
+      id: "item-1",
+      effects: new Map([
+        [
+          "effect-1",
+          {
+            id: "effect-1",
+            name: "Test Effect",
+            system: {
+              changes: [{ key: "system.attributes.magicPoints.max", type: "add", value: 5 }],
+            },
+          },
+        ],
+      ]),
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.magicPointsMaxFromEffects",
+    );
+  });
+
+  it("should skip already migrated effects", async () => {
+    const migratedEffect = {
+      id: "effect-1",
+      name: "Test Effect",
+      system: {
+        changes: [{ key: "system.attributes.magicPointsMaxFromEffects", type: "add", value: 5 }],
+      },
+    };
+
+    const mockItem = {
+      name: "Test Item",
+      id: "item-1",
+      effects: new Map([["effect-1", migratedEffect]]),
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeUndefined();
+  });
+
+  it("should only migrate ADD-type changes", async () => {
+    const mockItem = {
+      name: "Test Item",
+      id: "item-1",
+      effects: new Map([
+        [
+          "effect-1",
+          {
+            id: "effect-1",
+            name: "Test Effect",
+            system: {
+              changes: [
+                { key: "system.attributes.magicPoints.max", type: "add", value: 5 }, // ADD type - should migrate
+                { key: "system.attributes.hitPoints.max", type: "multiply", value: 10 }, // Non-ADD type - should not migrate
+              ],
+            },
+          },
+        ],
+      ]),
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.magicPointsMaxFromEffects",
+    );
+    expect((updateData.effects as any[])?.[0].system.changes[1].key).toBe(
+      "system.attributes.hitPoints.max", // Unchanged
+    );
+  });
+
+  it("should return empty updateData if nothing to migrate", async () => {
+    const mockItem = {
+      name: "Test Item",
+      id: "item-1",
+      effects: new Map([
+        [
+          "effect-1",
+          {
+            id: "effect-1",
+            name: "Test Effect",
+            system: {
+              changes: [{ key: "system.other.field", type: "add", value: 5 }],
+            },
+          },
+        ],
+      ]),
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeUndefined();
+  });
+
+  it("should migrate legacy paths when effects are provided as an array", async () => {
+    const mockItem = {
+      name: "Embedded Item Data",
+      id: "item-embedded-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Legacy Effect",
+          system: {
+            changes: [{ key: "system.attributes.magicPoints.max", type: "add", value: 5 }],
+          },
+        },
+      ],
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.magicPointsMaxFromEffects",
+    );
+  });
+
+  it("should normalize undefined ADD value on already-migrated key", async () => {
+    const mockItem = {
+      name: "Broken Migrated Item",
+      id: "item-broken-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Broken Effect",
+          system: {
+            changes: [
+              {
+                key: "system.attributes.magicPointsMaxFromEffects",
+                type: "add",
+                value: undefined,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].value).toBe(0);
+  });
+
+  it("should not migrate legacy key when type is missing", async () => {
+    const mockItem = {
+      name: "Missing Mode Item",
+      id: "item-missing-mode-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Legacy No-Mode Effect",
+          system: {
+            changes: [
+              {
+                key: "system.attributes.magicPoints.max",
+                value: undefined,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeUndefined();
+  });
+
+  it("should strip transient effect back-reference from migrated changes", async () => {
+    const mockItem = {
+      name: "Transient Field Item",
+      id: "item-transient-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Transient Change Effect",
+          system: {
+            changes: [
+              {
+                effect: { _id: "effect-1", name: "Transient Change Effect" },
+                key: "system.attributes.magicPoints.max",
+                type: "add",
+                value: 12,
+                phase: "initial",
+                priority: 0,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].effect).toBeUndefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.magicPointsMaxFromEffects",
+    );
+  });
+
+  it("should migrate when system.changes exists and top-level changes is empty", async () => {
+    const mockItem = {
+      name: "Mixed Changes Container Item",
+      id: "item-mixed-containers-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Mixed Container Effect",
+          changes: [],
+          system: {
+            changes: [
+              {
+                key: "system.attributes.magicPoints.max",
+                type: "add",
+                value: 4,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.magicPointsMaxFromEffects",
+    );
+  });
+
+  it("should migrate document-like effects via toObject source", async () => {
+    const mockItem = {
+      name: "Document Shape Item",
+      id: "item-doc-shape-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Doc Effect",
+          toObject: () => ({
+            _id: "effect-1",
+            name: "Doc Effect",
+            system: {
+              changes: [
+                {
+                  key: "system.attributes.magicPoints.max",
+                  type: "add",
+                  value: 2,
+                },
+              ],
+            },
+          }),
+        },
+      ],
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0]._id).toBe("effect-1");
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.magicPointsMaxFromEffects",
+    );
+  });
+
+  it("should migrate effects with system.changes only", async () => {
+    const mockItem = {
+      name: "Canonical Changes Item",
+      id: "item-canonical-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Canonical Effect",
+          system: {
+            changes: [
+              {
+                key: "system.attributes.magicPoints.max",
+                type: "add",
+                value: 3,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.magicPointsMaxFromEffects",
+    );
+  });
+
+  it("should ignore top-level changes when both exist (canonical takes precedence)", async () => {
+    const mockItem = {
+      name: "Conflicting Changes Item",
+      id: "item-conflicting-2",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Conflicting Effect",
+          changes: [
+            {
+              key: "system.other.field",
+              type: "add",
+              value: 99,
+            },
+          ],
+          system: {
+            changes: [
+              {
+                key: "system.attributes.magicPoints.max",
+                type: "add",
+                value: 3,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const updateData = await migrateItemActiveEffectPaths(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].key).toBe(
+      "system.attributes.magicPointsMaxFromEffects",
+    );
+    expect(Array.isArray(mockItem.effects)).toBe(true);
+    expect((mockItem.effects as any[])[0].changes).toEqual([
+      {
+        key: "system.other.field",
+        type: "add",
+        value: 99,
+      },
+    ]);
+  });
+});

--- a/src/system/migrations/migrations-item/migrateItemActiveEffectPaths.ts
+++ b/src/system/migrations/migrations-item/migrateItemActiveEffectPaths.ts
@@ -1,0 +1,40 @@
+import type { ItemMigration } from "../applyMigrations";
+import type { RqgItem } from "@items/rqgItem.ts";
+import {
+  migrateEffectArray,
+  effectArraysChanged,
+  toPersistedEffectArray,
+} from "../shared-ae-migration-utils";
+
+/**
+ * ItemMigration: Process all effects on world-level items
+ *
+ * BG: PR4 moved derived values into non-persisted DataModel fields with v14 AE support.
+ * This migration rewrites effects targeting the old paths to the new ones so they continue
+ * to function correctly. This handles effects on world-level items (not embedded in actors).
+ */
+export const migrateItemActiveEffectPaths: ItemMigration = async (
+  item: RqgItem,
+): Promise<Item.UpdateData> => {
+  const updateData: Item.UpdateData = {};
+  const rawEffects = (item as any).effects;
+  const originalEffects = Array.isArray(rawEffects)
+    ? rawEffects
+    : Array.from(rawEffects?.values?.() ?? []);
+
+  // Migrate item-owned effects
+  if (originalEffects.length > 0) {
+    const migratedEffects = migrateEffectArray(originalEffects);
+
+    if (effectArraysChanged(originalEffects, migratedEffects)) {
+      updateData.effects = toPersistedEffectArray(migratedEffects) as any; // Type coercion needed for UpdateData
+      originalEffects.forEach((effect) => {
+        if (migratedEffects.some((migrated) => migrated !== effect)) {
+          console.log(`RQG | Migrated AE paths on effect "${effect.name}" in item ${item.name}`);
+        }
+      });
+    }
+  }
+
+  return updateData;
+};

--- a/src/system/migrations/migrations-item/migrateItemActiveEffectPaths.ts
+++ b/src/system/migrations/migrations-item/migrateItemActiveEffectPaths.ts
@@ -28,8 +28,8 @@ export const migrateItemActiveEffectPaths: ItemMigration = async (
 
     if (effectArraysChanged(originalEffects, migratedEffects)) {
       updateData.effects = toPersistedEffectArray(migratedEffects) as any; // Type coercion needed for UpdateData
-      originalEffects.forEach((effect) => {
-        if (migratedEffects.some((migrated) => migrated !== effect)) {
+      originalEffects.forEach((effect, index) => {
+        if (migratedEffects[index] !== effect) {
           console.log(`RQG | Migrated AE paths on effect "${effect.name}" in item ${item.name}`);
         }
       });

--- a/src/system/migrations/migrations-item/migrateItemActiveEffectPaths.ts
+++ b/src/system/migrations/migrations-item/migrateItemActiveEffectPaths.ts
@@ -27,7 +27,33 @@ export const migrateItemActiveEffectPaths: ItemMigration = async (
     const migratedEffects = migrateEffectArray(originalEffects);
 
     if (effectArraysChanged(originalEffects, migratedEffects)) {
-      updateData.effects = toPersistedEffectArray(migratedEffects) as any; // Type coercion needed for UpdateData
+      const effectUpdates = originalEffects.flatMap((effect, index) => {
+        const migrated = migratedEffects[index];
+        if (migrated === effect) {
+          return [];
+        }
+
+        const persisted = toPersistedEffectArray([migrated])[0] as any;
+        const effectId =
+          persisted?._id ?? persisted?.id ?? (effect as any)?._id ?? (effect as any)?.id;
+        if (!effectId) {
+          return [];
+        }
+
+        return [
+          {
+            _id: effectId,
+            system: {
+              changes: persisted?.system?.changes ?? [],
+            },
+          },
+        ];
+      });
+
+      if (effectUpdates.length > 0) {
+        updateData.effects = effectUpdates as any; // Type coercion needed for UpdateData
+      }
+
       originalEffects.forEach((effect, index) => {
         if (migratedEffects[index] !== effect) {
           console.log(`RQG | Migrated AE paths on effect "${effect.name}" in item ${item.name}`);

--- a/src/system/migrations/migrations-item/migrateItemActiveEffectTypes.test.ts
+++ b/src/system/migrations/migrations-item/migrateItemActiveEffectTypes.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { RqgItem } from "@items/rqgItem.ts";
+import { migrateItemActiveEffectTypes } from "./migrateItemActiveEffectTypes";
+
+describe("migrateItemActiveEffectTypes", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("should normalize malformed custom.20 type to custom", async () => {
+    const mockItem = {
+      name: "Malformed Type Item",
+      id: "item-malformed-type-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Malformed Type Effect",
+          system: {
+            changes: [
+              {
+                key: "system.attributes.magicPoints.max",
+                type: "custom.20",
+                value: "5",
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const updateData = await migrateItemActiveEffectTypes(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].type).toBe("custom");
+    expect((updateData.effects as any[])?.[0].system.changes[0].value).toBe("5");
+  });
+
+  it("should normalize single-digit numeric mode values to canonical string type", async () => {
+    const mockItem = {
+      name: "Numeric Type Item",
+      id: "item-numeric-type-1",
+      effects: [
+        {
+          id: "effect-1",
+          name: "Numeric Type Effect",
+          system: {
+            changes: [
+              {
+                key: "system.attributes.magicPoints.max",
+                type: 2,
+                value: "6",
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const updateData = await migrateItemActiveEffectTypes(mockItem as unknown as RqgItem);
+
+    expect(updateData.effects).toBeDefined();
+    expect((updateData.effects as any[])?.[0].system.changes[0].type).toBe("add");
+  });
+});

--- a/src/system/migrations/migrations-item/migrateItemActiveEffectTypes.ts
+++ b/src/system/migrations/migrations-item/migrateItemActiveEffectTypes.ts
@@ -1,0 +1,31 @@
+import type { ItemMigration } from "../applyMigrations";
+import type { RqgItem } from "@items/rqgItem.ts";
+import {
+  effectArraysChanged,
+  migrateEffectTypeArray,
+  toPersistedEffectArray,
+} from "../shared-ae-migration-utils";
+
+/**
+ * ItemMigration: Repair malformed ActiveEffect change.type values on item effects.
+ */
+export const migrateItemActiveEffectTypes: ItemMigration = async (
+  item: RqgItem,
+): Promise<Item.UpdateData> => {
+  const updateData: Item.UpdateData = {};
+  const rawEffects = (item as any).effects;
+  const originalEffects = Array.isArray(rawEffects)
+    ? rawEffects
+    : Array.from(rawEffects?.values?.() ?? []);
+
+  if (originalEffects.length > 0) {
+    const migratedEffects = migrateEffectTypeArray(originalEffects);
+
+    if (effectArraysChanged(originalEffects, migratedEffects)) {
+      updateData.effects = toPersistedEffectArray(migratedEffects) as any;
+      console.log(`RQG | Repaired AE change.type values in item ${item.name}`);
+    }
+  }
+
+  return updateData;
+};

--- a/src/system/migrations/shared-ae-migration-utils.ts
+++ b/src/system/migrations/shared-ae-migration-utils.ts
@@ -1,0 +1,144 @@
+/**
+ * Shared utilities for Active Effect path migrations
+ *
+ * Handles rewriting legacy AE paths to new non-persisted AE-target fields
+ * introduced in PR4 for Foundry v14 compatibility.
+ */
+
+interface AEPathMapping {
+  legacyKey: string;
+  newKey: string;
+}
+
+export const AE_LEGACY_PATH_MAPPINGS: AEPathMapping[] = [
+  {
+    legacyKey: "system.attributes.magicPoints.max",
+    newKey: "system.attributes.magicPointsMaxFromEffects",
+  },
+  {
+    legacyKey: "system.attributes.hitPoints.max",
+    newKey: "system.attributes.hitPointsMaxFromEffects",
+  },
+];
+
+const AE_TARGET_KEYS = new Set(AE_LEGACY_PATH_MAPPINGS.flatMap((m) => [m.legacyKey, m.newKey]));
+
+function getEffectChanges(effect: any): any[] {
+  // v14 canonical persisted location is `system.changes`.
+  // Foundry's own migrateData moves top-level changes → system.changes.
+  // The shim only creates top-level as a getter/setter proxy.
+  const systemChanges = Array.isArray(effect?.system?.changes) ? effect.system.changes : [];
+  return systemChanges;
+}
+
+function setEffectChanges(effect: any, changes: any[]): void {
+  effect.system ??= {};
+  effect.system.changes = changes;
+}
+
+function toPersistedChangeData(change: any): any {
+  const persisted = { ...change };
+  // v14 runtime shape includes a back-reference to the parent effect.
+  // It is not part of persisted change data and should never be written.
+  delete persisted.effect;
+  return persisted;
+}
+
+function toEffectObject(effect: any): any {
+  if (effect && typeof effect.toObject === "function") {
+    // ActiveEffect documents expose persisted source via toObject().
+    return effect.toObject();
+  }
+  return structuredClone(effect);
+}
+
+function normalizeNumericValue(rawValue: unknown): number {
+  if (typeof rawValue === "number" && Number.isFinite(rawValue)) {
+    return rawValue;
+  }
+  if (typeof rawValue === "string") {
+    const normalized = rawValue.trim().replace(",", ".");
+    if (normalized.length === 0) {
+      return 0;
+    }
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+/**
+ * Migrate changes in a single effect: rewrite legacy keys to new ones.
+ * Only migrates ADD-mode changes; non-ADD modes are left untouched for manual review.
+ *
+ * @returns true if any changes were migrated
+ */
+export function migrateEffectChanges(effect: any): boolean {
+  const changes = getEffectChanges(effect);
+  if (!changes.length) {
+    return false;
+  }
+
+  const legacyKeyMap = new Map(AE_LEGACY_PATH_MAPPINGS.map((m) => [m.legacyKey, m.newKey]));
+  let hasChanges = false;
+
+  const migratedChanges = changes.map((change) => {
+    const persistedChange = toPersistedChangeData(change);
+    if (change.type !== "add") {
+      return persistedChange;
+    }
+    const keyBeforeRewrite = persistedChange.key;
+    const keyAfterRewrite = legacyKeyMap.get(keyBeforeRewrite) ?? keyBeforeRewrite;
+    const nextKey = keyAfterRewrite;
+    let nextValue = persistedChange.value;
+
+    if (AE_TARGET_KEYS.has(nextKey)) {
+      nextValue = normalizeNumericValue(persistedChange.value);
+    }
+
+    if (nextKey !== persistedChange.key || nextValue !== persistedChange.value) {
+      hasChanges = true;
+      return {
+        ...persistedChange,
+        key: nextKey,
+        value: nextValue,
+      };
+    }
+
+    return persistedChange;
+  });
+
+  setEffectChanges(effect, migratedChanges);
+
+  return hasChanges;
+}
+
+/**
+ * Process an array of effects and return the migrated array
+ * Clones and migrates effects as needed
+ *
+ * @returns array of effects (migrated or original)
+ */
+export function migrateEffectArray(effects: any[]): any[] {
+  return effects.map((effect) => {
+    const effectClone = toEffectObject(effect);
+    if (migrateEffectChanges(effectClone)) {
+      return effectClone;
+    }
+    return effect;
+  });
+}
+
+/**
+ * Convert an effects array to persisted plain data suitable for document updates.
+ */
+export function toPersistedEffectArray(effects: any[]): any[] {
+  return effects.map((effect) => toEffectObject(effect));
+}
+
+/**
+ * Check if effect arrays are different (any migrations occurred)
+ */
+export function effectArraysChanged(original: any[], migrated: any[]): boolean {
+  return migrated.some((e, i) => e !== original[i]);
+}

--- a/src/system/migrations/shared-ae-migration-utils.ts
+++ b/src/system/migrations/shared-ae-migration-utils.ts
@@ -10,14 +10,32 @@ interface AEPathMapping {
   newKey: string;
 }
 
+const LEGACY_NUMERIC_TYPE_TO_CANONICAL: Record<number, ActiveEffectChangeType> = {
+  0: "custom",
+  1: "multiply",
+  2: "add",
+  3: "downgrade",
+  4: "upgrade",
+  5: "override",
+};
+
+const CANONICAL_CHANGE_TYPES = new Set<ActiveEffectChangeType>([
+  "custom",
+  "multiply",
+  "add",
+  "downgrade",
+  "upgrade",
+  "override",
+]);
+
 export const AE_LEGACY_PATH_MAPPINGS: AEPathMapping[] = [
   {
     legacyKey: "system.attributes.magicPoints.max",
-    newKey: "system.attributes.magicPointsMaxFromEffects",
+    newKey: "system.effect.magicPoints.max",
   },
   {
     legacyKey: "system.attributes.hitPoints.max",
-    newKey: "system.attributes.hitPointsMaxFromEffects",
+    newKey: "system.effect.hitPoints.max",
   },
 ];
 
@@ -67,6 +85,37 @@ function normalizeNumericValue(rawValue: unknown): number {
   return 0;
 }
 
+function normalizeChangeType(rawType: unknown): ActiveEffectChangeType | undefined {
+  if (typeof rawType === "number" && Number.isInteger(rawType)) {
+    return LEGACY_NUMERIC_TYPE_TO_CANONICAL[rawType];
+  }
+
+  if (typeof rawType !== "string") {
+    return undefined;
+  }
+
+  if (rawType === "subtract") {
+    return "add";
+  }
+
+  if (CANONICAL_CHANGE_TYPES.has(rawType as ActiveEffectChangeType)) {
+    return rawType as ActiveEffectChangeType;
+  }
+
+  const customNumericMatch = /^custom\.(-?\d+)$/.exec(rawType);
+  if (!customNumericMatch) {
+    return undefined;
+  }
+
+  const numericType = Number(customNumericMatch[1]);
+  if (!Number.isInteger(numericType)) {
+    return undefined;
+  }
+
+  const mappedLegacyMode = LEGACY_NUMERIC_TYPE_TO_CANONICAL[numericType];
+  return mappedLegacyMode ?? "custom";
+}
+
 /**
  * Migrate changes in a single effect: rewrite legacy keys to new ones.
  * Only migrates ADD-mode changes; non-ADD modes are left untouched for manual review.
@@ -114,6 +163,35 @@ export function migrateEffectChanges(effect: any): boolean {
 }
 
 /**
+ * Repair malformed or legacy change.type values in a single effect.
+ *
+ * @returns true if any type values were normalized
+ */
+export function migrateEffectChangeTypes(effect: any): boolean {
+  const changes = getEffectChanges(effect);
+  if (!changes.length) {
+    return false;
+  }
+
+  let hasChanges = false;
+  const migratedChanges = changes.map((change) => {
+    const persistedChange = toPersistedChangeData(change);
+    const normalizedType = normalizeChangeType(persistedChange.type);
+    if (normalizedType && normalizedType !== persistedChange.type) {
+      hasChanges = true;
+      persistedChange.type = normalizedType;
+    }
+    return persistedChange;
+  });
+
+  if (hasChanges) {
+    setEffectChanges(effect, migratedChanges);
+  }
+
+  return hasChanges;
+}
+
+/**
  * Process an array of effects and return the migrated array
  * Clones and migrates effects as needed
  *
@@ -123,6 +201,19 @@ export function migrateEffectArray(effects: any[]): any[] {
   return effects.map((effect) => {
     const effectClone = toEffectObject(effect);
     if (migrateEffectChanges(effectClone)) {
+      return effectClone;
+    }
+    return effect;
+  });
+}
+
+/**
+ * Process an array of effects and normalize change.type values.
+ */
+export function migrateEffectTypeArray(effects: any[]): any[] {
+  return effects.map((effect) => {
+    const effectClone = toEffectObject(effect);
+    if (migrateEffectChangeTypes(effectClone)) {
       return effectClone;
     }
     return effect;

--- a/src/system/migrations/shared-ae-migration-utils.ts
+++ b/src/system/migrations/shared-ae-migration-utils.ts
@@ -192,6 +192,18 @@ export function migrateEffectChangeTypes(effect: any): boolean {
 }
 
 /**
+ * Normalize change.type values and then rewrite legacy paths in one pass.
+ *
+ * This keeps Active Effect migration behavior self-contained even when
+ * migration infrastructure merges payloads from independent migration functions.
+ */
+export function migrateEffectTypesAndPaths(effect: any): boolean {
+  const normalizedTypes = migrateEffectChangeTypes(effect);
+  const migratedPaths = migrateEffectChanges(effect);
+  return normalizedTypes || migratedPaths;
+}
+
+/**
  * Process an array of effects and return the migrated array
  * Clones and migrates effects as needed
  *
@@ -200,7 +212,7 @@ export function migrateEffectChangeTypes(effect: any): boolean {
 export function migrateEffectArray(effects: any[]): any[] {
   return effects.map((effect) => {
     const effectClone = toEffectObject(effect);
-    if (migrateEffectChanges(effectClone)) {
+    if (migrateEffectTypesAndPaths(effectClone)) {
       return effectClone;
     }
     return effect;

--- a/src/system/tokenStatusEffects.ts
+++ b/src/system/tokenStatusEffects.ts
@@ -33,7 +33,7 @@ export function getTokenStatusEffects(): any[] {
       changes: [
         {
           key: "~^i\\.hit-location\\.:system.naturalAp",
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.custom,
+          type: "custom",
           value: "1",
         },
       ],
@@ -48,7 +48,7 @@ export function getTokenStatusEffects(): any[] {
       changes: [
         {
           key: "~^i\\.hit-location\\.:system.naturalAp",
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.custom,
+          type: "custom",
           value: "2",
         },
       ],
@@ -63,7 +63,7 @@ export function getTokenStatusEffects(): any[] {
       changes: [
         {
           key: "~^i\\.hit-location\\.:system.naturalAp",
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.custom,
+          type: "custom",
           value: "3",
         },
       ],
@@ -78,7 +78,7 @@ export function getTokenStatusEffects(): any[] {
       changes: [
         {
           key: "~^i\\.hit-location\\.:system.naturalAp",
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.custom,
+          type: "custom",
           value: "4",
         },
       ],
@@ -94,7 +94,7 @@ export function getTokenStatusEffects(): any[] {
       changes: [
         {
           key: "system.characteristics.strength.value",
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          type: "add",
           value: "8",
         },
       ],
@@ -138,7 +138,7 @@ export function getTokenStatusEffects(): any[] {
       changes: [
         {
           key: "system.characteristics.dexterity.value",
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          type: "add",
           value: "3",
         },
       ],
@@ -289,7 +289,7 @@ export function getTokenStatusEffects(): any[] {
       changes: [
         {
           key: "system.characteristics.constitution.value",
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          type: "add",
           value: "3",
         },
       ],

--- a/static/system.json
+++ b/static/system.json
@@ -4,8 +4,8 @@
   "description": "A RuneQuest Glorantha system implementation.",
   "version": "99999.0.0-localhost",
   "compatibility": {
-    "minimum": 13,
-    "verified": 13
+    "minimum": 14,
+    "verified": 14
   },
   "license": "UNLICENSED",
   "background": "systems/rqg/assets/images/ui/sacred-time.webp",

--- a/test/setup/foundryMockFunctions.js
+++ b/test/setup/foundryMockFunctions.js
@@ -560,6 +560,7 @@ class MockDocument {
   getFlag(_scope, _path) {
     return undefined;
   }
+  prepareDerivedData() {}
 }
 
 class MockRoll {
@@ -692,6 +693,18 @@ class MockContextMenu {
   _setPosition(_menu, _target, _options) {}
 }
 
+class MockTypeDataModel {
+  constructor(source = {}) {
+    this._source = source;
+  }
+
+  static migrateData(source) {
+    return source;
+  }
+
+  prepareDerivedData() {}
+}
+
 // --------------------------------------
 // ---      Foundry global mocks      ---
 // ------------------------------
@@ -704,7 +717,7 @@ globalThis.foundry = {
   },
   abstract: {
     Document: MockDocument,
-    TypeDataModel: null, // TODO ***-
+    TypeDataModel: MockTypeDataModel,
   },
   appv1: {
     api: {


### PR DESCRIPTION

## Foundry v14 DataModel Modernization & Active Effects Compatibility

This PR modernizes the RQG system for Foundry v14 by restructuring derived value calculations into the DataModel and rewriting Active Effects to use v14-compatible non-persisted, AE-targetable fields. The change consolidates calculation logic, enables proper AE support, and includes comprehensive world migrations.

---

## Part 1: Derived Values Moved to DataModel

### Architecture Shift

Previously, derived value calculations were scattered across actor lifecycle methods:
- `RqgActor.prepareBaseData()` → calculated `magicPoints.max`
- `RqgActor.prepareEmbeddedDocuments()` → calculated `hitPoints.max` and `skillCategoryModifiers`

Now **all** derived value logic lives in `CharacterDataModel.prepareDerivedData()`:
- Calculates base values from characteristics (POW → magic points, CON/SIZ/POW → hit points, characteristic bonuses → skill modifiers)
- Composes each with effects deltas by reading non-persisted `*FromEffects` fields
- Applies encumbrance penalties to final composed skill modifiers
- Single source of truth, easier to test and maintain

### Why it matters

- Foundry v14 requires calculations in DataModel prep to support AE-targetable fields
- Non-persisted fields recalculate every prep cycle, allowing AE deltas to inject cleanly
- Simplifies actor class—removes calculation logic, keeps prep delegation only

---

## Part 2: Active Effects v14 Compatibility

### Non-Persisted Field Targets

Added non-persisted fields to `CharacterDataModel.attributes`:
- `magicPointsMaxFromEffects` — AE-targetable delta for magic points
- `hitPointsMaxFromEffects` — AE-targetable delta for hit points
- `skillCategoryModifiersFromEffects` — Full skill categories object for AE deltas per category

These fields:
- Never persist to database (recalculated every prep)
- Allow Active Effects to target derived values without side effects
- Are composed into final values during DataModel prep

### Comprehensive World Migration

Migrates all existing effects targeting old persisted paths to new non-persisted targets:
- `system.attributes.magicPoints.max` → `system.attributes.magicPointsMaxFromEffects`
- `system.attributes.hitPoints.max` → `system.attributes.hitPointsMaxFromEffects`

Migration infrastructure extended to support three levels:
- **Actor-owned effects** → `migrateActorActiveEffectPaths`
- **Item-owned effects** (world and embedded) → `migrateItemActiveEffectPaths`
- **Standalone ActiveEffect documents** (new v14 compendium type) → `migrateActiveEffectActiveEffectPaths`

Migration logic (`shared-ae-migration-utils.ts`):
- Only rewrites ADD-mode changes; preserves non-ADD modes for manual review
- Handles v14's canonical persisted location (`system.changes`)
- Strips transient runtime fields before persistence
- Normalizes numeric values safely

### System Compatibility
- Updated `system.json` to require Foundry v14 (dropped v13 support)
- Migrations run on world load; no manual intervention needed

---

## Test Coverage

- **Actor effect migrations**: 15+ tests covering legacy paths, ADD-type filtering, array handling, no-op detection
- **Item effect migrations**: 17+ tests including edge cases (conflicting containers, document-like effects, undefined values, already-migrated effects)
- All migrations log which effects were updated and on which documents

---

## Result

The system now aligns with Foundry v14's architecture: DataModel owns derived calculations, non-persisted fields support Active Effects cleanly, and a smooth migration path ensures existing effects continue working correctly.


---

```mermaid
flowchart TD
  subgraph P1["Phase 1: prepareEmbeddedDocuments"]
    A0["Actor + embedded Items + Active Effects"]
    FCore["Foundry super.prepareEmbeddedDocuments"]
    AEStd["Standard AE path application"]
    AECustom["Custom AE mode on items by rqid:system.path"]
    ItemEmb["Item lifecycle: handleActorPrepareEmbeddedDocuments"]
    HLPrep["HitLocation prep: armorPoints and location HP seed"]
    RMPrep["RuneMagic prep: chance from cult+runes"]

    A0 --> FCore
    FCore --> AEStd
    FCore --> AECustom
    FCore --> ItemEmb
    ItemEmb --> HLPrep
    ItemEmb --> RMPrep
  end

  subgraph P2["Phase 2: DataModel prepareDerivedData (inside super.prepareDerivedData)"]
    CharVals["Prepared characteristics STR CON SIZ DEX INT POW CHA"]
    BaseDeriv["Compute base derived values"]
    BaseSCM["baseSkillCategoryModifiers"]
    EffSCM["system.effect.skillCategoryModifiers deltas"]
    FinalSCM["skillCategoryModifiers = base + effect"]
    MPBase["MP base from POW"]
    HPBase["HP base from CON+SIZ+POW"]
    EffMP["system.effect.magicPoints.max"]
    EffHP["system.effect.hitPoints.max"]
    FinalMP["attributes.magicPoints.max = base + delta"]
    FinalHP["attributes.hitPoints.max = base + delta"]
    OtherDeriv["dexSR sizSR damageBonus healingRate spiritCombatDamage"]

    CharVals --> BaseDeriv
    BaseDeriv --> BaseSCM
    EffSCM --> FinalSCM
    BaseSCM --> FinalSCM

    CharVals --> MPBase
    CharVals --> HPBase
    MPBase --> FinalMP
    EffMP --> FinalMP
    HPBase --> FinalHP
    EffHP --> FinalHP

    BaseDeriv --> OtherDeriv
  end

  subgraph P3["Phase 3: Actor post-processing in RqgActor.prepareDerivedData"]
    EncInputs["STR CON locomotion carryingFactor + item weights"]
    EncVals["encumbrance max equipped travel"]
    EqPen["equipped enc penalty"]
    TrPen["travel enc penalty"]
    SCMPost["Apply equipped penalty to skillCategoryModifiers"]
    MoveBase["move.value"]
    MoveEq["move.equipped"]
    MoveTr["move.travel"]
    ItemDeriv["Item lifecycle: handleActorPrepareDerivedData"]
    SkillDeriv["Skill chance recompute"]
    Health["Combined actor health status"]

    EncInputs --> EncVals
    EncVals --> EqPen
    EncVals --> TrPen
    FinalSCM --> SCMPost
    EqPen --> SCMPost

    MoveBase --> MoveEq
    EqPen --> MoveEq
    MoveBase --> MoveTr
    TrPen --> MoveTr

    SCMPost --> ItemDeriv
    ItemDeriv --> SkillDeriv
    FinalHP --> ItemDeriv
    ItemDeriv --> Health
  end

  P1 --> P2
  P2 --> P3
  ```

```mermaid
flowchart TD
  AEChar["Active Effects on characteristics"] --> STR["STR"]
  AEChar --> CON["CON"]
  AEChar --> SIZ["SIZ"]
  AEChar --> DEX["DEX"]
  AEChar --> INT["INT"]
  AEChar --> POW["POW"]
  AEChar --> CHA["CHA"]

  STR --> BaseDeriv["Base characteristic-derived calculations"]
  CON --> BaseDeriv
  SIZ --> BaseDeriv
  DEX --> BaseDeriv
  INT --> BaseDeriv
  POW --> BaseDeriv
  CHA --> BaseDeriv

  BaseDeriv --> BaseSCM["Base skillCategoryModifiers"]
  BaseDeriv --> DexSR["dexStrikeRank"]
  BaseDeriv --> SizSR["sizStrikeRank"]
  BaseDeriv --> DmgBonus["damageBonus"]
  BaseDeriv --> HealRate["healingRate"]
  BaseDeriv --> SpiritDmg["spiritCombatDamage"]

  POW --> MPBase["magicPoints.max base"]
  CON --> HPBase["hitPoints.max base"]
  SIZ --> HPBase
  POW --> HPBase

  AEEff["Active Effects on system.effect deltas"] --> EffSCM["effect.skillCategoryModifiers.*"]
  AEEff --> EffMP["effect.magicPoints.max"]
  AEEff --> EffHP["effect.hitPoints.max"]

  BaseSCM --> FinalSCM["Final skillCategoryModifiers"]
  EffSCM --> FinalSCM

  MPBase --> FinalMP["Final magicPoints.max"]
  EffMP --> FinalMP

  HPBase --> FinalHP["Final hitPoints.max"]
  EffHP --> FinalHP

  STR --> EncMax["encumbrance.max"]
  CON --> EncMax
  Carry["locomotion carryingFactor"] --> EncMax
  Items["Items"] --> EncEq["encumbrance.equipped"]
  Items --> EncTr["encumbrance.travel"]

  EncMax --> EqPenalty["equipped encumbrance penalty"]
  EncEq --> EqPenalty
  EncMax --> TrPenalty["travel encumbrance penalty"]
  EncTr --> TrPenalty

  FinalSCM --> PostSCM["Post-encumbrance skillCategoryModifiers"]
  EqPenalty --> PostSCM

  MoveBase["move.value"] --> MoveEq["move.equipped"]
  EqPenalty --> MoveEq
  MoveBase --> MoveTr["move.travel"]
  TrPenalty --> MoveTr

  PostSCM --> SkillChance["Skill chance"]
  Items --> SkillChance
  EncEq --> SkillChance

  FinalHP --> HitLocHP["Hit location HP"]
  Items --> HitLocAP["Hit location armor points"]
  HitLocHP --> HitLocFinal["Hit location final durability"]
  HitLocAP --> HitLocFinal

  Items --> RuneMagicChance["Rune magic chance from cult+runes"]
```


```mermaid
flowchart TD
  STR[STR] --> Base[Base derived calculations]
  CON[CON] --> Base
  SIZ[SIZ] --> Base
  DEX[DEX] --> Base
  INT[INT] --> Base
  POW[POW] --> Base
  CHA[CHA] --> Base

  Base --> DexSR[dexStrikeRank]
  Base --> SizSR[sizStrikeRank]
  Base --> DmgBonus[damageBonus]
  Base --> HealRate[healingRate]
  Base --> SpiritDmg[spiritCombatDamage]
  Base --> BaseSCM[baseSkillCategoryModifiers]

  AEEff[AE deltas on system.effect] --> EffSCM[effect.skillCategoryModifiers]
  BaseSCM --> FinalSCM[skillCategoryModifiers]
  EffSCM --> FinalSCM

  POW --> MPBase[magicPoints.max base]
  AEEff --> MPDelta[effect.magicPoints.max]
  MPBase --> MPFinal[magicPoints.max]
  MPDelta --> MPFinal

  CON --> HPBase[hitPoints.max base]
  SIZ --> HPBase
  POW --> HPBase
  AEEff --> HPDelta[effect.hitPoints.max]
  HPBase --> HPFinal[hitPoints.max]
  HPDelta --> HPFinal
```