### PR TITLE
fix(items): show actor name in Apply Wound dialog title

### DIFF
--- a/src/items/hit-location-item/hit-location-add-wound-dialog.ts
+++ b/src/items/hit-location-item/hit-location-add-wound-dialog.ts
@@ -41,6 +41,7 @@ export async function showHitLocationAddWoundDialog(
   void foundry.applications.api.DialogV2.wait({
     window: {
       title: localize("RQG.Item.HitLocation.AddWound.Title", {
+        actorName: actor.name,
         hitLocationName: hitLocation.name,
       }),
     },

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -823,7 +823,7 @@
         "ArmorPoints": "Armor Points",
         "Wounds": "Wounds",
         "AddWound": {
-          "Title": "Apply Wound to {hitLocationName}",
+          "Title": "Apply Wound to {hitLocationName} of {actorName}",
           "DamageToApply": "Damage to apply",
           "TotalHpAfter": "Total HP after",
           "ApplyToTotalHitPointsQ": "Apply to total HP?",


### PR DESCRIPTION
## Summary
Adds the target actor's name to the Apply Wound dialog title so it's clear who receives the wound, especially when multiple actor sheets are open (e.g. two actors in combat).

Title changes from:
`Apply Wound to {hitLocationName}`
to:
`Apply Wound to {hitLocationName} of {actorName}`

Named placeholders let translators reorder `actorName`/`hitLocationName` per their language's grammar (e.g. Swedish would naturally use a possessive form).

Addresses the main ask of #194. The other proposed items (current/max HP, AP display) are already implemented in the current dialog; the annotation/tooltip suggestions are considered overkill for now.

Closes #194

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>