### PR TITLE
fix: derive Improve dialog's category modifier from source characteristics

### DIFF
--- a/src/applications/improve-dialogs/improve-ability-dialog.test.ts
+++ b/src/applications/improve-dialogs/improve-ability-dialog.test.ts
@@ -9,12 +9,36 @@ import {
   updateAdapterForSkill,
 } from "./improve-ability-dialog";
 
+// Agility category mod == DEX's linearMod alone when STR/SIZ/POW sit in the flattenedMod(0) band
+// (5-16): flattenedMod(str) - flattenedMod(siz) + linearMod(dex) + flattenedMod(pow).
+// linearMod(dex) = (ceil(dex/4) - 3) * 5, so dex = (mod/5 + 3) * 4 inverts it exactly on multiples of 5.
+function dexterityForAgilityMod(agilityMod: number): number {
+  return (agilityMod / 5 + 3) * 4;
+}
+
 function createSkillItem(baseChance: number, gainedChance: number = 0, categoryMod: number = 0) {
+  const neutral = { value: 13 }; // str/siz/pow in the flattenedMod(0) band
   return {
     type: "skill",
     system: { category: "agility" },
     _source: { system: { baseChance, gainedChance } },
-    parent: { type: "character", system: { baseSkillCategoryModifiers: { agility: categoryMod } } },
+    parent: {
+      type: "character",
+      _source: {
+        system: {
+          characteristics: {
+            strength: neutral,
+            constitution: neutral,
+            size: neutral,
+            dexterity: { value: dexterityForAgilityMod(categoryMod) },
+            intelligence: neutral,
+            power: neutral,
+            charisma: neutral,
+          },
+          attributes: { isCreature: false },
+        },
+      },
+    },
   } as any;
 }
 
@@ -75,6 +99,21 @@ describe("updateAdapterForSkill", () => {
     updateAdapterForSkill(improvementData, createSkillItem(80));
     expect(improvementData.canTraining).toBe(false);
     expect(improvementData.skillOver75).toBe(true);
+  });
+
+  it("derives the category modifier from source characteristics, ignoring active-effect deltas", () => {
+    // A live characteristic value shifted by an active effect (e.g. a DEX-draining status effect)
+    // must not change the category mod used for this gate roll: only actor._source is honored.
+    const item = createSkillItem(40, 0, 15);
+    item.parent.system = {
+      // Live/prepared data an active effect could have overwritten, e.g. dropping DEX far enough
+      // to fall out of the category mod band that the unmodified DEX 21 sits in.
+      baseSkillCategoryModifiers: { agility: -5 },
+      characteristics: { dexterity: { value: 5 } },
+    };
+    const improvementData = createImprovementData();
+    updateAdapterForSkill(improvementData, item);
+    expect(improvementData.categoryMod).toBe(15);
   });
 });
 

--- a/src/applications/improve-dialogs/improve-ability-dialog.ts
+++ b/src/applications/improve-dialogs/improve-ability-dialog.ts
@@ -13,6 +13,7 @@ import {
 } from "../../system/util";
 import { templatePaths } from "../../system/load-handlebars-templates";
 import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data.ts";
+import { getCharacteristicDerivedValues } from "../../data-model/actor-data/derived-character-values";
 import type { PassionItem } from "@item-model/passion-data-model.ts";
 import type { RuneItem } from "@item-model/rune-data-model.ts";
 import type { SkillItem } from "@item-model/skill-data-model.ts";
@@ -618,9 +619,21 @@ export function updateAdapterForSkill(
   assertDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character);
 
   // Use unmodified values for improvement checks: base category modifier and source skill value.
-  improvementData.categoryMod = Number(
-    actor.system.baseSkillCategoryModifiers[item.system.category] ?? 0,
-  );
+  // Derived from the actor's *source* characteristics rather than actor.system.baseSkillCategoryModifiers,
+  // since active effects on characteristics (e.g. status-effect conditions) are already baked into the
+  // live/prepared characteristic values and must not influence this gate roll.
+  const sourceCharacteristics = actor._source.system.characteristics;
+  const sourceCategoryModifiers = getCharacteristicDerivedValues({
+    str: sourceCharacteristics.strength.value,
+    con: sourceCharacteristics.constitution.value,
+    siz: sourceCharacteristics.size.value,
+    dex: sourceCharacteristics.dexterity.value,
+    int: sourceCharacteristics.intelligence.value,
+    pow: sourceCharacteristics.power.value,
+    cha: sourceCharacteristics.charisma.value,
+    isCreature: actor._source.system.attributes.isCreature,
+  }).skillCategoryModifiers;
+  improvementData.categoryMod = Number(sourceCategoryModifiers[item.system.category] ?? 0);
   improvementData.categoryModDisplay = formatCategoryModDisplay(improvementData.categoryMod);
   const unmodifiedSkillChance =
     Number(item._source.system.baseChance) + Number(item._source.system.gainedChance);


### PR DESCRIPTION
## Summary
- The Improve Ability dialog's Experience/Research/Training gate roll is supposed to use unmodified values so temporary effects don't influence a seasonal downtime improvement roll. The skill-value side already honored this (reads from `item._source`), but the category-modifier side did not: it read `actor.system.baseSkillCategoryModifiers`, which is derived from the actor's *live* characteristics and therefore already bakes in any active effect on STR/DEX/CON/etc (e.g. status-effect conditions).
- `updateAdapterForSkill` now recomputes the category modifier locally via `getCharacteristicDerivedValues`, sourced from `actor._source.system.characteristics` (and `_source.system.attributes.isCreature`), so a temporary characteristic-affecting condition can no longer shift the category-modifier band used for this gate roll.

Fixes #954

## Test plan
- [x] Added a regression test asserting the category mod is computed from source characteristics and unaffected by a live/prepared override (simulating an active-effect delta)
- [x] `pnpm vitest run` — 403 tests pass
- [x] `tsc -noEmit` — no errors
- [x] `pnpm -s i18n:audit-unused` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)