### PR TITLE
fix(actors): improve cult info column spacing on v2 rune magic tab

### DIFF
--- a/src/actors/_actorsheet-v2.scss
+++ b/src/actors/_actorsheet-v2.scss
@@ -1933,7 +1933,9 @@
 
               > span,
               > div {
-                flex: 1 1 auto;
+                // Holy Days / Gifts / Geases: get most of any extra space,
+                // since they usually hold the longest text
+                flex: 4 1 10em;
                 min-width: 0;
                 overflow: hidden;
                 display: -webkit-box;
@@ -1955,14 +1957,21 @@
                 }
               }
 
+
               > span.rune-points {
                 flex: 0 0 auto;
                 display: block; // override line-clamp display
+                white-space: nowrap;
+                min-width: 5.5em; // fit label + input without wrapping
               }
 
               > div.joined-cults {
-                flex: 0 0 auto;
+                // Cult/god name: size to its (usually short) content instead of
+                // stretching, but cap so a long name/tagline doesn't dominate
+                flex: 1 1 auto;
                 min-width: 8em;
+                max-width: 16em;
+                overflow-wrap: break-word;
               }
             }
 

--- a/src/actors/rqg-actor-sheet-data-prep.ts
+++ b/src/actors/rqg-actor-sheet-data-prep.ts
@@ -30,6 +30,7 @@ import {
   getItemDocumentTypes,
   isDocumentSubType,
   localize,
+  localizeDynamic,
   range,
 } from "../system/util";
 import { ItemTypeEnum, type PhysicalItem } from "@item-model/item-types.ts";
@@ -668,6 +669,20 @@ export async function organizeEmbeddedItems(
         await foundry.applications.ux.TextEditor.implementation.enrichHTML(cultItem.system.geases);
     }) ?? [],
   );
+
+  // Build the HTML for the joined cults / god names column, reused both for
+  // the (line-clamped) visible sheet content and its full-text tooltip
+  itemTypes[ItemTypeEnum.Cult]?.forEach((cult) => {
+    const cultItem = cult as CultItem;
+    (cultItem.system as any).enrichedJoinedCults = (cultItem.system.joinedCults ?? [])
+      .map((joinedCult) => {
+        const rankText = localizeDynamic("RQG.Actor.RuneMagic.CultRank.", joinedCult.rank);
+        const header = `<b>${joinedCult.cultName} – ${rankText}</b>`;
+        const tagline = joinedCult.tagline ? `<br><i>${joinedCult.tagline}</i>` : "";
+        return `<div>${header}${tagline}</div>`;
+      })
+      .join("");
+  });
 
   // Extract hasAccessToRuneMagic info from subCults and sum up learned rune magic points per cult
   itemTypes[ItemTypeEnum.Cult]?.forEach((cult) => {

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-rune-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-rune-magic.hbs
@@ -44,20 +44,16 @@
             </span>
           {{/if}}
           {{#if system.enrichedHolyDays}}
-            <span><b>{{localize "RQG.Actor.RuneMagic.HolyDays"}}</b> {{{system.enrichedHolyDays}}}</span>
+            <span data-tooltip-html="{{system.enrichedHolyDays}}"><b>{{localize "RQG.Actor.RuneMagic.HolyDays"}}</b> {{{system.enrichedHolyDays}}}</span>
           {{/if}}
           {{#if system.enrichedGifts}}
-            <span><b>{{localize "RQG.Actor.RuneMagic.Gifts"}}</b> {{{system.enrichedGifts}}}</span>
+            <span data-tooltip-html="{{system.enrichedGifts}}"><b>{{localize "RQG.Actor.RuneMagic.Gifts"}}</b> {{{system.enrichedGifts}}}</span>
           {{/if}}
           {{#if system.enrichedGeases}}
-            <span><b>{{localize "RQG.Actor.RuneMagic.Geases"}}</b> {{{system.enrichedGeases}}}</span>
+            <span data-tooltip-html="{{system.enrichedGeases}}"><b>{{localize "RQG.Actor.RuneMagic.Geases"}}</b> {{{system.enrichedGeases}}}</span>
           {{/if}}
-          <div class="joined-cults" {{#if system.descriptionRqidLink.rqid}}data-rqid-link="{{system.descriptionRqidLink.rqid}}"{{/if}}>
-            {{#each system.joinedCults}}
-              <div><b>{{cultName}} – {{localizeDynamic "RQG.Actor.RuneMagic.CultRank." rank}}</b>
-                {{#if tagline}}<br><i>{{tagline}}</i>{{/if}}
-              </div>
-            {{/each}}
+          <div class="joined-cults" data-tooltip-html="{{system.enrichedJoinedCults}}" {{#if system.descriptionRqidLink.rqid}}data-rqid-link="{{system.descriptionRqidLink.rqid}}"{{/if}}>
+            {{{system.enrichedJoinedCults}}}
           </div>
           </div>{{!-- cult-meta-row --}}
         </div>


### PR DESCRIPTION
Fixes #886

## Summary
- Rune Points column no longer wraps its label onto two lines.
- Holy Days / Gifts / Geases share the bulk of extra row width (flex-grow 4), since they usually hold the longest text.
- Cult/god name column sizes to its content (capped) instead of stretching or being squeezed to a min-width floor, and still wraps to two lines.
- Full text for Holy Days / Gifts / Geases / joined cults is now available via a native Foundry tooltip (`data-tooltip-html`) when the visible text is clamped to two lines, backed by a new reusable `enrichedJoinedCults` field in the actor sheet data prep.

Scoped to the v2 actor sheet only (`_actorsheet-v2.scss`, `actor-sheet-v2-rune-magic.hbs`).

## Testing
- `pnpm lint:scripts`, `pnpm lint:styles`
- `pnpm typecheck`
- `pnpm test` (targeted + full suite via pre-push hook)