### PR TITLE
fix: broken reputation icon when world settings predate that key

### DIFF
--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -4,6 +4,7 @@ import { ActorTypeEnum, type CharacterActor } from "../data-model/actor-data/rqg
 import { CharacterDataModel } from "../data-model/actor-data/character-data-model";
 import { actorHealthStatuses } from "../data-model/actor-data/attributes";
 import { RQG_CONFIG, systemId } from "../system/config";
+import { getDefaultItemIconSettings } from "../system/settings/default-item-icons";
 import {
   assertDocumentSubType,
   getEventTargetElement,
@@ -22,7 +23,7 @@ import {
 
 import type { RqgItem } from "../items/rqg-item";
 import type { RqgActor } from "./rqg-actor";
-import type { AbilityItem, PhysicalItem } from "@item-model/item-types.ts";
+import type { AbilityItem, PhysicalItem, RqgItemType } from "@item-model/item-types.ts";
 import type { ArmorItem } from "@item-model/armor-data-model.ts";
 import type { OccupationItem } from "@item-model/occupation-data-model.ts";
 import { abilityItemTypes, ItemTypeEnum } from "@item-model/item-types.ts";
@@ -1037,12 +1038,11 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     _event: PointerEvent,
     _target: HTMLElement,
   ): Promise<void> {
-    const defaultItemIconSettings: any = game.settings?.get(systemId, "defaultItemIconSettings");
     const newPassionName = localize("RQG.Item.Passion.PassionEnum.Loyalty");
     const passion = {
       name: newPassionName,
       type: ItemTypeEnum.Passion,
-      img: defaultItemIconSettings[ItemTypeEnum.Passion],
+      img: getDefaultItemIconSettings()[ItemTypeEnum.Passion as RqgItemType],
       system: { passion: newPassionName },
     };
     const createdItems = await this.actor.createEmbeddedDocuments("Item", [passion]);
@@ -1056,7 +1056,6 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     target: HTMLElement,
   ): Promise<void> {
     const physicalItemType = getRequiredDomDataset(target, "gear-add") as PhysicalItemType;
-    const defaultItemIconSettings: any = game.settings?.get(systemId, "defaultItemIconSettings");
 
     const physicalItemType2ItemName = new Map<string, string>([
       ["unique", "RQG.Actor.Gear.NewGear"],
@@ -1071,7 +1070,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     const newGear = {
       name: name,
       type: ItemTypeEnum.Gear,
-      img: defaultItemIconSettings[ItemTypeEnum.Gear],
+      img: getDefaultItemIconSettings()[ItemTypeEnum.Gear as RqgItemType],
       system: { physicalItemType: physicalItemType },
     };
     const createdItems = await this.actor.createEmbeddedDocuments("Item", [newGear]);

--- a/src/actors/rqg-actor-sheet.ts
+++ b/src/actors/rqg-actor-sheet.ts
@@ -4,6 +4,7 @@ import {
   abilityItemTypes,
   ItemTypeEnum,
   type PhysicalItem,
+  type RqgItemType,
 } from "@item-model/item-types.ts";
 import {
   showHitLocationAddWoundDialog,
@@ -45,6 +46,7 @@ import { ActorTypeEnum, type CharacterActor } from "../data-model/actor-data/rqg
 import { CharacterDataModel } from "../data-model/actor-data/character-data-model";
 import { ActorWizard } from "../applications/actor-wizard-application";
 import { RQG_CONFIG, systemId } from "../system/config";
+import { getDefaultItemIconSettings } from "../system/settings/default-item-icons";
 import { RqidLink } from "../data-model/shared/rqid-link";
 import { actorWizardFlags } from "../data-model/shared/rqg-document-flags";
 import { addRqidLinkToSheetJQuery } from "../documents/rqid-sheet-button";
@@ -768,15 +770,11 @@ export class RqgActorSheet<
     // Add Passion button
     htmlElement?.querySelectorAll<HTMLElement>("[data-passion-add]").forEach((el) => {
       el.addEventListener("click", async () => {
-        const defaultItemIconSettings: any = game.settings?.get(
-          systemId,
-          "defaultItemIconSettings",
-        );
         const newPassionName = localize("RQG.Item.Passion.PassionEnum.Loyalty");
         const passion = {
           name: newPassionName,
           type: ItemTypeEnum.Passion,
-          img: defaultItemIconSettings[ItemTypeEnum.Passion],
+          img: getDefaultItemIconSettings()[ItemTypeEnum.Passion as RqgItemType],
           system: { passion: newPassionName },
         };
         const createdItems = await this.actor.createEmbeddedDocuments("Item", [passion]);
@@ -821,11 +819,6 @@ export class RqgActorSheet<
     htmlElement?.querySelectorAll<HTMLElement>("[data-gear-add]").forEach((el) => {
       const physicalItemType = getRequiredDomDataset(el, "gear-add") as PhysicalItemType;
       el.addEventListener("click", async () => {
-        const defaultItemIconSettings: any = game.settings?.get(
-          systemId,
-          "defaultItemIconSettings",
-        );
-
         const physicalItemType2ItemName = new Map<PhysicalItemType, string>([
           ["unique", "RQG.Actor.Gear.NewGear"],
           ["currency", "RQG.Actor.Gear.NewCurrency"],
@@ -839,7 +832,7 @@ export class RqgActorSheet<
         const newGear = {
           name: name,
           type: ItemTypeEnum.Gear,
-          img: defaultItemIconSettings[ItemTypeEnum.Gear],
+          img: getDefaultItemIconSettings()[ItemTypeEnum.Gear as RqgItemType],
           system: { physicalItemType: physicalItemType },
         };
         const createdItems = await this.actor.createEmbeddedDocuments("Item", [newGear]);

--- a/src/actors/rqg-actor.ts
+++ b/src/actors/rqg-actor.ts
@@ -16,6 +16,7 @@ import {
 } from "../system/util";
 import { initializeAllCharacteristics } from "./context-menus/characteristic-context-menu";
 import { RQG_CONFIG, systemId } from "../system/config";
+import { getDefaultItemIconSettings } from "../system/settings/default-item-icons";
 import { Rqid } from "../system/api/rqid-api";
 import type { RqidString } from "../system/api/rqid-api";
 import { AbilitySuccessLevelEnum } from "../rolls/ability-roll/ability-roll.defs";
@@ -202,13 +203,12 @@ export class RqgActor extends Actor {
   }
 
   private createReputationFakeItem(token?: TokenDocument | null): PartialAbilityItem {
-    const defaultItemIconSettings: any = game.settings?.get(systemId, "defaultItemIconSettings");
     const actingToken =
       token ?? (getTokenFromActor(this) as PartialAbilityItem["actingToken"] | undefined);
     assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
     return {
       name: "Reputation",
-      img: defaultItemIconSettings.reputation,
+      img: getDefaultItemIconSettings().reputation,
       parent: this,
       system: {
         chance: this.system.background.reputation ?? 0,

--- a/src/applications/default-item-icon-settings.ts
+++ b/src/applications/default-item-icon-settings.ts
@@ -1,5 +1,8 @@
 import { systemId } from "../system/config";
-import { defaultItemIconsObject } from "../system/settings/default-item-icons";
+import {
+  defaultItemIconsObject,
+  getDefaultItemIconSettings,
+} from "../system/settings/default-item-icons";
 import type { ItemTypeEnum, RqgItemType } from "@item-model/item-types.ts";
 import { templatePaths } from "../system/load-handlebars-templates";
 import {
@@ -58,11 +61,11 @@ export class DefaultItemIconSettings extends HandlebarsApplicationMixin(
   };
 
   override async _prepareContext(): Promise<DefaultItemIconSettingsContext> {
-    const currentSettings: any = game.settings?.get(systemId, "defaultItemIconSettings");
-    const iconRows = Object.entries(defaultItemIconsObject)
+    const mergedSettings = getDefaultItemIconSettings();
+    const iconRows = Object.entries(mergedSettings)
       .map(([key, value]) => ({
         key: key as RqgItemType | "reputation",
-        value: currentSettings[key] ?? value,
+        value,
       }))
       .sort((a, b) => localizeItemType(a.key).localeCompare(localizeItemType(b.key)));
 

--- a/src/items/rqg-item.ts
+++ b/src/items/rqg-item.ts
@@ -1,6 +1,11 @@
 import { PassionSheet } from "./passion-item/passion-sheet";
 import { PassionSheetV2 } from "./passion-item/passion-sheet-v2";
-import { type AbilityItem, abilityItemTypes, ItemTypeEnum } from "@item-model/item-types.ts";
+import {
+  type AbilityItem,
+  abilityItemTypes,
+  ItemTypeEnum,
+  type RqgItemType,
+} from "@item-model/item-types.ts";
 import { RuneSheet } from "./rune-item/rune-sheet";
 import { RuneSheetV2 } from "./rune-item/rune-sheet-v2";
 import { SkillSheet } from "./skill-item/skill-sheet";
@@ -25,6 +30,7 @@ import { HomelandSheetV2 } from "./homeland-item/homeland-sheet-v2";
 import { OccupationSheet } from "./occupation-item/occupation-sheet";
 import { OccupationSheetV2 } from "./occupation-item/occupation-sheet-v2";
 import { systemId } from "../system/config";
+import { getDefaultItemIconSettings } from "../system/settings/default-item-icons";
 import { AbilitySuccessLevelEnum } from "../rolls/ability-roll/ability-roll.defs";
 import type { AbilityRollOptions } from "../rolls/ability-roll/ability-roll.types";
 import type { SpiritMagicRollOptions } from "../rolls/spirit-magic-roll/spirit-magic-roll.types";
@@ -432,13 +438,12 @@ export class RqgItem extends Item {
   }
 
   protected override _onCreate(itemData: any, options: never, userId: string): void {
-    const defaultItemIconSettings: any = game.settings?.get(systemId, "defaultItemIconSettings");
     const item = itemData._id ? game.items?.get(itemData._id) : undefined;
     const defaultIcon = foundry.documents.BaseItem.DEFAULT_ICON;
 
     if (item?.img === defaultIcon) {
       const updateData: any = {
-        img: defaultItemIconSettings[itemData.type],
+        img: getDefaultItemIconSettings()[itemData.type as RqgItemType],
         "data.namePrefix": itemData.name,
       };
 

--- a/src/system/api/rqid-api.ts
+++ b/src/system/api/rqid-api.ts
@@ -1,5 +1,6 @@
 import { ItemTypeEnum } from "@item-model/item-types.ts";
 import { systemId } from "../config";
+import { getDefaultItemIconSettings } from "../settings/default-item-icons";
 import {
   getAvailableRunes,
   isDocumentSubType,
@@ -742,8 +743,8 @@ export class Rqid {
         }
       }
 
-      const iconSettings = game.settings?.get(systemId, "defaultItemIconSettings");
-      const defaultItemIcon = itemType && iconSettings?.[itemType as keyof typeof iconSettings];
+      const iconSettings = getDefaultItemIconSettings();
+      const defaultItemIcon = itemType && iconSettings[itemType as keyof typeof iconSettings];
       if (defaultItemIcon) {
         // TODO If undefined then the rqid is invalid since all items need a type
         return `<img src="${defaultItemIcon}"/>`;

--- a/src/system/register-handlebars-helpers.ts
+++ b/src/system/register-handlebars-helpers.ts
@@ -9,12 +9,12 @@ import {
   toCamelCase,
 } from "./util";
 
-import { systemId } from "./config";
 import { Rqid } from "./api/rqid-api";
 import type { RqgItem } from "../items/rqg-item";
 import type { SkillItem } from "@item-model/skill-data-model.ts";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import { ItemTypeEnum } from "@item-model/item-types";
+import { getDefaultItemIconSettings } from "./settings/default-item-icons";
 
 export const registerHandlebarsHelpers = function () {
   const getHelperHash = (options: unknown): Record<string, string> | undefined => {
@@ -300,8 +300,9 @@ export const registerHandlebarsHelpers = function () {
   });
 
   Handlebars.registerHelper("defaultItemIconSrc", (itemType: string): string | undefined => {
-    const defaultItemIconSettings: any = game.settings?.get(systemId, "defaultItemIconSettings");
-    return defaultItemIconSettings[itemType];
+    return getDefaultItemIconSettings()[
+      itemType as keyof ReturnType<typeof getDefaultItemIconSettings>
+    ];
   });
 
   Handlebars.registerHelper("equippedIcon", (equippedStatus: EquippedStatus): string => {

--- a/src/system/settings/default-item-icons.ts
+++ b/src/system/settings/default-item-icons.ts
@@ -1,4 +1,5 @@
 import type { RqgItemType } from "@item-model/item-types.ts";
+import { systemId } from "../config.ts";
 
 export const defaultItemIconsObject = {
   armor: "systems/rqg/assets/images/items/armor.svg",
@@ -15,3 +16,10 @@ export const defaultItemIconsObject = {
   weapon: "systems/rqg/assets/images/items/weapon.svg",
   reputation: "systems/rqg/assets/images/other/reputation.svg",
 } satisfies Record<RqgItemType | "reputation", string>;
+
+// Falls back to the built-in defaults for keys missing from a world's stored
+// settings (e.g. "reputation" was added after some worlds already saved this setting).
+export function getDefaultItemIconSettings(): Record<RqgItemType | "reputation", string> {
+  const storedSettings: any = game.settings?.get(systemId, "defaultItemIconSettings");
+  return { ...defaultItemIconsObject, ...storedSettings };
+}


### PR DESCRIPTION
## Summary
- `getDefaultItemIconSettings()` merges the stored `defaultItemIconSettings` world setting over the built-in defaults, fixing the reputation icon (and any future icon key) rendering broken in worlds whose stored setting predates that key. Migrated every read site (`rqg-item.ts`, `rqg-actor.ts`, both actor sheets, `rqid-api.ts`) and de-duplicated the settings dialog's own fallback logic to reuse it.

Fixes #976

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (413 tests passing)
- [x] `pnpm i18n:audit:en`
- [x] `pnpm build:system`
- [ ] Manual verification in a running Foundry world

🤖 Generated with [Claude Code](https://claude.com/claude-code)