### PR TITLE
fix: restore useless legs when the abdomen wound causing them heals

### DIFF
--- a/src/items/hit-location-item/hit-location-healing-calculations.test.ts
+++ b/src/items/hit-location-item/hit-location-healing-calculations.test.ts
@@ -13,15 +13,16 @@ import { describe, it, expect, beforeEach } from "vitest";
 describe("HealingCalculations", () => {
   let mockActor: CharacterActor;
   let mockLeftLeg: HitLocationItem;
+  let mockRightLeg: HitLocationItem;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let mockHead: HitLocationItem;
   let mockChest: HitLocationItem;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let mockAbdomen: HitLocationItem;
 
   beforeEach(() => {
     mockActor = JSON.parse(JSON.stringify(mockActorOriginal));
     mockLeftLeg = mockActor.items.find((i) => i.name === "Left Leg")! as HitLocationItem;
+    mockRightLeg = mockActor.items.find((i) => i.name === "Right Leg")! as HitLocationItem;
     mockHead = mockActor.items.find((i) => i.name === "Head")! as HitLocationItem;
     mockChest = mockActor.items.find((i) => i.name === "Chest")! as HitLocationItem;
     mockAbdomen = mockActor.items.find((i) => i.name === "Abdomen")! as HitLocationItem;
@@ -233,6 +234,46 @@ describe("HealingCalculations", () => {
       },
     });
     expect(usefulLegs).toStrictEqual([]);
+  });
+
+  it("should restore useless legs when the abdomen wound causing them heals below threshold", () => {
+    const appliedDamage = mockAbdomen.system.hitPoints.max!;
+
+    applyTestDamage(appliedDamage, true, mockAbdomen, mockActor);
+    // Simulate the connected legs having been made useless by the abdomen wound.
+    mockLeftLeg.system.hitLocationHealthState = "useless";
+    mockRightLeg.system.hitLocationHealthState = "useless";
+
+    const { usefulLegs } = applyTestHealing(appliedDamage, 0, mockAbdomen, mockActor);
+
+    expect(usefulLegs).toStrictEqual([
+      {
+        _id: "Dhm40qEh3Idp5HSE",
+        system: { hitLocationHealthState: "healthy" },
+      },
+      {
+        _id: "RFt7m9xXHtjpVNeY",
+        system: { hitLocationHealthState: "healthy" },
+      },
+    ]);
+  });
+
+  it("should not restore a leg that is independently useless from its own damage", () => {
+    const appliedDamage = mockAbdomen.system.hitPoints.max!;
+
+    applyTestDamage(appliedDamage, true, mockAbdomen, mockActor);
+    applyTestDamage(mockLeftLeg.system.hitPoints.max!, true, mockLeftLeg, mockActor);
+    mockRightLeg.system.hitLocationHealthState = "useless";
+    expect(mockLeftLeg.system.hitLocationHealthState).toBe("useless");
+
+    const { usefulLegs } = applyTestHealing(appliedDamage, 0, mockAbdomen, mockActor);
+
+    expect(usefulLegs).toStrictEqual([
+      {
+        _id: "RFt7m9xXHtjpVNeY",
+        system: { hitLocationHealthState: "healthy" },
+      },
+    ]);
   });
 
   it("throws when trying to heal a missing wound", () => {

--- a/src/items/hit-location-item/hit-location-healing-calculations.ts
+++ b/src/items/hit-location-item/hit-location-healing-calculations.ts
@@ -1,11 +1,15 @@
 import type { ActorHealthState } from "../../data-model/actor-data/attributes";
-import { assertDocumentSubType, RqgError } from "../../system/util";
+import { assertDocumentSubType, isDocumentSubType, RqgError } from "../../system/util";
 import type { HitLocationItem } from "@item-model/hit-location-data-model.ts";
-import type { HitLocationHealthState } from "@item-model/hit-location-enums.ts";
+import {
+  HitLocationTypesEnum,
+  type HitLocationHealthState,
+} from "@item-model/hit-location-enums.ts";
 import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
 import { ItemTypeEnum } from "@item-model/item-types.ts";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "../rqg-item";
+import { systemId } from "../../system/config";
 
 import type { DeepPartial } from "fvtt-types/utils";
 
@@ -33,7 +37,7 @@ export class HealingCalculations {
     const healingEffects: HealingEffects = {
       hitLocationUpdates: {},
       actorUpdates: {},
-      usefulLegs: [], // Not used yet
+      usefulLegs: [],
     };
 
     if (!Number.isInteger(healWoundIndex) || hitLocation.system.wounds.length <= healWoundIndex) {
@@ -70,6 +74,37 @@ export class HealingCalculations {
       actorHealthImpact = "wounded";
       if (hitLocationHealthState !== "severed") {
         hitLocationHealthState = "wounded";
+      }
+    }
+
+    // A healed abdomen wound that drops below the useless-legs threshold restores any
+    // connected legs that were only made useless by the abdomen wound (not by their own damage).
+    if (
+      hitLocation.system.hitLocationType === HitLocationTypesEnum.Abdomen &&
+      woundsSumAfter < hpMax
+    ) {
+      const hitLocationRqid = hitLocation.flags?.[systemId]?.documentRqidFlags?.id;
+      const connectedLimbs = actor.items.filter(
+        (i) =>
+          isDocumentSubType<HitLocationItem>(i, ItemTypeEnum.HitLocation) &&
+          i.system.connectedTo === hitLocationRqid,
+      ) as HitLocationItem[];
+
+      for (const limb of connectedLimbs) {
+        if (limb.system.hitLocationHealthState !== "useless") {
+          continue;
+        }
+        const limbHpMax = limb.system.hitPoints.max ?? CONFIG.RQG.minTotalHitPoints;
+        const limbDamage = limb.system.wounds.reduce((acc: number, w: number) => acc + w, 0);
+        if (limbDamage >= limbHpMax) {
+          continue; // Limb is independently useless from its own damage
+        }
+        healingEffects.usefulLegs.push({
+          _id: limb.id ?? "",
+          system: {
+            hitLocationHealthState: limbDamage === 0 ? "healthy" : "wounded",
+          },
+        });
       }
     }
 


### PR DESCRIPTION
## Summary
- `HealingCalculations.healWound()` always returned an empty `usefulLegs` array, so healing an abdomen wound that had made both legs useless never restored them, even though the consumer (`healWoundOnHitLocation`) was already wired to apply such updates.
- Legs are now restored to `healthy`/`wounded` when the healed abdomen wound's cumulative damage drops back below the useless-legs threshold, unless a leg is independently useless from its own damage.

Fixes #981

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm i18n:audit-unused`
- [x] `pnpm vitest run` (418/418, incl. 2 new tests for this fix)