### PR TITLE
fix: improve actor portrait display on v2 character sheet

### DIFF
--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -526,17 +526,28 @@
           grid-row: 1 / 3;
           grid-column: profile-start / profile-end;
           margin-right: 15px;
+          margin-top: 8px; /* clearance from the window top */
 
-          & img {
-            height: 125px;
-            transform: rotate(5deg);
-            box-shadow: var(--rqg-box-shadow-profile-img);
-            border-radius: 10px;
+          & .profile-frame {
+            position: relative;
+            top: -2px; /* pull the frame up so it starts at the top of the window */
+            width: fit-content; /* shrink-wraps to whatever size the portrait renders at */
             cursor: pointer;
+            margin: -4px -24px -36px -14px;
 
-            &.unset {
-              height: 20px;
-              flex: 0 0 20px;
+            & img {
+              display: block;
+              max-width: 250px;
+              height: 120px;
+              border-radius: 10px;
+              object-fit: contain; /* never crops -- tall/wide outliers letterbox instead of losing content */
+              filter: drop-shadow(2px 2px 3px rgb(0 0 0 / 70%));
+            }
+
+            & .unset {
+              height: 30px;
+              width: 30px;
+              filter: none;
             }
           }
         }

--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -533,7 +533,7 @@
             top: -2px; /* pull the frame up so it starts at the top of the window */
             width: fit-content; /* shrink-wraps to whatever size the portrait renders at */
             cursor: pointer;
-            margin: -4px -24px -36px -14px;
+            margin: -4px -24px -36px 0;
 
             & img {
               display: block;
@@ -626,6 +626,8 @@
           grid-row: 2;
           grid-column: name-rune-start / name-rune-end;
           margin-top: -2px;
+          min-height: 80px; /* prevents responsive font shrink from also shrinking this row,
+            which let the portrait bleed into the strike-rank row below at narrow widths */
           display: grid;
           grid-template-columns: repeat(7, auto);
           justify-content: space-between;

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -434,6 +434,23 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       this.element.classList.toggle(state, health === state);
     }
 
+    // Right-click the portrait to see it larger, via Foundry's native image popout --
+    // the same action as the sidebar's "Show Player Artwork" context menu entry.
+    const portraitImg = this.element.querySelector<HTMLImageElement>(
+      ".profile-frame img.profile-img",
+    );
+    portraitImg?.addEventListener("contextmenu", (event) => {
+      event.preventDefault();
+      if (!this.actor.img) {
+        return;
+      }
+      new foundry.applications.apps.ImagePopout({
+        src: this.actor.img,
+        uuid: this.actor.uuid,
+        window: { title: this.actor.name },
+      }).render({ force: true });
+    });
+
     // RQID header button (AppV2 _getFrameButtons version)
     await decorateRqidFrameButton(this as unknown as DocumentSheet<any, any>);
 

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-header.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-header.hbs
@@ -2,8 +2,11 @@
   <div class="header-grid">
 
     <div class="profile">
-      <img class="profile-img {{#if (eq img 'icons/svg/mystery-man.svg')}}unset{{/if}}"
-          src="{{img}}" data-action="editImage" data-edit="img" data-tooltip="{{name}}">
+      <div class="profile-frame">
+        <img class="profile-img {{#if (eq img 'icons/svg/mystery-man.svg')}}unset{{/if}}" src="{{img}}"
+            data-action="editImage" data-edit="img"
+            data-tooltip="{{name}}<br>{{localize 'RQG.UI.PortraitTooltip'}}">
+      </div>
     </div>
 
     <div class="name-runes-cults">

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -1559,7 +1559,8 @@
     },
     "UI": {
       "SortItems": "Sort items alphabetically",
-      "MultipleCults": "Character has more cults,<br> see Rune Magic Tab"
+      "MultipleCults": "Character has more cults,<br> see Rune Magic Tab",
+      "PortraitTooltip": "Right-click to view larger"
     },
     "SheetName": {
       "Actor": {


### PR DESCRIPTION
## Summary
- Portrait no longer gets clipped by the window top, and the drop-shadow now follows the image's own shape instead of tracing a rectangular bounding box (so round/transparent portraits no longer get a mismatched square shadow)
- Portrait sizing never crops or distorts non-square images (`object-fit: contain`)
- Right-clicking the portrait opens Foundry's native image popout for a larger, on-demand view (same action as the sidebar's "Show Player Artwork" context menu entry), instead of permanently enlarging the header

Fixes #969

## Test plan
- [x] `pnpm check` (lint, 403 tests, typecheck) passes
- [x] `pnpm i18n:audit:en` passes (new `RQG.UI.PortraitTooltip` key used and translated)
- [ ] Manually verify in Foundry: portrait renders correctly for square, landscape, portrait-oriented, and default/no-image actors; right-click opens the image popout; left-click still opens the file picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)