### PR TITLE
fix: make AE duration-units migration idempotent

### DIFF
--- a/src/system/migrations/migrations-actor/migrate-actor-active-effect-duration-units.ts
+++ b/src/system/migrations/migrations-actor/migrate-actor-active-effect-duration-units.ts
@@ -7,7 +7,7 @@ import { normalizeLegacyActiveEffectDuration } from "../shared-ae-duration-migra
  */
 export const migrateActorActiveEffectDurationUnits: ActorMigration = (
   actor: RqgActor,
-  logger,
+  _logger,
 ): Actor.UpdateData => {
   const updateData: Actor.UpdateData = {};
   const rawEffects = (actor as any).effects;
@@ -42,10 +42,6 @@ export const migrateActorActiveEffectDurationUnits: ActorMigration = (
 
   if (effectUpdates.length > 0) {
     updateData.effects = effectUpdates as any;
-    logger?.info(`Migrated AE duration units for actor ${actor.name}`, {
-      notify: false,
-      documents: [{ kind: "Actor", uuid: actor.uuid, label: actor.name }],
-    });
   }
 
   return updateData;

--- a/src/system/migrations/migrations-effect/migrate-active-effect-duration-units.ts
+++ b/src/system/migrations/migrations-effect/migrate-active-effect-duration-units.ts
@@ -6,17 +6,12 @@ import { normalizeLegacyActiveEffectDuration } from "../shared-ae-duration-migra
  */
 export const migrateActiveEffectDurationUnits: ActiveEffectMigration = async (
   effect: ActiveEffect.Implementation,
-  logger,
+  _logger,
 ): Promise<ActiveEffect.UpdateData> => {
   const normalized = normalizeLegacyActiveEffectDuration(effect);
   if (!normalized) {
     return {};
   }
-
-  logger?.info(`Migrated AE duration units on compendium effect "${effect.name}"`, {
-    notify: false,
-    documents: [{ kind: "ActiveEffect", uuid: effect.uuid, label: effect.name }],
-  });
 
   return {
     duration: normalized.duration as any,

--- a/src/system/migrations/migrations-item/migrate-item-active-effect-duration-units.ts
+++ b/src/system/migrations/migrations-item/migrate-item-active-effect-duration-units.ts
@@ -7,8 +7,8 @@ import { normalizeLegacyActiveEffectDuration } from "../shared-ae-duration-migra
  */
 export const migrateItemActiveEffectDurationUnits: ItemMigration = async (
   item: RqgItem,
-  owningActor,
-  logger,
+  _owningActor,
+  _logger,
 ): Promise<Item.UpdateData> => {
   const updateData: Item.UpdateData = {};
   const rawEffects = (item as any).effects;
@@ -43,10 +43,6 @@ export const migrateItemActiveEffectDurationUnits: ItemMigration = async (
 
   if (effectUpdates.length > 0) {
     updateData.effects = effectUpdates as any;
-    logger?.info(`Migrated AE duration units on item ${item.name}`, {
-      notify: false,
-      documents: [{ kind: "Item", uuid: item.uuid, label: item.name }],
-    });
   }
 
   return updateData;

--- a/src/system/migrations/shared-ae-duration-migration-utils.test.ts
+++ b/src/system/migrations/shared-ae-duration-migration-utils.test.ts
@@ -67,4 +67,36 @@ describe("normalizeLegacyActiveEffectDuration", () => {
 
     expect(normalized).toBeUndefined();
   });
+
+  it("returns undefined when legacy keys are only Foundry's deprecation getters", () => {
+    // Foundry v14 keeps the deprecated duration keys readable via getters that
+    // derive from the new value/units/start fields, so they report data forever
+    // and can never be deleted. A prior bug treated those shims as real legacy
+    // data, so already-migrated documents were re-migrated on every pass and
+    // kept reappearing under "Performed migrations". See issue #984.
+    const duration: Record<string, unknown> = { value: 10, units: "turns" };
+    const start = { time: 41254758748, round: 9, turn: 5, combat: "e0ZOFZUjkzNg87KS" };
+    Object.defineProperties(duration, {
+      startTime: { get: () => start.time, enumerable: true },
+      seconds: { get: () => null, enumerable: true },
+      combat: { get: () => start.combat, enumerable: true },
+      rounds: { get: () => null, enumerable: true },
+      turns: { get: () => duration["value"], enumerable: true },
+      startRound: { get: () => start.round, enumerable: true },
+      startTurn: { get: () => start.turn, enumerable: true },
+    });
+
+    expect(normalizeLegacyActiveEffectDuration({ duration, start })).toBeUndefined();
+  });
+
+  it("reads raw stored data from _source rather than the initialized document", () => {
+    const normalized = normalizeLegacyActiveEffectDuration({
+      _source: { duration: { seconds: 60, startTime: 123 } },
+      duration: { value: 60, units: "seconds" },
+    });
+
+    expect(normalized?.duration.value).toBe(60);
+    expect(normalized?.duration.units).toBe("seconds");
+    expect(normalized?.start.time).toBe(123);
+  });
 });

--- a/src/system/migrations/shared-ae-duration-migration-utils.ts
+++ b/src/system/migrations/shared-ae-duration-migration-utils.ts
@@ -32,15 +32,28 @@ export interface NormalizedActiveEffectDuration {
   };
 }
 
+/**
+ * Foundry v14 keeps the deprecated duration keys readable via getters that derive
+ * their value from the new `duration.value`/`units`/`start` fields. Those shims
+ * report data forever, so only a real stored (data) property counts as legacy.
+ */
+function hasStoredLegacyValue(duration: LegacyDurationRecord, key: string): boolean {
+  const descriptor = Object.getOwnPropertyDescriptor(duration, key);
+  if (!descriptor || typeof descriptor.get === "function") {
+    return false;
+  }
+  return descriptor.value !== null && descriptor.value !== undefined;
+}
+
 export function normalizeLegacyActiveEffectDuration(
   effectLike: unknown,
 ): NormalizedActiveEffectDuration | undefined {
+  // Deliberately read `_source` rather than `toObject()`: cloning would collapse
+  // the deprecation getters into plain values and hide the distinction above.
   const source =
-    effectLike &&
-    typeof effectLike === "object" &&
-    "toObject" in effectLike &&
-    typeof (effectLike as { toObject?: unknown }).toObject === "function"
-      ? (effectLike as { toObject: () => Record<string, unknown> }).toObject()
+    effectLike && typeof effectLike === "object" && "_source" in effectLike
+      ? ((effectLike as { _source: Record<string, unknown> })._source ??
+        (effectLike as Record<string, unknown>))
       : (effectLike as Record<string, unknown> | undefined);
 
   const durationRaw = source?.["duration"];
@@ -49,21 +62,27 @@ export function normalizeLegacyActiveEffectDuration(
   }
 
   const duration = durationRaw as LegacyDurationRecord;
-  const hasLegacyDurationShape = LEGACY_DURATION_KEYS.some((key) => key in duration);
-  if (!hasLegacyDurationShape) {
-    return undefined;
-  }
 
   const toFiniteNumber = (value: unknown): number | null => {
     const numeric = typeof value === "string" ? Number(value) : value;
     return typeof numeric === "number" && Number.isFinite(numeric) ? numeric : null;
   };
 
+  const hasLegacyDurationShape = LEGACY_DURATION_KEYS.some((key) =>
+    hasStoredLegacyValue(duration, key),
+  );
+  if (!hasLegacyDurationShape) {
+    return undefined;
+  }
+
+  const legacyValue = (key: string): unknown =>
+    hasStoredLegacyValue(duration, key) ? duration[key] : undefined;
+
   const existingValue = toFiniteNumber(duration["value"]);
   const existingUnits = duration["units"];
-  const seconds = toFiniteNumber(duration["seconds"]);
-  const rounds = toFiniteNumber(duration["rounds"]);
-  const turns = toFiniteNumber(duration["turns"]);
+  const seconds = toFiniteNumber(legacyValue("seconds"));
+  const rounds = toFiniteNumber(legacyValue("rounds"));
+  const turns = toFiniteNumber(legacyValue("turns"));
 
   let inferredValue: number | null = null;
   let inferredUnits: "seconds" | "rounds" | "turns" = "seconds";
@@ -105,10 +124,10 @@ export function normalizeLegacyActiveEffectDuration(
       startTurn: _del,
     },
     start: {
-      time: toFiniteNumber(startRecord["time"]) ?? toFiniteNumber(duration["startTime"]) ?? 0,
-      round: toFiniteNumber(startRecord["round"]) ?? toFiniteNumber(duration["startRound"]),
-      turn: toFiniteNumber(startRecord["turn"]) ?? toFiniteNumber(duration["startTurn"]),
-      combat: startRecord["combat"] ?? duration["combat"] ?? null,
+      time: toFiniteNumber(startRecord["time"]) ?? toFiniteNumber(legacyValue("startTime")) ?? 0,
+      round: toFiniteNumber(startRecord["round"]) ?? toFiniteNumber(legacyValue("startRound")),
+      turn: toFiniteNumber(startRecord["turn"]) ?? toFiniteNumber(legacyValue("startTurn")),
+      combat: startRecord["combat"] ?? legacyValue("combat") ?? null,
       combatant: startRecord["combatant"] ?? null,
       initiative: toFiniteNumber(startRecord["initiative"]),
     },

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -1536,7 +1536,7 @@
       "reportChangeLegendRemoved": "- delete",
       "reportSaved": "Saved migration report to journal: {journalName}",
       "reportSaveFailed": "Failed to save migration report to journal: {error}",
-      "reportNoPerformedMigrationsDetected": "No successful migrations were recorded.",
+      "reportNoPerformedMigrationsDetected": "No documents needed migrating - nothing was changed.",
       "reportNoIssuesDetected": "No warnings or errors detected.",
       "reportSourceWorld": "World",
       "reportSourceScene": "Scene: {name}",


### PR DESCRIPTION
## Summary
- Foundry v14 installs deprecation getters for the legacy ActiveEffect duration keys (`startTime`, `seconds`, `rounds`, `turns`, `startRound`, `startTurn`, `combat`) that derive their values from the new `value`/`units`/`start` fields. The idempotency check was reading those getters back as if they were real stored data, so already-migrated effects kept re-triggering the migration and reappearing under "Performed migrations" on every world-migration run.
- Fixed by only counting a key as legacy if it's a real stored *data* property (not an accessor), and reading raw `_source` instead of `toObject()` so that distinction survives cloning.
- Dropped the manual `logger.info` calls in the three duration-units migration functions (effect/actor/item) in favor of the framework's diff-based `pruneNoopUpdateData` reporting, matching every other migration in the codebase.
- Reworded the "no performed migrations" report string from "No successful migrations were recorded." to "No documents needed migrating - nothing was changed." — accurate now that a clean idempotent run can produce an actually-empty list, and scoped correctly (doesn't imply anything about the separate warnings/errors section).

Fixes #984

## Test plan
- [x] `vitest run src/system/migrations` — 75/75 passing, including new regression tests reproducing Foundry's real deprecation-getter shim and confirming `_source` (not the initialized document) is read
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Manually verified against a live Foundry v14 world: ran the world migration three times in a row on a copy of a real world — duration-units entries appeared once (for effects with genuine unmigrated legacy data) and did not reappear on subsequent runs
- [x] Verified against the actor from GitHub issue #942 (unrelated AE-path migration) to confirm no regression there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7kqGVWwcKh32F9VJ3AL6F