### PR TITLE
fix: hide health section and use MP for spirits with no hit points

### DIFF
--- a/src/actors/rqg-actor-sheet-data-prep.ts
+++ b/src/actors/rqg-actor-sheet-data-prep.ts
@@ -807,7 +807,9 @@ export function getUiSectionVisibility(actor: CharacterActor): UiSections {
   return {
     health:
       CONFIG.RQG.debug.showAllUiSections ||
-      actor.system.attributes.hitPoints.max != null ||
+      actor.system.characteristics.strength.value != null ||
+      actor.system.characteristics.constitution.value != null ||
+      actor.system.characteristics.size.value != null ||
       actor.items.some((i) => isDocumentSubType<HitLocationItem>(i, ItemTypeEnum.HitLocation)),
     combat:
       CONFIG.RQG.debug.showAllUiSections ||

--- a/src/items/hit-location-item/hit-location-damage-calculations.ts
+++ b/src/items/hit-location-item/hit-location-damage-calculations.ts
@@ -280,10 +280,22 @@ export class DamageCalculations {
   static getCombinedActorHealth(actor: RqgActor): ActorHealthState {
     assertDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character);
 
-    const maxHitPoints = actor.system.attributes.hitPoints.max;
+    const tracksHitPoints =
+      actor.system.characteristics.strength.value != null ||
+      actor.system.characteristics.constitution.value != null ||
+      actor.system.characteristics.size.value != null ||
+      actor.items.some((i) => isDocumentSubType<HitLocationItem>(i, ItemTypeEnum.HitLocation));
 
     const hasMaxMagicPoints = !!actor.system.attributes.magicPoints.max;
     const currentMagicPoints = actor.system.attributes.magicPoints.value ?? 0;
+
+    if (!tracksHitPoints) {
+      // Actors without physical characteristics (e.g. spirits) have no hit points, but
+      // still fall unconscious when their magic points are depleted, same as other actors.
+      return hasMaxMagicPoints && currentMagicPoints <= 0 ? "unconscious" : "healthy";
+    }
+
+    const maxHitPoints = actor.system.attributes.hitPoints.max;
 
     if (maxHitPoints == null) {
       return "healthy";


### PR DESCRIPTION
## Summary
- The health/hit-location UI section and `getCombinedActorHealth()` both keyed off `system.attributes.hitPoints.max`, which is `null` for actors without physical characteristics (e.g. spirits) before the first derived-data pass — causing the health section to briefly show up on first render after import, then correctly hide on reopen.
- Both checks now explicitly detect whether an actor tracks hit points at all (STR/CON/SIZ present, or a Hit Location item), instead of relying on the possibly-stale `hitPoints.max`.
- Actors that don't track hit points now derive health from magic points instead — they go "unconscious" at 0 MP, same rule already used for normal actors, rather than incorrectly showing hit-point-based wounds/death or always "healthy".

Fixes #488

## Test plan
- [x] `tsc --noEmit` passes
- [x] i18n audit passes
- [x] `vitest run` — 393 tests passing