### PR TITLE
fix: sweep module compendiums during world migration

### DIFF
--- a/src/system/migrations/apply-migrations.ts
+++ b/src/system/migrations/apply-migrations.ts
@@ -332,9 +332,6 @@ async function migrateWorldCompendiumPacks(
     if (pack.metadata.packageName === systemId) {
       return false;
     }
-    if (pack.metadata.packageType !== "world") {
-      return false;
-    }
     return ["Actor", "Item", "Scene", "ActiveEffect"].includes(pack.metadata.type);
   });
   migrationResult.stats.compendiumsSkippedByDesign = allPacks.length - packs.length;


### PR DESCRIPTION
## Summary
- World migration only swept compendium packs with `packageType: "world"`, silently skipping Actor/Item packs shipped in installed modules (e.g. NPC/equipment content). Anything dragged from such a pack kept legacy Active Effect keys forever, since nothing else ever revisits an already-migrated world.
- Removed the `packageType !== "world"` restriction so any installed module's Actor/Item/Scene/ActiveEffect packs get swept too, not just world-owned ones. The system's own bundled packs (`packageName === systemId`) remain excluded, since those ship pre-migrated with each release.
- Measured impact in a test world (`f9-rqg-fresh` + `wiki-en-rqg` + `xxx-xxx`, ~2400 combined Actor/Item documents across world and module packs): full migration pass completed in ~11.7s, confirming the wider sweep is not a practical performance concern for a one-time, version-gated, progress-barred operation.

Related to #942 (root cause there was traced to an actor whose embedded item still carried a legacy `system.attributes.magicPoints.max` Active Effect key from before the world's last migration pass).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `pnpm -s i18n:audit-unused` clean
- [x] Full test suite (403 tests) passes
- [x] Manually re-ran `game.system.api.migration.applyWorldMigrations()` against a real world with module compendiums installed and confirmed it completes in ~11.7s