### PR TITLE
fix: migrate stale hit-location connectedTo/hitLocationType data

### DIFF
--- a/src/system/migrations/migrate-world.ts
+++ b/src/system/migrations/migrate-world.ts
@@ -17,6 +17,7 @@ import { RqidBatchEditor } from "../../applications/rqid-batch-editor/rqid-batch
 import { openDataModelRepairDialog } from "../api/data-model-repair";
 import { migrateRuneItemType } from "./migrations-item/migrate-rune-item-type";
 import { relabelRuneMagicCommandCultSpiritRqid } from "./migrations-item/relabel-rune-magic-command-cult-spirit-rqid";
+import { migrateHitLocationConnectedToAndType } from "./migrations-item/migrate-hit-location-connected-to-and-type";
 import { migrateActorActiveEffectPaths } from "./migrations-actor/migrate-actor-active-effect-paths";
 import { migrateItemActiveEffectPaths } from "./migrations-item/migrate-item-active-effect-paths";
 import { migrateActiveEffectActiveEffectPaths } from "./migrations-effect/migrate-active-effect-active-effect-paths";
@@ -156,6 +157,7 @@ export async function applyDefaultWorldMigrations(
     migrateWeaponSkillLinks,
     migrateRuneItemType,
     relabelRuneMagicCommandCultSpiritRqid,
+    migrateHitLocationConnectedToAndType,
     migrateItemActiveEffectPaths,
     migrateItemActiveEffectDurationUnits,
   ];

--- a/src/system/migrations/migrations-item/migrate-hit-location-connected-to-and-type.test.ts
+++ b/src/system/migrations/migrations-item/migrate-hit-location-connected-to-and-type.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { migrateHitLocationConnectedToAndType } from "./migrate-hit-location-connected-to-and-type";
+import { mockActor as mockActorOriginal } from "../../../../test/mocks/mockActor.ts";
+import type { HitLocationItem } from "@item-model/hit-location-data-model.ts";
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import type { RqgItem } from "@items/rqg-item.ts";
+import type { MigrationLogger } from "../../logging/migration-logger.ts";
+
+function makeHitLocationItem(rqid: string, hitLocationType: string, connectedTo = "") {
+  return {
+    type: "hitLocation",
+    name: "Test Location",
+    flags: {
+      rqg: {
+        documentRqidFlags: { id: rqid },
+      },
+    },
+    system: {
+      hitLocationType,
+      connectedTo,
+    },
+  };
+}
+
+function makeActor(bodyType: string, items: unknown[] = []) {
+  return {
+    type: "character",
+    items,
+    getBodyType: () => bodyType,
+  };
+}
+
+describe("migrateHitLocationConnectedToAndType", () => {
+  describe("humanoid actors - fixed directly from the item's own rqid", () => {
+    it("fills in an invalid hitLocationType from the canonical table", async () => {
+      const item = makeHitLocationItem("i.hit-location.abdomen", "");
+      const actor = makeActor("humanoid");
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        item as unknown as RqgItem,
+        actor as unknown as RqgActor,
+      );
+
+      expect(updateData).toStrictEqual({ system: { hitLocationType: "abdomen" } });
+    });
+
+    it("overwrites an already-valid-but-wrong hitLocationType with the canonical value", async () => {
+      const item = makeHitLocationItem("i.hit-location.abdomen", "limb");
+      const actor = makeActor("humanoid");
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        item as unknown as RqgItem,
+        actor as unknown as RqgActor,
+      );
+
+      expect(updateData).toStrictEqual({ system: { hitLocationType: "abdomen" } });
+    });
+
+    it("leaves hitLocationType alone when it already matches the canonical value", async () => {
+      const item = makeHitLocationItem("i.hit-location.abdomen", "abdomen");
+      const actor = makeActor("humanoid");
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        item as unknown as RqgItem,
+        actor as unknown as RqgActor,
+      );
+
+      expect(updateData).toStrictEqual({});
+    });
+
+    it("overwrites an already-valid-but-wrong connectedTo with the canonical value", async () => {
+      const item = makeHitLocationItem("i.hit-location.right-leg", "limb", "i.hit-location.chest");
+      const actor = makeActor("humanoid", []);
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        item as unknown as RqgItem,
+        actor as unknown as RqgActor,
+      );
+
+      expect(updateData).toStrictEqual({ system: { connectedTo: "i.hit-location.abdomen" } });
+    });
+
+    it("leaves connectedTo alone when it already matches the canonical value", async () => {
+      const item = makeHitLocationItem(
+        "i.hit-location.right-leg",
+        "limb",
+        "i.hit-location.abdomen",
+      );
+      const actor = makeActor("humanoid", []);
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        item as unknown as RqgItem,
+        actor as unknown as RqgActor,
+      );
+
+      expect(updateData).toStrictEqual({});
+    });
+
+    it("fixes connectedTo directly from the canonical table, without needing a sibling", async () => {
+      const item = makeHitLocationItem("i.hit-location.right-leg", "limb", "Right Leg");
+      const actor = makeActor("humanoid", []);
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        item as unknown as RqgItem,
+        actor as unknown as RqgActor,
+      );
+
+      expect(updateData).toStrictEqual({ system: { connectedTo: "i.hit-location.abdomen" } });
+    });
+
+    it("fixes both fields together when both are invalid", async () => {
+      const item = makeHitLocationItem("i.hit-location.left-arm", "", "Left Arm");
+      const actor = makeActor("humanoid", []);
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        item as unknown as RqgItem,
+        actor as unknown as RqgActor,
+      );
+
+      expect(updateData).toStrictEqual({
+        system: { hitLocationType: "limb", connectedTo: "i.hit-location.chest" },
+      });
+    });
+
+    it("does not guess hitLocationType for a non-canonical rqid", async () => {
+      const item = makeHitLocationItem("i.hit-location.tail", "");
+      const actor = makeActor("humanoid");
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        item as unknown as RqgItem,
+        actor as unknown as RqgActor,
+      );
+
+      expect(updateData).toStrictEqual({});
+    });
+  });
+
+  describe("non-humanoid actors", () => {
+    it("never guesses hitLocationType", async () => {
+      const item = makeHitLocationItem("i.hit-location.abdomen", "");
+      const actor = makeActor("other");
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        item as unknown as RqgItem,
+        actor as unknown as RqgActor,
+      );
+
+      expect(updateData).toStrictEqual({});
+    });
+
+    it("falls back to resolving connectedTo by sibling name", async () => {
+      const abdomen = makeHitLocationItem("i.hit-location.abdomen", "abdomen");
+      const item = makeHitLocationItem("i.hit-location.left-leg", "limb", "Test Location Abdomen");
+      // Sibling must be named exactly what the legacy connectedTo value holds.
+      abdomen.name = "Test Location Abdomen";
+      const actor = makeActor("other", [abdomen]);
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        item as unknown as RqgItem,
+        actor as unknown as RqgActor,
+      );
+
+      expect(updateData).toStrictEqual({ system: { connectedTo: "i.hit-location.abdomen" } });
+    });
+
+    it("warns and does nothing when connectedTo matches no sibling by name", async () => {
+      const item = makeHitLocationItem("i.hit-location.left-leg", "limb", "Some Unknown Location");
+      const actor = makeActor("other", []);
+      const warnings: string[] = [];
+      const logger = { warn: (msg: string) => warnings.push(msg) } as unknown as MigrationLogger;
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        item as unknown as RqgItem,
+        actor as unknown as RqgActor,
+        logger,
+      );
+
+      expect(updateData).toStrictEqual({});
+      expect(warnings).toHaveLength(1);
+    });
+  });
+
+  describe("with the real mock actor fixture", () => {
+    let mockActor: RqgActor;
+    let mockLeftLeg: HitLocationItem;
+
+    beforeEach(() => {
+      mockActor = JSON.parse(JSON.stringify(mockActorOriginal));
+      // JSON round-tripping drops class methods - the mock actor's hit locations are exactly
+      // the canonical 7, so stub getBodyType() the way the real RqgActor would resolve it.
+      (mockActor as unknown as { getBodyType: () => string }).getBodyType = () => "humanoid";
+      mockLeftLeg = mockActor.items.find((i) => i.name === "Left Leg")! as HitLocationItem;
+    });
+
+    it("resolves a legacy name-based connectedTo via the canonical table (mock actor is humanoid)", async () => {
+      mockLeftLeg.system.connectedTo = "Abdomen";
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        mockLeftLeg as unknown as RqgItem,
+        mockActor,
+      );
+
+      expect(updateData).toStrictEqual({ system: { connectedTo: "i.hit-location.abdomen" } });
+    });
+
+    it("does nothing when connectedTo is already a valid rqid", async () => {
+      mockLeftLeg.system.connectedTo = "i.hit-location.abdomen";
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        mockLeftLeg as unknown as RqgItem,
+        mockActor,
+      );
+
+      expect(updateData).toStrictEqual({});
+    });
+
+    it("overwrites a valid-but-wrong rqid connectedTo (leg mistakenly connected to the chest)", async () => {
+      mockLeftLeg.system.connectedTo = "i.hit-location.chest";
+
+      const updateData = await migrateHitLocationConnectedToAndType(
+        mockLeftLeg as unknown as RqgItem,
+        mockActor,
+      );
+
+      expect(updateData).toStrictEqual({ system: { connectedTo: "i.hit-location.abdomen" } });
+    });
+  });
+
+  it("skips non-hitLocation items", async () => {
+    const item = { type: "skill", system: {} };
+    const actor = makeActor("humanoid");
+
+    const updateData = await migrateHitLocationConnectedToAndType(
+      item as unknown as RqgItem,
+      actor as unknown as RqgActor,
+    );
+
+    expect(updateData).toStrictEqual({});
+  });
+
+  it("does nothing when there is no owning actor", async () => {
+    const item = makeHitLocationItem("i.hit-location.abdomen", "", "Abdomen");
+
+    const updateData = await migrateHitLocationConnectedToAndType(item as unknown as RqgItem);
+
+    expect(updateData).toStrictEqual({});
+  });
+
+  it("does not warn about an already-correct connectedTo on a standalone item with no owning actor", async () => {
+    // Reproduces compendium library packs of hit locations (e.g. a "hit-locations-humanoids"
+    // Item pack) that aren't embedded in any Actor - connectedTo is already a well-formed rqid,
+    // but there's no sibling to validate it against, so it must be left alone silently rather
+    // than flagged as broken.
+    const item = makeHitLocationItem("i.hit-location.left-arm", "limb", "i.hit-location.chest");
+    const warnings: string[] = [];
+    const logger = { warn: (msg: string) => warnings.push(msg) } as unknown as MigrationLogger;
+
+    const updateData = await migrateHitLocationConnectedToAndType(
+      item as unknown as RqgItem,
+      undefined,
+      logger,
+    );
+
+    expect(updateData).toStrictEqual({});
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/src/system/migrations/migrations-item/migrate-hit-location-connected-to-and-type.ts
+++ b/src/system/migrations/migrations-item/migrate-hit-location-connected-to-and-type.ts
@@ -1,0 +1,162 @@
+import { ItemTypeEnum } from "@item-model/item-types.ts";
+import type { HitLocationItem } from "@item-model/hit-location-data-model.ts";
+import { HitLocationTypesEnum } from "@item-model/hit-location-enums.ts";
+import {
+  ActorTypeEnum,
+  type CharacterActor,
+} from "../../../data-model/actor-data/rqg-actor-data.ts";
+import { isDocumentSubType } from "../../util.ts";
+import { systemId } from "../../config";
+import type { RqgItem } from "@items/rqg-item.ts";
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import type { MigrationDocumentLink } from "../apply-migrations";
+import type { MigrationLogger } from "../../logging/migration-logger.ts";
+
+type CanonicalHumanoidFields = {
+  hitLocationType: (typeof HitLocationTypesEnum)[keyof typeof HitLocationTypesEnum];
+  connectedTo?: string;
+};
+
+// For a confirmed-humanoid actor (RqgActor.getBodyType() === "humanoid" - exactly the canonical
+// 7 hit locations, no more, no less), a hit location's own rqid alone tells us both fields with
+// certainty: e.g. "i.hit-location.right-leg" is always a Limb connected to the abdomen. That
+// makes the fragile "guess from a sibling's name" approach unnecessary for this case - it's only
+// needed as a fallback for non-humanoid actors, where there's no fixed canonical answer.
+const canonicalHumanoidFields: ReadonlyMap<string, CanonicalHumanoidFields> = new Map([
+  ["i.hit-location.head", { hitLocationType: HitLocationTypesEnum.Head }],
+  ["i.hit-location.chest", { hitLocationType: HitLocationTypesEnum.Chest }],
+  ["i.hit-location.abdomen", { hitLocationType: HitLocationTypesEnum.Abdomen }],
+  [
+    "i.hit-location.left-arm",
+    { hitLocationType: HitLocationTypesEnum.Limb, connectedTo: "i.hit-location.chest" },
+  ],
+  [
+    "i.hit-location.right-arm",
+    { hitLocationType: HitLocationTypesEnum.Limb, connectedTo: "i.hit-location.chest" },
+  ],
+  [
+    "i.hit-location.left-leg",
+    { hitLocationType: HitLocationTypesEnum.Limb, connectedTo: "i.hit-location.abdomen" },
+  ],
+  [
+    "i.hit-location.right-leg",
+    { hitLocationType: HitLocationTypesEnum.Limb, connectedTo: "i.hit-location.abdomen" },
+  ],
+]);
+
+/**
+ * Repairs two hit-location fields that silently break the "useless legs" matching used by
+ * damage/healing calculations when wrong, with no error surfaced anywhere:
+ *  - `hitLocationType` ("act as"): drives limb vs head/chest/abdomen damage rules.
+ *  - `connectedTo`: which torso location a limb is attached to, compared by rqid.
+ *
+ * On a confirmed-humanoid actor, both are derived directly from the item's own rqid and always
+ * synced to that canonical value - even overwriting an already-valid-but-wrong value (e.g. a
+ * right-leg somehow typed as "chest", or connected to the chest instead of the abdomen). There's
+ * no legitimate reason a humanoid's fixed 7-location anatomy would intentionally deviate, so
+ * certainty here beats caution.
+ *
+ * On any other actor, `hitLocationType` is left alone entirely (no reliable reference for
+ * non-standard anatomy), and `connectedTo` falls back to resolving a legacy name-based value
+ * against a same-named sibling on the same actor - actor-local, so it works regardless of
+ * species or locale, but only repairs what the old data already pointed at, and never overwrites
+ * an already-valid rqid.
+ */
+export async function migrateHitLocationConnectedToAndType(
+  itemData: RqgItem,
+  owningActorData?: RqgActor,
+  migrationLogger?: MigrationLogger,
+): Promise<Item.UpdateData> {
+  if (!isDocumentSubType<HitLocationItem>(itemData, ItemTypeEnum.HitLocation)) {
+    return {};
+  }
+
+  const isHumanoidActor =
+    isDocumentSubType<CharacterActor>(owningActorData, ActorTypeEnum.Character) &&
+    owningActorData.getBodyType() === "humanoid";
+
+  const ownRqid = itemData.flags?.[systemId]?.documentRqidFlags?.id ?? "";
+  const canonicalFields = isHumanoidActor ? canonicalHumanoidFields.get(ownRqid) : undefined;
+
+  const systemUpdate: { hitLocationType?: string; connectedTo?: string } = {};
+
+  if (canonicalFields && itemData.system.hitLocationType !== canonicalFields.hitLocationType) {
+    systemUpdate["hitLocationType"] = canonicalFields.hitLocationType;
+  }
+
+  const connectedToFix = getConnectedToFix(
+    itemData,
+    canonicalFields,
+    owningActorData,
+    migrationLogger,
+  );
+  if (connectedToFix) {
+    systemUpdate["connectedTo"] = connectedToFix;
+  }
+
+  if (Object.keys(systemUpdate).length === 0) {
+    return {};
+  }
+
+  return { system: systemUpdate } as Item.UpdateData;
+}
+
+function getConnectedToFix(
+  itemData: HitLocationItem,
+  canonicalFields: CanonicalHumanoidFields | undefined,
+  owningActorData: RqgActor | undefined,
+  migrationLogger: MigrationLogger | undefined,
+): string | undefined {
+  const connectedTo = itemData.system.connectedTo;
+
+  // Confirmed-humanoid canonical limb: always sync to the known-correct connection, regardless
+  // of the current value (blank, a legacy name, or a valid-but-wrong rqid).
+  if (canonicalFields?.connectedTo) {
+    return connectedTo === canonicalFields.connectedTo ? undefined : canonicalFields.connectedTo;
+  }
+
+  // Without an owning actor - a standalone template item in a world/compendium Item pack (e.g.
+  // library packs of hit locations used to build out actors elsewhere) - there are no sibling
+  // hit locations to validate or repair connectedTo against. The value there is just an rqid
+  // string awaiting a real actor context; we have no way to tell a genuinely broken one from an
+  // already-correct one, so leave it alone rather than warn about something that may well be
+  // fine.
+  if (!owningActorData || !connectedTo) {
+    return undefined;
+  }
+
+  const siblingHitLocations = owningActorData.items.filter((i) =>
+    isDocumentSubType<HitLocationItem>(i, ItemTypeEnum.HitLocation),
+  ) as HitLocationItem[];
+
+  const alreadyMatchesARqid = siblingHitLocations.some(
+    (sibling) => sibling.flags?.[systemId]?.documentRqidFlags?.id === connectedTo,
+  );
+  if (alreadyMatchesARqid) {
+    return undefined;
+  }
+
+  const matchedSibling = siblingHitLocations.find((sibling) => sibling.name === connectedTo);
+  const matchedRqid = matchedSibling?.flags?.[systemId]?.documentRqidFlags?.id;
+  if (matchedRqid) {
+    return matchedRqid;
+  }
+
+  const documents: MigrationDocumentLink[] = [
+    {
+      kind: "Actor",
+      uuid: owningActorData.uuid,
+      label: owningActorData.name ?? "Actor",
+    },
+    {
+      kind: "Item",
+      uuid: itemData.uuid ?? "",
+      label: itemData.name ?? "Hit Location",
+    },
+  ];
+  migrationLogger?.warn(
+    `Hit location [${itemData.name}] has a "Connected to" value ("${connectedTo}") that doesn't match a known rqid or a sibling hit location by name; leaving it as-is.`,
+    { notify: false, documents },
+  );
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Adds `migrateHitLocationConnectedToAndType`, registered as a world item migration, to repair hit-location `connectedTo`/`hitLocationType` data that predates the rqid-based matching used by damage/healing calculations.
- Confirmed-humanoid actors: both fields are always synced from a canonical rqid lookup table derived from the item's own rqid, even overwriting an already-valid-but-wrong value.
- Non-humanoid actors: `hitLocationType` is left alone (no reliable reference); `connectedTo` falls back to resolving a legacy name-based value against a same-named sibling on the same actor.
- Standalone hit-location items with no owning actor (e.g. compendium library packs) are left untouched, avoiding false-positive warnings on already-correct data.

Fixes #983

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm i18n:audit-unused`
- [x] `pnpm vitest run` (435/435, incl. new migration test suite)