### PR TITLE
fix: preserve AE path rewrite when duration migration also touches an effect

### DIFF
--- a/src/system/migrations/apply-migrations.merge.test.ts
+++ b/src/system/migrations/apply-migrations.merge.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { mergeMigrationUpdateData, mergeEmbeddedEffectsUpdates } from "./apply-migrations";
+
+/**
+ * Regression coverage for issue #942: an embedded ActiveEffect that needed both
+ * a legacy path rewrite (migrateItemActiveEffectPaths) and a duration-unit
+ * normalization (migrateItemActiveEffectDurationUnits) lost the path rewrite
+ * because foundry.utils.mergeObject replaces arrays wholesale instead of
+ * merging their entries by _id. mergeMigrationUpdateData/mergeEmbeddedEffectsUpdates
+ * fix that by merging embedded `effects` update arrays entry-by-entry.
+ */
+describe("mergeEmbeddedEffectsUpdates", () => {
+  it("combines two partial updates for the same effect instead of one replacing the other", () => {
+    const fromPathRewrite = [
+      { _id: "effect-1", system: { changes: [{ key: "system.effect.add.magicPoints.max" }] } },
+    ];
+    const fromDurationFix = [{ _id: "effect-1", duration: { seconds: null }, start: { time: 0 } }];
+
+    const merged = mergeEmbeddedEffectsUpdates(fromPathRewrite, fromDurationFix);
+
+    expect(merged).toEqual([
+      {
+        _id: "effect-1",
+        system: { changes: [{ key: "system.effect.add.magicPoints.max" }] },
+        duration: { seconds: null },
+        start: { time: 0 },
+      },
+    ]);
+  });
+
+  it("keeps unrelated effects from both sides untouched", () => {
+    const existing = [{ _id: "effect-1", system: { changes: [] } }];
+    const incoming = [{ _id: "effect-2", duration: { seconds: 10 } }];
+
+    const merged = mergeEmbeddedEffectsUpdates(existing, incoming);
+
+    expect(merged).toEqual([
+      { _id: "effect-1", system: { changes: [] } },
+      { _id: "effect-2", duration: { seconds: 10 } },
+    ]);
+  });
+});
+
+describe("mergeMigrationUpdateData", () => {
+  it("merges effects arrays from successive migration functions by _id instead of overwriting", () => {
+    // Simulates getItemMigrationUpdates() folding migrateItemActiveEffectPaths'
+    // result, then migrateItemActiveEffectDurationUnits' result, into one updateData.
+    let updateData: Record<string, unknown> = {};
+
+    const pathRewriteUpdate = {
+      effects: [
+        { _id: "effect-1", system: { changes: [{ key: "system.effect.add.magicPoints.max" }] } },
+      ],
+    };
+    updateData = mergeMigrationUpdateData(updateData, pathRewriteUpdate);
+
+    const durationFixUpdate = {
+      effects: [{ _id: "effect-1", duration: { seconds: null }, start: { time: 0 } }],
+    };
+    updateData = mergeMigrationUpdateData(updateData, durationFixUpdate);
+
+    const effects = updateData["effects"] as any[];
+    expect(effects).toHaveLength(1);
+    // The path rewrite must survive the later duration-only update.
+    expect(effects[0].system.changes[0].key).toBe("system.effect.add.magicPoints.max");
+    expect(effects[0].duration).toEqual({ seconds: null });
+    expect(effects[0].start).toEqual({ time: 0 });
+  });
+
+  it("still merges non-effects keys the normal mergeObject way", () => {
+    let updateData: Record<string, unknown> = {};
+    updateData = mergeMigrationUpdateData(updateData, { name: "New Name" });
+    updateData = mergeMigrationUpdateData(updateData, { system: { pow: 10 } });
+
+    expect(updateData).toEqual({ name: "New Name", system: { pow: 10 } });
+  });
+});

--- a/src/system/migrations/apply-migrations.ts
+++ b/src/system/migrations/apply-migrations.ts
@@ -747,7 +747,7 @@ async function getItemMigrationUpdates(
       migrationNames.add(migrationName);
     }
 
-    updateData = mergeMigrationUpdateData(updateData, fnUpdate) as Item.UpdateData; // TODO can mergeObject be made to return the correct type?
+    updateData = mergeMigrationUpdateData(updateData, fnUpdate) as Item.UpdateData;
   }
 
   return {

--- a/src/system/migrations/apply-migrations.ts
+++ b/src/system/migrations/apply-migrations.ts
@@ -572,6 +572,88 @@ function getMigrationDocumentKind(
 /* -------------------------------------------- */
 /*  Document Type Migration Helpers             */
 /* -------------------------------------------- */
+
+/**
+ * Merge a migration function's proposed update into the accumulated update data.
+ *
+ * foundry.utils.mergeObject treats arrays as atomic values (they are only
+ * recursively merged when both sides are plain Objects), so a plain mergeObject
+ * call here would let a later migration's `effects` array silently overwrite an
+ * earlier migration's `effects` array wholesale instead of combining them by
+ * `_id`. Since multiple AE migrations (path rewrites, duration-unit normalization)
+ * can each target the same embedded effect, the `effects` key is merged
+ * separately, entry-by-entry, while everything else goes through the normal
+ * mergeObject path.
+ */
+export function mergeMigrationUpdateData(
+  accumulated: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+): Record<string, unknown> {
+  const { effects: incomingEffects, ...incomingRest } = incoming;
+
+  const merged = foundry.utils.mergeObject(accumulated, incomingRest, {
+    performDeletions: false,
+  }) as Record<string, unknown>;
+
+  if (incomingEffects !== undefined) {
+    merged["effects"] = mergeEmbeddedEffectsUpdates(merged["effects"], incomingEffects);
+  }
+
+  return merged;
+}
+
+/**
+ * Merge two arrays of partial embedded-ActiveEffect update objects (each
+ * shaped like `{ _id, ...partialFields }`) by `_id`, so that different
+ * migrations touching different fields of the same effect combine rather than
+ * one replacing the other.
+ */
+export function mergeEmbeddedEffectsUpdates(existing: unknown, incoming: unknown): unknown[] {
+  const existingArray = Array.isArray(existing) ? existing : [];
+  const incomingArray = Array.isArray(incoming) ? incoming : [];
+
+  const byId = new Map<string, Record<string, unknown>>();
+  const order: string[] = [];
+
+  for (const entry of existingArray) {
+    if (!isPlainObject(entry)) {
+      continue;
+    }
+    const entryId = String((entry as Record<string, unknown>)["_id"] ?? "");
+    if (!entryId) {
+      continue;
+    }
+    byId.set(entryId, { ...(entry as Record<string, unknown>) });
+    order.push(entryId);
+  }
+
+  for (const entry of incomingArray) {
+    if (!isPlainObject(entry)) {
+      continue;
+    }
+    const entryId = String((entry as Record<string, unknown>)["_id"] ?? "");
+    if (!entryId) {
+      continue;
+    }
+    const prior = byId.get(entryId);
+    if (prior) {
+      // `prior` is our own owned shallow copy (spread in above), so mutating it
+      // in place via the default `inplace: true` is safe here.
+      byId.set(
+        entryId,
+        foundry.utils.mergeObject(prior, entry as Record<string, unknown>, {
+          performDeletions: false,
+        }) as Record<string, unknown>,
+      );
+    } else {
+      byId.set(entryId, { ...(entry as Record<string, unknown>) });
+      order.push(entryId);
+    }
+  }
+
+  return order.map((id) => byId.get(id)!);
+}
+
 async function getActorMigrationUpdates(
   actorData: RqgActor,
   itemMigrations: ItemMigration[],
@@ -591,9 +673,7 @@ async function getActorMigrationUpdates(
     if (!foundry.utils.isEmpty(pruneNoopUpdateData(fnUpdate, actorSourceData))) {
       actorMigrationNames.add(migrationName);
     }
-    actorUpdateData = foundry.utils.mergeObject(actorUpdateData, fnUpdate, {
-      performDeletions: false,
-    }) as Actor.UpdateData;
+    actorUpdateData = mergeMigrationUpdateData(actorUpdateData, fnUpdate) as Actor.UpdateData;
   });
 
   if ("items" in (actorUpdateData as Record<string, unknown>)) {
@@ -667,9 +747,7 @@ async function getItemMigrationUpdates(
       migrationNames.add(migrationName);
     }
 
-    updateData = foundry.utils.mergeObject(updateData, fnUpdate, {
-      performDeletions: false,
-    }) as Item.UpdateData; // TODO can mergeObject be made to return the correct type?
+    updateData = mergeMigrationUpdateData(updateData, fnUpdate) as Item.UpdateData; // TODO can mergeObject be made to return the correct type?
   }
 
   return {


### PR DESCRIPTION
## Summary
- `getItemMigrationUpdates`/`getActorMigrationUpdates` merged each AE migration function's proposed update with plain `foundry.utils.mergeObject`, which treats arrays as atomic and replaces them wholesale instead of merging by `_id`.
- When an embedded ActiveEffect needed both `migrateItemActiveEffectPaths` (legacy key rewrite, e.g. `system.attributes.magicPoints.max` → `system.effect.add.magicPoints.max`) and `migrateItemActiveEffectDurationUnits` (legacy duration field cleanup), the later migration's `effects` array silently discarded the earlier one's `system.changes` rewrite. Confirmed directly against a real migration report where both migrations logged as having run, but only the duration diff made it into the applied update — the AE stayed on the old path and Add Magic Points/Add Hit Points effects never applied post-upgrade.
- Same latent defect existed for actor-owned effects (`migrateActorActiveEffectPaths` + `migrateActorActiveEffectDurationUnits`).
- Added `mergeMigrationUpdateData`/`mergeEmbeddedEffectsUpdates` in `apply-migrations.ts` to merge the `effects` update array by `_id` before falling back to normal `mergeObject` for everything else, and wired both merge loops through it.

Fixes #942

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (407 tests pass, including 4 new regression tests in `apply-migrations.merge.test.ts`)
- [x] Reporter (wake42) reproduced the bug against an imported actor, applied this fix, and confirmed the AE path now correctly migrates to `system.effect.add.magicPoints.max`

🤖 Generated with [Claude Code](https://claude.com/claude-code)