### PR TITLE
feat: add Skill/Rune Research improvement path

### DIFF
--- a/src/applications/improve-dialogs/improve-ability-dialog-body.hbs
+++ b/src/applications/improve-dialogs/improve-ability-dialog-body.hbs
@@ -11,6 +11,16 @@
     {{/improveDialogSourceOption}}
 
     {{#> improveDialogSourceOption
+      show=improvementData.showResearch
+      source="research"
+      can=improvementData.canResearch
+      selectedSource=selectedSource
+      labelKey="RQG.Dialog.improveAbilityDialog.throughResearch"
+    }}
+      {{localize "RQG.Dialog.improveAbilityDialog.sourceUnavailableResearch" typeLocName=improvementData.typeLocName}}
+    {{/improveDialogSourceOption}}
+
+    {{#> improveDialogSourceOption
       show=improvementData.showTraining
       source="training"
       can=improvementData.canTraining
@@ -70,6 +80,52 @@
             {{#if showSourceChooser}}{{#if (eq selectedSource "experience")}}checked{{/if}}{{else}}checked{{/if}}
           >
           <span class="improve-dialog-option-label">{{localize "RQG.Dialog.improveAbilityDialog.gainLower" gain=improvementData.experienceGainRandom}}</span>
+        </label>
+      </section>
+    {{/if}}
+
+    {{#if improvementData.showResearch}}
+      <section
+        class="improve-dialog-panel improve-dialog-panel--research"
+        data-source-panel="research"
+        {{#if showSourceChooser}}{{#unless (eq selectedSource "research")}}hidden{{/unless}}{{/if}}
+      >
+        <div class="improve-dialog-option-context">
+          {{#if (eq improvementData.abilityType "skill")}}
+            <span class="improve-dialog-formula-value">{{improvementData.chanceToGain}}%</span>
+            {{localize "RQG.Dialog.improveAbilityDialog.improvementChanceLabel"}}
+            ({{localize "RQG.Dialog.improveAbilityDialog.rollThresholdLabel" requiredRoll=improvementData.requiredRoll}})
+            <span class="improve-dialog-formula">(
+              <b>{{localize "RQG.Dialog.improveAbilityDialog.rollLabel"}}</b>{{#unless (eq improvementData.categoryMod 0)}}<b>{{improvementData.categoryModDisplay}}</b><sub><i>{{localize "RQG.Dialog.improveAbilityDialog.categoryModifierLabel"}}</i></sub>{{/unless}}
+              {{localize "RQG.Dialog.improveAbilityDialog.toBeatLabel"}}
+              <b>{{improvementData.skillChance}}</b><sub><i>{{localize "RQG.Dialog.improveAbilityDialog.skillValueLabel"}}</i></sub>
+              {{localize "RQG.Dialog.improveAbilityDialog.modifiedHundredAlwaysLabel"}}
+            )</span>
+          {{else}}
+            <span class="improve-dialog-formula-value">{{improvementData.chanceToGain}}%</span>
+            {{localize "RQG.Dialog.improveAbilityDialog.improvementChanceLabel"}}
+            ({{localize "RQG.Dialog.improveAbilityDialog.rollThresholdLabel" requiredRoll=improvementData.requiredRoll}})
+          {{/if}}
+        </div>
+        <label>
+          <input
+            type="radio"
+            name="experiencegaintype"
+            class="improvement-type-checkbox"
+            value="research-gain-fixed"
+          >
+          <span class="improve-dialog-option-label">{{localize "RQG.Dialog.improveAbilityDialog.gainLower" gain=improvementData.researchGainFixed}}</span>
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="experiencegaintype"
+            class="improvement-type-checkbox"
+            value="research-gain-random"
+            data-default-method
+            {{#if showSourceChooser}}{{#if (eq selectedSource "research")}}checked{{/if}}{{else}}{{#unless improvementData.showExperience}}checked{{/unless}}{{/if}}
+          >
+          <span class="improve-dialog-option-label">{{localize "RQG.Dialog.improveAbilityDialog.gainLower" gain=improvementData.researchGainRandom}}</span>
         </label>
       </section>
     {{/if}}

--- a/src/applications/improve-dialogs/improve-ability-dialog.test.ts
+++ b/src/applications/improve-dialogs/improve-ability-dialog.test.ts
@@ -4,16 +4,17 @@ import {
   buildSkillExperienceRollFormula,
   configureAdapterForAbilityItem,
   formatCategoryModDisplay,
+  getGateThreshold,
   isSupportedAbilityGainType,
   updateAdapterForSkill,
 } from "./improve-ability-dialog";
 
-function createSkillItem(baseChance: number, gainedChance: number = 0) {
+function createSkillItem(baseChance: number, gainedChance: number = 0, categoryMod: number = 0) {
   return {
     type: "skill",
     system: { category: "agility" },
     _source: { system: { baseChance, gainedChance } },
-    parent: { type: "character", system: { baseSkillCategoryModifiers: { agility: 0 } } },
+    parent: { type: "character", system: { baseSkillCategoryModifiers: { agility: categoryMod } } },
   } as any;
 }
 
@@ -74,6 +75,24 @@ describe("updateAdapterForSkill", () => {
     updateAdapterForSkill(improvementData, createSkillItem(80));
     expect(improvementData.canTraining).toBe(false);
     expect(improvementData.skillOver75).toBe(true);
+  });
+});
+
+describe("getGateThreshold", () => {
+  it("uses the unmodified skill value for skills, not the category-modified chance", () => {
+    const improvementData = createImprovementData();
+    // baseChance 40 + categoryMod 15 -> chance 55, but the gate threshold must stay at
+    // the unmodified 40, since the roll formula already adds the category mod itself.
+    updateAdapterForSkill(improvementData, createSkillItem(40, 0, 15));
+    expect(improvementData.chance).toBe(55);
+    expect(getGateThreshold(improvementData)).toBe(40);
+  });
+
+  it("uses the plain chance for Runes/Passions, which get no category modifier", () => {
+    const improvementData = createImprovementData();
+    improvementData.abilityType = "rune";
+    improvementData.chance = 30;
+    expect(getGateThreshold(improvementData)).toBe(30);
   });
 });
 

--- a/src/applications/improve-dialogs/improve-ability-dialog.test.ts
+++ b/src/applications/improve-dialogs/improve-ability-dialog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildSkillExperienceRollFormula,
+  configureAdapterForAbilityItem,
   formatCategoryModDisplay,
   isSupportedAbilityGainType,
   updateAdapterForSkill,
@@ -17,7 +18,12 @@ function createSkillItem(baseChance: number, gainedChance: number = 0) {
 }
 
 function createImprovementData() {
-  return { canTraining: true } as any;
+  return {
+    showTraining: true,
+    canTraining: true,
+    showResearch: true,
+    canResearch: true,
+  } as any;
 }
 
 describe("buildSkillExperienceRollFormula", () => {
@@ -75,13 +81,41 @@ describe("isSupportedAbilityGainType", () => {
   it("returns true for supported gain types", () => {
     expect(isSupportedAbilityGainType("experience-gain-fixed")).toBe(true);
     expect(isSupportedAbilityGainType("experience-gain-random")).toBe(true);
+    expect(isSupportedAbilityGainType("research-gain-fixed")).toBe(true);
+    expect(isSupportedAbilityGainType("research-gain-random")).toBe(true);
     expect(isSupportedAbilityGainType("training-gain-fixed")).toBe(true);
     expect(isSupportedAbilityGainType("training-gain-random")).toBe(true);
   });
 
   it("returns false for empty or unknown gain types", () => {
     expect(isSupportedAbilityGainType("")).toBe(false);
-    expect(isSupportedAbilityGainType("research-gain-random")).toBe(false);
     expect(isSupportedAbilityGainType("not-a-gain-type")).toBe(false);
+  });
+});
+
+describe("configureAdapterForAbilityItem", () => {
+  it("allows research for skills", () => {
+    const improvementData = createImprovementData();
+    configureAdapterForAbilityItem(improvementData, createSkillItem(50));
+    expect(improvementData.showResearch).toBe(true);
+    expect(improvementData.canResearch).toBe(true);
+  });
+
+  it("allows research for runes", () => {
+    const improvementData = createImprovementData();
+    const runeItem = { type: "rune", system: { rune: "Fire" } } as any;
+    configureAdapterForAbilityItem(improvementData, runeItem);
+    expect(improvementData.showResearch).toBe(true);
+    expect(improvementData.canResearch).toBe(true);
+  });
+
+  it("disallows research and training for passions", () => {
+    const improvementData = createImprovementData();
+    const passionItem = { type: "passion" } as any;
+    configureAdapterForAbilityItem(improvementData, passionItem);
+    expect(improvementData.showResearch).toBe(false);
+    expect(improvementData.canResearch).toBe(false);
+    expect(improvementData.showTraining).toBe(false);
+    expect(improvementData.canTraining).toBe(false);
   });
 });

--- a/src/applications/improve-dialogs/improve-ability-dialog.ts
+++ b/src/applications/improve-dialogs/improve-ability-dialog.ts
@@ -30,10 +30,12 @@ import {
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 const logger = new RqgLogger("improve-ability-dialog");
-const IMPROVEMENT_SOURCES = ["experience", "training"] as const;
+const IMPROVEMENT_SOURCES = ["experience", "research", "training"] as const;
 const SUPPORTED_ABILITY_GAIN_TYPES = [
   "experience-gain-fixed",
   "experience-gain-random",
+  "research-gain-fixed",
+  "research-gain-random",
   "training-gain-fixed",
   "training-gain-random",
 ] as const;
@@ -46,8 +48,10 @@ type AbilityImprovementData = {
   name: string; // name of item
   currentValueDisplay: string;
   showExperience: boolean;
+  showResearch: boolean;
   showTraining: boolean;
   canExperience: boolean;
+  canResearch: boolean;
   canTraining: boolean;
   img: string | null;
   skillChance?: number;
@@ -59,11 +63,13 @@ type AbilityImprovementData = {
   skillOver75?: boolean;
   experienceGainFixed: number;
   experienceGainRandom: string;
+  researchGainFixed: number;
+  researchGainRandom: string;
   trainingGainFixed: number;
   trainingGainRandom: string;
 };
 
-type ImprovementSource = "experience" | "training";
+type ImprovementSource = "experience" | "research" | "training";
 
 type ImproveAbilityDialogContext = {
   headerData: ImproveDialogHeaderData;
@@ -345,6 +351,10 @@ class ImproveAbilityDialog extends HandlebarsApplicationMixin(
       }
     }
 
+    if (gainType === "research-gain-fixed" || gainType === "research-gain-random") {
+      gain = await this.resolveResearchGain(gainType, speakerName);
+    }
+
     if (gainType === "training-gain-fixed") {
       const flavor = localize("RQG.Dialog.improveAbilityDialog.trainingResultChat.flavor", {
         name: improvementData.name,
@@ -386,6 +396,104 @@ class ImproveAbilityDialog extends HandlebarsApplicationMixin(
     await abilityData.applyChanceGain(gain);
   }
 
+  /**
+   * Research (Core p.417) requires the same gate roll as Experience, but unlike Experience it
+   * doesn't require a prior in-play experience check - it's self-directed study instead.
+   */
+  private async resolveResearchGain(
+    gainType: "research-gain-fixed" | "research-gain-random",
+    speakerName: string,
+  ): Promise<number> {
+    const improvementData = this.improvementData;
+    const categoryMod = improvementData.categoryMod ?? 0;
+    const rollFlavor = localize("RQG.Dialog.improveAbilityDialog.researchRoll.flavor", {
+      actorName: speakerName,
+      name: improvementData.name,
+      typeLocName: improvementData.typeLocName,
+    });
+
+    const rollContent =
+      improvementData.abilityType === "skill"
+        ? localize("RQG.Dialog.improveAbilityDialog.researchRoll.contentSkill", {
+            mod: improvementData.categoryModDisplay ?? formatCategoryModDisplay(categoryMod),
+            skillChance: improvementData.chance.toString(),
+            name: improvementData.name,
+            typeLocName: improvementData.typeLocName,
+          })
+        : localize("RQG.Dialog.improveAbilityDialog.researchRoll.contentOther", {
+            chance: improvementData.chance.toString(),
+            name: improvementData.name,
+            typeLocName: improvementData.typeLocName,
+          });
+
+    const gateRoll = new Roll(
+      improvementData.abilityType === "skill"
+        ? buildSkillExperienceRollFormula(categoryMod)
+        : "1d100",
+    );
+    await gateRoll.toMessage({
+      speaker: this.speaker,
+      flavor: `<div class="roll-action">${rollFlavor}</div><p>${rollContent}</p>`,
+    });
+
+    const isNaturalHundredOnSkillRoll =
+      improvementData.abilityType === "skill" && gateRoll.dice[0]?.total === 100;
+
+    if (
+      gateRoll.total === undefined ||
+      !(
+        gateRoll.total > Number(improvementData.chance) ||
+        gateRoll.total >= 100 ||
+        isNaturalHundredOnSkillRoll
+      )
+    ) {
+      await ChatMessage.create({
+        speaker: this.speaker,
+        flavor: localize("RQG.Dialog.improveAbilityDialog.researchGainFailed.flavor", {
+          name: improvementData.name,
+          typeLocName: improvementData.typeLocName,
+        }),
+        content: localize("RQG.Dialog.improveAbilityDialog.researchGainFailed.content", {
+          actorName: speakerName,
+          name: improvementData.name,
+          typeLocName: improvementData.typeLocName,
+        }),
+      });
+      return 0;
+    }
+
+    const resultFlavor = localize("RQG.Dialog.improveAbilityDialog.researchResultChat.flavor", {
+      name: improvementData.name,
+      typeLocName: improvementData.typeLocName,
+    });
+
+    if (gainType === "research-gain-fixed") {
+      const fixedGain = improvementData.researchGainFixed;
+      const content = localize(
+        "RQG.Dialog.improveAbilityDialog.researchResultChat.contentChoseFixed",
+        { gain: `${fixedGain}%` },
+      );
+      const gainRoll = new Roll(String(fixedGain));
+      await gainRoll.toMessage({
+        speaker: this.speaker,
+        flavor: `<div class="roll-action">${resultFlavor}</div><p>${content}</p>`,
+      });
+      return fixedGain;
+    }
+
+    const gainRoll = new Roll(improvementData.researchGainRandom);
+    await gainRoll.evaluate();
+    const content = localize(
+      "RQG.Dialog.improveAbilityDialog.researchResultChat.contentChoseRandom",
+      { gain: `${improvementData.researchGainRandom}%` },
+    );
+    await gainRoll.toMessage({
+      speaker: this.speaker,
+      flavor: `<div class="roll-action">${resultFlavor}</div><p>${content}</p>`,
+    });
+    return Number(gainRoll.total) || 0;
+  }
+
   private buildAdapter(): AbilityImprovementData {
     const sourceAbility = this.item._source.system as Partial<IAbility>;
     const sourceChance = Number(sourceAbility.chance ?? 0);
@@ -397,8 +505,10 @@ class ImproveAbilityDialog extends HandlebarsApplicationMixin(
       abilityType,
       currentValueDisplay: "",
       showExperience: Boolean(sourceAbility.hasExperience),
+      showResearch: true,
       showTraining: true,
       canExperience: Boolean(sourceAbility.hasExperience),
+      canResearch: true,
       canTraining: true,
       img: this.item.img,
       chance: sourceChance,
@@ -406,6 +516,8 @@ class ImproveAbilityDialog extends HandlebarsApplicationMixin(
       requiredRoll: Math.min(Math.max(Math.floor(sourceChance) + 1, 1), 100),
       experienceGainFixed: 3,
       experienceGainRandom: "1d6",
+      researchGainFixed: 1,
+      researchGainRandom: "1d6-2",
       trainingGainFixed: 2,
       trainingGainRandom: "1d6-1",
     };
@@ -435,6 +547,9 @@ function getDefaultImprovementSource(
 ): ImprovementSource | null {
   if (improvementData.canExperience) {
     return "experience";
+  }
+  if (improvementData.canResearch) {
+    return "research";
   }
   if (improvementData.canTraining) {
     return "training";
@@ -515,7 +630,7 @@ export function updateAdapterForSkill(
   }
 }
 
-function configureAdapterForAbilityItem(
+export function configureAdapterForAbilityItem(
   improvementData: AbilityImprovementData,
   item: RqgItem,
 ): void {
@@ -526,9 +641,11 @@ function configureAdapterForAbilityItem(
 
   if (isDocumentSubType<PassionItem>(item, ItemTypeEnum.Passion)) {
     improvementData.abilityType = "passion";
-    // Cannot train passions
+    // Cannot train or research passions (Core p.417: research is only for skills/Runes)
     improvementData.showTraining = false;
     improvementData.canTraining = false;
+    improvementData.showResearch = false;
+    improvementData.canResearch = false;
     return;
   }
 

--- a/src/applications/improve-dialogs/improve-ability-dialog.ts
+++ b/src/applications/improve-dialogs/improve-ability-dialog.ts
@@ -248,7 +248,7 @@ class ImproveAbilityDialog extends HandlebarsApplicationMixin(
           improvementData.abilityType === "skill"
             ? localize("RQG.Dialog.improveAbilityDialog.experienceRoll.contentSkill", {
                 mod: improvementData.categoryModDisplay ?? formatCategoryModDisplay(categoryMod),
-                skillChance: improvementData.chance.toString(),
+                skillChance: getGateThreshold(improvementData).toString(),
                 name: improvementData.name,
                 typeLocName: improvementData.typeLocName,
               })
@@ -273,7 +273,7 @@ class ImproveAbilityDialog extends HandlebarsApplicationMixin(
 
         if (
           expRoll.total !== undefined &&
-          (expRoll.total > Number(improvementData.chance) ||
+          (expRoll.total > getGateThreshold(improvementData) ||
             expRoll.total >= 100 ||
             isNaturalHundredOnSkillRoll)
         ) {
@@ -416,7 +416,7 @@ class ImproveAbilityDialog extends HandlebarsApplicationMixin(
       improvementData.abilityType === "skill"
         ? localize("RQG.Dialog.improveAbilityDialog.researchRoll.contentSkill", {
             mod: improvementData.categoryModDisplay ?? formatCategoryModDisplay(categoryMod),
-            skillChance: improvementData.chance.toString(),
+            skillChance: getGateThreshold(improvementData).toString(),
             name: improvementData.name,
             typeLocName: improvementData.typeLocName,
           })
@@ -442,7 +442,7 @@ class ImproveAbilityDialog extends HandlebarsApplicationMixin(
     if (
       gateRoll.total === undefined ||
       !(
-        gateRoll.total > Number(improvementData.chance) ||
+        gateRoll.total > getGateThreshold(improvementData) ||
         gateRoll.total >= 100 ||
         isNaturalHundredOnSkillRoll
       )
@@ -540,6 +540,18 @@ export function buildSkillExperienceRollFormula(categoryMod: number): string {
 
 export function formatCategoryModDisplay(categoryMod: number): string {
   return toSignedString(categoryMod);
+}
+
+/**
+ * The gate-roll threshold for Experience/Research: the *unmodified* skill value for skills
+ * (the category modifier is already baked into the roll itself via
+ * `buildSkillExperienceRollFormula`, so using the modified `chance` here would cancel it out),
+ * or the plain chance for Runes/Passions (Core p.415-416: they get no category modifier).
+ */
+export function getGateThreshold(improvementData: AbilityImprovementData): number {
+  return improvementData.abilityType === "skill"
+    ? Number(improvementData.skillChance ?? 0)
+    : Number(improvementData.chance);
 }
 
 function getDefaultImprovementSource(

--- a/src/applications/improve-dialogs/improve-dialogs.css
+++ b/src/applications/improve-dialogs/improve-dialogs.css
@@ -28,9 +28,9 @@
     }
 
     & .improve-dialog-source-options {
-      display: grid;
+      display: flex;
+      flex-wrap: nowrap;
       gap: 0.5rem;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
 
     & .improve-dialog-source-option {
@@ -39,9 +39,11 @@
       cursor: pointer;
       display: flex;
       align-items: center;
+      flex: 1 1 0;
       flex-wrap: wrap;
       gap: 0.55rem;
       min-height: 2.75rem;
+      min-width: 0;
       opacity: 0.7;
       padding: 0.5rem 0.75rem;
       transition:

--- a/src/applications/improve-dialogs/improve-dialogs.css
+++ b/src/applications/improve-dialogs/improve-dialogs.css
@@ -29,7 +29,7 @@
 
     & .improve-dialog-source-options {
       display: flex;
-      flex-wrap: nowrap;
+      flex-wrap: wrap;
       gap: 0.5rem;
     }
 
@@ -39,11 +39,11 @@
       cursor: pointer;
       display: flex;
       align-items: center;
-      flex: 1 1 0;
+      flex: 1 1 150px;
       flex-wrap: wrap;
       gap: 0.55rem;
       min-height: 2.75rem;
-      min-width: 0;
+      min-width: 150px;
       opacity: 0.7;
       padding: 0.5rem 0.75rem;
       transition:

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -714,10 +714,13 @@
         },
         "researchRoll": {
           "flavor": "{actorName} makes a research improvement check for {typeLocName} \"{name}\"",
+          "contentSkill": "Roll 1d100 and add the skill category modifier ({mod}) and gain if the modified roll is HIGHER than the {typeLocName} \"{name}\" value {skillChance}% or 100.",
+          "contentOther": "Roll 1d100 and gain if the roll is HIGHER than the {typeLocName} \"{name}\" value of {chance}%",
           "contentChar": "Roll 1d100 and gain if the roll is LOWER THAN OR EQUAL TO {chanceToGain}%.  This is based on the Species Maximum for the Characteristic of {speciesMax} minus the Characteristic \"{name}\" value of {chance} times five."
         },
         "researchResultChat": {
           "flavor": "Research improvement for {typeLocName} \"{name}\"",
+          "contentChoseFixed": "Chose fixed gain of {gain}.",
           "contentChoseRandom": "Chose gain of {gain}."
         },
         "researchGainFailed": {


### PR DESCRIPTION
## Summary

Closes #952.

Skills and Runes previously only supported Experience and Training on the Improve Ability dialog. This adds the missing **Research** path (Core rulebook, RuneQuest: Roleplaying in Glorantha 2nd printing, p.417), mirroring the Research implementation that already exists for Characteristics.

- Gate roll: same experience-style check used by Experience (1d100 + category modifier for skills, plain 1d100 vs chance for Runes; success if modified roll beats the current rating or hits 100+).
- Gain: flat +1%, or 1D6−2, chosen before rolling (note the roll can reduce the ability on a bad result).
- Not offered for Passions, matching the existing Training restriction for Passions.

## Changes

- `improve-ability-dialog.ts`: new `research` improvement source, `resolveResearchGain` gate+gain roll flow, adapter fields (`showResearch`/`canResearch`/`researchGainFixed`/`researchGainRandom`).
- `improve-ability-dialog-body.hbs`: Research source-chooser option and panel between Experience and Training.
- `uiContent.json`: added `researchRoll.contentSkill`/`contentOther` and `researchResultChat.contentChoseFixed` (the rest of the research locale keys already existed, shared with the Characteristic dialog).
- Tests for `configureAdapterForAbilityItem` covering skill/rune (research enabled) and passion (research + training disabled).

## Test plan

- [x] `vitest run` — 400 tests pass
- [x] `tsc --noEmit`
- [x] `pnpm i18n:audit-unused --lang en --fail-on-unused`
- [ ] Manual check in Foundry: improve a skill via Research (success and failure), improve a Rune via Research, confirm Research option is absent for Passions