### PR TITLE
Fix: Spirit Magic capacity limited by CHA, not INT; fix Sorcery spell-count accounting

### DIFF
--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -110,6 +110,12 @@
       }
     }
 
+/* Shared "magic capacity limit" status banner, used by the Spirit Magic, Sorcery and Rune Magic tabs. */
+    & .magic-limit-banner {
+      font-size: small;
+      padding: 2px 0;
+    }
+
 /* Dark fill visible behind both nav and parchment transparent areas */
     background: rgb(0 0 0 / 60%);
 
@@ -1811,20 +1817,6 @@
         }
       }
 
-      & .int-capacity-row {
-        display: flex;
-        justify-content: flex-end;
-        padding: 0 6px;
-        margin-bottom: 0.25rem;
-        text-align: right;
-        font-size: 0.75em;
-        font-weight: normal;
-
-        & .warning {
-          color: var(--color-text-dark-warn, #a00);
-        }
-      }
-
       & .skill-row {
         display: contents;
 
@@ -1853,21 +1845,7 @@
 /* --- Spirit Magic tab --- */
     .spirit-magic-tab-v2 {
       & h2 {
-        display: flex;
-        align-items: baseline;
-        gap: 0.5rem;
         padding: 0 6px;
-        flex-wrap: wrap;
-
-        & .small-size {
-          font-size: 0.75em;
-          font-weight: normal;
-          margin-left: auto;
-        }
-
-        & .warning {
-          color: var(--color-text-dark-warn, #a00);
-        }
       }
 
       & .grid.spiritmagic.item-list {
@@ -1987,16 +1965,6 @@
               object-fit: contain;
               vertical-align: middle;
             }
-
-            & .small-size {
-              font-size: 0.75em;
-              font-weight: normal;
-              margin-left: auto;
-            }
-
-            & .warning {
-              color: var(--color-text-dark-warn, #a00);
-            }
           }
 
           & .cult-meta {
@@ -2081,11 +2049,6 @@
             }
           }
         }
-      }
-
-      & .cult-cha-limit {
-        font-size: 0.85em;
-        padding: 2px 0;
       }
 
       & .grid.runemagic.item-list {

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -319,6 +319,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       baseStrikeRank: DataPrep.getBaseStrikeRank(dexStrikeRank, system.attributes.sizStrikeRank),
 
       spiritMagicPointSum: spiritMagicPointSum,
+      sorcerySkillCount: CharacterDataModel.getSorcerySkillCount(this.actor),
       freeInt: CharacterDataModel.getFreeInt(this.actor, spiritMagicPointSum),
       powCrystals: DataPrep.getPowCrystals(this.actor),
 

--- a/src/actors/rqg-actor-sheet-v2.types.ts
+++ b/src/actors/rqg-actor-sheet-v2.types.ts
@@ -87,6 +87,8 @@ export interface RqgActorSheetV2Context {
 
   /** Total spirit magic points memorized. */
   spiritMagicPointSum: number;
+  /** Number of sorcery spells (rune-linked skills) learned. */
+  sorcerySkillCount: number;
   /** INT remaining after spirit magic. */
   freeInt: number;
 

--- a/src/actors/rqg-actor-sheet.ts
+++ b/src/actors/rqg-actor-sheet.ts
@@ -234,6 +234,7 @@ export class RqgActorSheet<
       itemLocationTree: itemTree.toSheetData(),
       powCrystals: DataPrep.getPowCrystals(this.actor),
       spiritMagicPointSum: spiritMagicPointSum,
+      sorcerySkillCount: CharacterDataModel.getSorcerySkillCount(this.actor),
       freeInt: CharacterDataModel.getFreeInt(this.actor, spiritMagicPointSum),
       baseStrikeRank: DataPrep.getBaseStrikeRank(dexStrikeRank, system.attributes.sizStrikeRank),
       enrichedAllies: await foundry.applications.ux.TextEditor.implementation.enrichHTML(

--- a/src/actors/rqg-actor-sheet.types.ts
+++ b/src/actors/rqg-actor-sheet.types.ts
@@ -106,6 +106,7 @@ export interface CharacterSheetData {
   /** list of pow-crystals */
   powCrystals: { name: string; size: number }[];
   spiritMagicPointSum: number;
+  sorcerySkillCount: number;
   freeInt: number;
   baseStrikeRank: number | undefined;
   enrichedAllies: string;

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-rune-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-rune-magic.hbs
@@ -68,8 +68,8 @@
 
       {{#if hasAccessToRuneMagic}}
         {{#if (lte (difference @root.system.characteristics.charisma.value system.runePoints.max) -1)}}
-          <div class="cult-cha-limit">
-            <span class="small-size warning"
+          <div class="magic-limit-banner">
+            <span class="warning"
                   data-tooltip="{{localize 'RQG.Actor.RuneMagic.CHALimitExceeded'
                       runePointsMax=system.runePoints.max
                       chaValue=@root.system.characteristics.charisma.value
@@ -79,8 +79,8 @@
               exceededBy=(difference system.runePoints.max @root.system.characteristics.charisma.value)}}</span>
           </div>
         {{else if (lte (difference @root.system.characteristics.charisma.value system.runePoints.max) 0)}}
-          <div class="cult-cha-limit">
-            <span class="small-size">{{localize "RQG.Actor.RuneMagic.CHALimitReached"
+          <div class="magic-limit-banner">
+            <span>{{localize "RQG.Actor.RuneMagic.CHALimitReached"
                 runePointsMax=system.runePoints.max}}</span>
           </div>
         {{/if}}

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-sorcery.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-sorcery.hbs
@@ -1,21 +1,25 @@
 <section class="tab sorcery-tab-v2{{#if (eq @root.activeTabs.primary "sorcery")}} active{{/if}}" data-group="primary" data-tab="sorcery">
-  <div class="int-capacity-row small-size">
+  <div class="magic-limit-banner">
     {{#if (lt freeInt 0)}}
       <span class="warning"
-            data-tooltip="{{localize 'RQG.Actor.SpiritMagic.INTLimitExceeded'
-                learnedPoints=spiritMagicPointSum
+            data-tooltip="{{localize 'RQG.Actor.Sorcery.INTLimitExceeded'
+                spiritMagicPoints=spiritMagicPointSum
+                sorceryCount=sorcerySkillCount
                 intValue=system.characteristics.intelligence.value
-                exceededBy=(difference 0 freeInt)}}">{{localize "RQG.Actor.SpiritMagic.INTLimitExceeded"
-          learnedPoints=spiritMagicPointSum
+                exceededBy=(difference 0 freeInt)}}">{{localize "RQG.Actor.Sorcery.INTLimitExceeded"
+          spiritMagicPoints=spiritMagicPointSum
+          sorceryCount=sorcerySkillCount
           intValue=system.characteristics.intelligence.value
           exceededBy=(difference 0 freeInt)}}</span>
     {{else if (eq freeInt 0)}}
-      <span class="warning">{{localize "RQG.Actor.SpiritMagic.INTLimitReached"
-          learnedPoints=spiritMagicPointSum}}</span>
+      <span>{{localize "RQG.Actor.Sorcery.INTLimitReached"
+          spiritMagicPoints=spiritMagicPointSum
+          sorceryCount=sorcerySkillCount}}</span>
     {{else}}
       <span data-tooltip="{{localize 'RQG.Actor.Sorcery.INTLimitTooltip'
-          intValue=system.characteristics.intelligence.value}}">{{localize "RQG.Actor.SpiritMagic.INTLimitFormula"
-          learnedPoints=spiritMagicPointSum
+          intValue=system.characteristics.intelligence.value}}">{{localize "RQG.Actor.Sorcery.INTLimitFormula"
+          spiritMagicPoints=spiritMagicPointSum
+          sorceryCount=sorcerySkillCount
           freePoints=freeInt}}</span>
     {{/if}}
   </div>

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
@@ -1,27 +1,27 @@
 <section class="tab spirit-magic-tab-v2{{#if (eq @root.activeTabs.primary "spiritmagic")}} active{{/if}}" data-group="primary" data-tab="spiritmagic">
 
-  <h2>
-    {{localize "RQG.Actor.SpiritMagic.SpiritMagic"}}
-    {{#if (lt freeInt 0)}}
-      <span class="small-size warning"
-            data-tooltip="{{localize 'RQG.Actor.SpiritMagic.INTLimitExceeded'
+  <h2>{{localize "RQG.Actor.SpiritMagic.SpiritMagic"}}</h2>
+
+  <div class="magic-limit-banner">
+    {{#if (lt (difference system.characteristics.charisma.value spiritMagicPointSum) 0)}}
+      <span class="warning"
+            data-tooltip="{{localize 'RQG.Actor.SpiritMagic.CHALimitExceeded'
                 learnedPoints=spiritMagicPointSum
-                intValue=system.characteristics.intelligence.value
-                exceededBy=(difference 0 freeInt)}}">{{localize "RQG.Actor.SpiritMagic.INTLimitExceeded"
+                chaValue=system.characteristics.charisma.value
+                exceededBy=(difference spiritMagicPointSum system.characteristics.charisma.value)}}">{{localize "RQG.Actor.SpiritMagic.CHALimitExceeded"
           learnedPoints=spiritMagicPointSum
-          intValue=system.characteristics.intelligence.value
-          exceededBy=(difference 0 freeInt)}}</span>
-    {{else if (eq freeInt 0)}}
-      <span class="small-size warning">{{localize "RQG.Actor.SpiritMagic.INTLimitReached"
+          chaValue=system.characteristics.charisma.value
+          exceededBy=(difference spiritMagicPointSum system.characteristics.charisma.value)}}</span>
+    {{else if (eq (difference system.characteristics.charisma.value spiritMagicPointSum) 0)}}
+      <span>{{localize "RQG.Actor.SpiritMagic.CHALimitReached"
           learnedPoints=spiritMagicPointSum}}</span>
     {{else}}
-      <span class="small-size"
-            data-tooltip="{{localize 'RQG.Actor.SpiritMagic.INTLimitTooltip'
-                intValue=system.characteristics.intelligence.value}}">{{localize "RQG.Actor.SpiritMagic.INTLimitFormula"
+      <span data-tooltip="{{localize 'RQG.Actor.SpiritMagic.CHALimitTooltip'
+                chaValue=system.characteristics.charisma.value}}">{{localize "RQG.Actor.SpiritMagic.CHALimitFormula"
           learnedPoints=spiritMagicPointSum
-          freePoints=freeInt}}</span>
+          freePoints=(difference system.characteristics.charisma.value spiritMagicPointSum)}}</span>
     {{/if}}
-  </h2>
+  </div>
 
   <div class="grid spiritmagic item-list">
     <div class="headings"></div>

--- a/src/actors/sheet-parts/sorcery-tab.hbs
+++ b/src/actors/sheet-parts/sorcery-tab.hbs
@@ -3,20 +3,24 @@
     <div class="small-size">
       {{#if (lt freeInt 0)}}
         <span class="warning"
-              data-tooltip="{{localize 'RQG.Actor.SpiritMagic.INTLimitExceeded'
-                  learnedPoints=spiritMagicPointSum
+              data-tooltip="{{localize 'RQG.Actor.Sorcery.INTLimitExceeded'
+                  spiritMagicPoints=spiritMagicPointSum
+                  sorceryCount=sorcerySkillCount
                   intValue=system.characteristics.intelligence.value
-                  exceededBy=(difference 0 freeInt)}}">{{localize "RQG.Actor.SpiritMagic.INTLimitExceeded"
-            learnedPoints=spiritMagicPointSum
+                  exceededBy=(difference 0 freeInt)}}">{{localize "RQG.Actor.Sorcery.INTLimitExceeded"
+            spiritMagicPoints=spiritMagicPointSum
+            sorceryCount=sorcerySkillCount
             intValue=system.characteristics.intelligence.value
             exceededBy=(difference 0 freeInt)}}</span>
       {{else if (eq freeInt 0)}}
-        <span class="warning">{{localize "RQG.Actor.SpiritMagic.INTLimitReached"
-            learnedPoints=spiritMagicPointSum}}</span>
+        <span>{{localize "RQG.Actor.Sorcery.INTLimitReached"
+            spiritMagicPoints=spiritMagicPointSum
+            sorceryCount=sorcerySkillCount}}</span>
       {{else}}
         <span data-tooltip="{{localize 'RQG.Actor.Sorcery.INTLimitTooltip'
-            intValue=system.characteristics.intelligence.value}}">{{localize "RQG.Actor.SpiritMagic.INTLimitFormula"
-            learnedPoints=spiritMagicPointSum
+            intValue=system.characteristics.intelligence.value}}">{{localize "RQG.Actor.Sorcery.INTLimitFormula"
+            spiritMagicPoints=spiritMagicPointSum
+            sorceryCount=sorcerySkillCount
             freePoints=freeInt}}</span>
       {{/if}}
     </div>

--- a/src/actors/sheet-parts/spirit-magic-tab.hbs
+++ b/src/actors/sheet-parts/spirit-magic-tab.hbs
@@ -1,23 +1,23 @@
 <h2>
   {{localize "RQG.Actor.SpiritMagic.SpiritMagic"}}
-  {{#if (lt freeInt 0)}}
+  {{#if (lt (difference system.characteristics.charisma.value spiritMagicPointSum) 0)}}
     <span class="small-size warning"
-          data-tooltip="{{localize 'RQG.Actor.SpiritMagic.INTLimitExceeded'
+          data-tooltip="{{localize 'RQG.Actor.SpiritMagic.CHALimitExceeded'
               learnedPoints=spiritMagicPointSum
-              intValue=system.characteristics.intelligence.value
-              exceededBy=(difference 0 freeInt)}}">{{localize "RQG.Actor.SpiritMagic.INTLimitExceeded"
+              chaValue=system.characteristics.charisma.value
+              exceededBy=(difference spiritMagicPointSum system.characteristics.charisma.value)}}">{{localize "RQG.Actor.SpiritMagic.CHALimitExceeded"
         learnedPoints=spiritMagicPointSum
-        intValue=system.characteristics.intelligence.value
-        exceededBy=(difference 0 freeInt)}}</span>
-  {{else if (eq freeInt 0)}}
-    <span class="small-size warning">{{localize "RQG.Actor.SpiritMagic.INTLimitReached"
+        chaValue=system.characteristics.charisma.value
+        exceededBy=(difference spiritMagicPointSum system.characteristics.charisma.value)}}</span>
+    {{else if (eq (difference system.characteristics.charisma.value spiritMagicPointSum) 0)}}
+    <span class="small-size">{{localize "RQG.Actor.SpiritMagic.CHALimitReached"
         learnedPoints=spiritMagicPointSum}}</span>
   {{else}}
     <span class="small-size"
-          data-tooltip="{{localize 'RQG.Actor.SpiritMagic.INTLimitTooltip'
-              intValue=system.characteristics.intelligence.value}}">{{localize "RQG.Actor.SpiritMagic.INTLimitFormula"
+          data-tooltip="{{localize 'RQG.Actor.SpiritMagic.CHALimitTooltip'
+              chaValue=system.characteristics.charisma.value}}">{{localize "RQG.Actor.SpiritMagic.CHALimitFormula"
         learnedPoints=spiritMagicPointSum
-        freePoints=freeInt}}</span>
+        freePoints=(difference system.characteristics.charisma.value spiritMagicPointSum)}}</span>
   {{/if}}
 </h2>
 <div class="grid spiritmagic item-list">

--- a/src/data-model/actor-data/character-data-model.ts
+++ b/src/data-model/actor-data/character-data-model.ts
@@ -218,11 +218,15 @@ export class CharacterDataModel extends RqgActorDataModel<
     }, 0);
   }
 
-  static getFreeInt(actor: CharacterActor, spiritMagicPointSum: number): number {
-    const sorcerySkillCount = actor.items.filter(
+  static getSorcerySkillCount(actor: CharacterActor): number {
+    return actor.items.filter(
       (i) =>
         isDocumentSubType<SkillItem>(i, ItemTypeEnum.Skill) && !!i.system.runeRqidLinks?.length,
     ).length;
+  }
+
+  static getFreeInt(actor: CharacterActor, spiritMagicPointSum: number): number {
+    const sorcerySkillCount = CharacterDataModel.getSorcerySkillCount(actor);
 
     return (
       (actor.system.characteristics.intelligence.value ?? 0) -

--- a/src/data-model/json-schemas/generated/item/cult.schema.json
+++ b/src/data-model/json-schemas/generated/item/cult.schema.json
@@ -49,13 +49,14 @@
           "default": 0
         },
         "max": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": "integer",
+          "default": 0
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "max"
+      ]
     },
     "holyDays": {
       "type": "string",

--- a/src/data-model/json-schemas/generated/item/hitLocation.schema.json
+++ b/src/data-model/json-schemas/generated/item/hitLocation.schema.json
@@ -26,13 +26,14 @@
           "default": 0
         },
         "max": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": "integer",
+          "default": 0
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "max"
+      ]
     },
     "baseHpDelta": {
       "type": "integer",

--- a/src/data-model/json-schemas/generated/item/weapon.schema.json
+++ b/src/data-model/json-schemas/generated/item/weapon.schema.json
@@ -554,13 +554,14 @@
           "default": 0
         },
         "max": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": "integer",
+          "default": 0
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "max"
+      ]
     },
     "hitPointLocation": {
       "type": "string",

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -397,17 +397,20 @@
         }
       },
       "Sorcery": {
-        "INTLimitTooltip": "Maximum learnable Sorcery is limited by INT ({intValue}). Spirit Magic points also count against this limit.",
+        "INTLimitTooltip": "Maximum learnable Sorcery spells is limited by INT ({intValue}). Spirit Magic points also count against this limit.",
+        "INTLimitFormula": "Remaining Sorcery capacity is {freePoints} Free INT ({spiritMagicPoints} Spirit Magic + {sorceryCount} Sorcery spells learned).",
+        "INTLimitReached": "Sorcery capacity reached — {spiritMagicPoints} Spirit Magic + {sorceryCount} Sorcery spells learned (INT limit).",
+        "INTLimitExceeded": "Sorcery capacity exceeded by {exceededBy} points! ({spiritMagicPoints} Spirit Magic + {sorceryCount} Sorcery spells learned, INT limit is {intValue}).",
         "Spells": "Spells",
         "Techniques": "Techniques",
         "MasteredRunes": "Mastered Runes"
       },
       "SpiritMagic": {
         "SpiritMagic": "Spirit Magic",
-        "INTLimitFormula": "Remaining learning capacity is {freePoints} points of Spirit Magic ({learnedPoints} points already learned).",
-        "INTLimitTooltip": "Maximum learnable Spirit Magic is limited by INT ({intValue}). Sorcery spells also count against this limit.",
-        "INTLimitReached": "Learning capacity reached — {learnedPoints} points of Spirit Magic learned (INT limit).",
-        "INTLimitExceeded": "Learning capacity exceeded by {exceededBy} points! ({learnedPoints} points learned, INT limit is {intValue}).",
+        "CHALimitFormula": "Remaining learning capacity is {freePoints} points of Spirit Magic ({learnedPoints} points already learned).",
+        "CHALimitTooltip": "Maximum Spirit Magic points learnable is limited by CHA ({chaValue}).",
+        "CHALimitReached": "Learning capacity reached — {learnedPoints} points of Spirit Magic learned (CHA limit).",
+        "CHALimitExceeded": "Learning capacity exceeded by {exceededBy} points! ({learnedPoints} points learned, CHA limit is {chaValue}).",
         "Name": "Name",
         "SpellFocus": "Focus",
         "SpellSummary": "Spell Summary",


### PR DESCRIPTION
## Problem
The Spirit Magic tab displayed a "learning capacity" warning based on **INT** (specifically Free INT), but per the RuneQuest: Glorantha rules, Spirit Magic point capacity is limited by **CHA**. INT/Free INT instead governs how many **Sorcery** spells a character can hold and cast.

## Changes
- **Spirit Magic tabs** (v1 + v2): capacity check now compares learned Spirit Magic points against **CHA** instead of Free INT. New `SpiritMagic.CHALimit*` localization keys replace the old, incorrect `SpiritMagic.INTLimit*` keys.
- **Sorcery tabs** (v1 + v2): now use their own dedicated `Sorcery.INTLimit*` keys (previously incorrectly reusing the Spirit Magic ones). The message now reports **Spirit Magic points** and **Sorcery spells learned** as two separate numbers instead of a single combined total — this also fixes a bug where the Sorcery spell count was silently dropped from the displayed message.
- **`CharacterDataModel`**: extracted `getSorcerySkillCount()` from the inline logic in `getFreeInt()`, so both the capacity math and the sheet display share one source of truth.
- **Sheet context prep** (`rqg-actor-sheet(-v2).ts` + types): expose `sorcerySkillCount` for template use.
- **CSS / v2 templates**: fixed illegible warning text (was using the non-existent `--color-text-dark-warn` variable, which always silently fell back to hardcoded dark red regardless of theme). Warning text now inherits the same color as normal body text (theme-adaptive, readable in both light and dark mode) and uses a consistent font size across all three tabs, instead of the previous inconsistent overrides. Deduplicated styling into one shared `.magic-limit-banner` class used consistently by the Spirit Magic, Sorcery, and Rune Magic tabs. The "limit reached exactly" state is informational, not a warning, so it no longer carries warning styling.
- Also includes a small unrelated **chore** commit regenerating stale generated JSON schemas (`cult`, `hitLocation`, `weapon`) that had drifted from a prior data-model change, so `pnpm check:schemas` passes again.

## Testing
- `pnpm lint:scripts`, `pnpm lint:styles`, `pnpm typecheck` all pass.
- Full `vitest` suite (393 tests) passes.
- `pnpm check:schemas` / `pnpm -s i18n:audit-unused --fail-on-unused` pass.
- Manually verified in-app: Spirit Magic/Sorcery/Rune Magic warning text is now readable and consistently sized/colored across light and dark themes.

## Notes
- English pluralization for the warning strings (e.g. "1 Sorcery spell" vs "2 Sorcery spells") was discussed and **intentionally not implemented** — kept consistent with the repo's existing "always plural" phrasing convention (see AGENTS.md).
