### PR TITLE
fix: self-heal invalid weapon damageType "cut" and spell isRitual typo

### DIFF
--- a/src/data-model/item-data/rune-magic-data-model.test.ts
+++ b/src/data-model/item-data/rune-magic-data-model.test.ts
@@ -81,3 +81,11 @@ describe("RuneMagicDataModel chance helpers", () => {
     });
   });
 });
+
+describe("RuneMagicDataModel.migrateData", () => {
+  it("rewrites a legacy string-typed isRitual value to a real boolean", () => {
+    const migrated = RuneMagicDataModel.migrateData({ isRitual: "true," });
+
+    expect(migrated["isRitual"]).toBe(true);
+  });
+});

--- a/src/data-model/item-data/rune-magic-data-model.ts
+++ b/src/data-model/item-data/rune-magic-data-model.ts
@@ -1,6 +1,6 @@
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
-import { spellSchemaFields } from "../shared/spell-schema-fields";
+import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { rqidLinkArraySchemaField } from "../shared/rqid-link-field";
@@ -46,6 +46,11 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
 
   static override defineSchema() {
     return defineRuneMagicSchema();
+  }
+
+  static override migrateData(source: Record<string, unknown>): Record<string, unknown> {
+    migrateSpellBooleanFields(source);
+    return super.migrateData(source);
   }
 
   getCult(): CultItem | undefined {

--- a/src/data-model/item-data/spirit-magic-data-model.test.ts
+++ b/src/data-model/item-data/spirit-magic-data-model.test.ts
@@ -21,3 +21,11 @@ describe("SpiritMagicDataModel cast validation", () => {
     );
   });
 });
+
+describe("SpiritMagicDataModel.migrateData", () => {
+  it("rewrites a legacy string-typed isRitual value to a real boolean", () => {
+    const migrated = SpiritMagicDataModel.migrateData({ isRitual: "true," });
+
+    expect(migrated["isRitual"]).toBe(true);
+  });
+});

--- a/src/data-model/item-data/spirit-magic-data-model.ts
+++ b/src/data-model/item-data/spirit-magic-data-model.ts
@@ -1,6 +1,6 @@
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
-import { spellSchemaFields } from "../shared/spell-schema-fields";
+import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { RqgError, localize, assertDocumentSubType } from "../../system/util";
@@ -38,6 +38,11 @@ export class SpiritMagicDataModel extends RqgItemDataModel<SpiritMagicSchema> {
 
   static override defineSchema() {
     return defineSpiritMagicSchema();
+  }
+
+  static override migrateData(source: Record<string, unknown>): Record<string, unknown> {
+    migrateSpellBooleanFields(source);
+    return super.migrateData(source);
   }
 
   getCastValidationError(levelUsed: number | undefined, boost: number = 0): string | undefined {

--- a/src/data-model/item-data/weapon-data-model.migrate-data.test.ts
+++ b/src/data-model/item-data/weapon-data-model.migrate-data.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { WeaponDataModel } from "./weapon-data-model";
+
+describe("WeaponDataModel.migrateData damageType cleanup", () => {
+  it("rewrites the retired 'cut' damageType to 'slash' on combat maneuvers", () => {
+    const source = {
+      rate: 1,
+      usage: {
+        oneHand: {
+          combatManeuvers: [
+            { name: "Claw", damageType: "cut", description: "" },
+            { name: "Parry", damageType: "parry", description: "" },
+          ],
+        },
+      },
+    };
+
+    const migrated = WeaponDataModel.migrateData(source);
+
+    expect((migrated["usage"] as any).oneHand.combatManeuvers).toEqual([
+      { name: "Claw", damageType: "slash", description: "" },
+      { name: "Parry", damageType: "parry", description: "" },
+    ]);
+  });
+
+  it("leaves already-valid damageType values untouched", () => {
+    const source = {
+      rate: 1,
+      usage: {
+        oneHand: {
+          combatManeuvers: [{ name: "Hit", damageType: "crush", description: "" }],
+        },
+      },
+    };
+
+    const migrated = WeaponDataModel.migrateData(source);
+
+    expect((migrated["usage"] as any).oneHand.combatManeuvers).toEqual([
+      { name: "Hit", damageType: "crush", description: "" },
+    ]);
+  });
+
+  it("does nothing when usage data is missing", () => {
+    const source = { rate: 1 };
+
+    expect(() => WeaponDataModel.migrateData(source)).not.toThrow();
+  });
+});

--- a/src/data-model/item-data/weapon-data-model.ts
+++ b/src/data-model/item-data/weapon-data-model.ts
@@ -128,6 +128,11 @@ export class WeaponDataModel extends RqgItemDataModel<WeaponSchema> {
   /**
    * Encode legacy weapon skill link data into the rqid field as a legacy-encoded rqid
    * so it survives schema cleaning and can be resolved by migrations.
+   *
+   * Also rewrites the retired "cut" damageType (renamed to "slash" before this schema's
+   * choices were fixed) so old worlds and stale compendium builds - e.g. natural weapon
+   * "Claw" maneuvers imported from a pre-fix wiki module build - don't fail schema
+   * validation or get silently reset to the "crush" default on import.
    */
   static override migrateData(source: Record<string, unknown>): Record<string, unknown> {
     const parsedRate = Math.trunc(Number(source["rate"]));
@@ -144,6 +149,19 @@ export class WeaponDataModel extends RqgItemDataModel<WeaponSchema> {
         const encoded = encodeLegacyWeaponSkillReferenceInRqid(u);
         if (encoded) {
           u["skillRqidLink"] = encoded;
+        }
+
+        const combatManeuvers = u["combatManeuvers"];
+        if (Array.isArray(combatManeuvers)) {
+          for (const maneuver of combatManeuvers) {
+            if (
+              maneuver &&
+              typeof maneuver === "object" &&
+              (maneuver as Record<string, unknown>)["damageType"] === "cut"
+            ) {
+              (maneuver as Record<string, unknown>)["damageType"] = damageType.Slash;
+            }
+          }
         }
       }
     }

--- a/src/data-model/shared/spell-schema-fields.test.ts
+++ b/src/data-model/shared/spell-schema-fields.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { migrateSpellBooleanFields } from "./spell-schema-fields";
+
+describe("migrateSpellBooleanFields", () => {
+  it("rewrites a trailing-comma string typo back to a real boolean", () => {
+    const source: Record<string, unknown> = { isRitual: "true," };
+
+    migrateSpellBooleanFields(source);
+
+    expect(source["isRitual"]).toBe(true);
+  });
+
+  it("rewrites a plain string 'false' to a real boolean", () => {
+    const source: Record<string, unknown> = { isEnchantment: "false" };
+
+    migrateSpellBooleanFields(source);
+
+    expect(source["isEnchantment"]).toBe(false);
+  });
+
+  it("leaves already-boolean values untouched", () => {
+    const source: Record<string, unknown> = { isRitual: true, isEnchantment: false };
+
+    migrateSpellBooleanFields(source);
+
+    expect(source["isRitual"]).toBe(true);
+    expect(source["isEnchantment"]).toBe(false);
+  });
+
+  it("does nothing when the fields are absent", () => {
+    const source: Record<string, unknown> = {};
+
+    expect(() => migrateSpellBooleanFields(source)).not.toThrow();
+    expect(source).toEqual({});
+  });
+});

--- a/src/data-model/shared/spell-schema-fields.ts
+++ b/src/data-model/shared/spell-schema-fields.ts
@@ -34,3 +34,18 @@ export function spellSchemaFields() {
     descriptionRqidLink: rqidLinkSchemaField({ nullable: true }),
   } as const;
 }
+
+/**
+ * Coerces legacy string-typed values on the boolean spell fields (e.g. "true," left over from
+ * an old compendium-authoring typo where a trailing comma turned the YAML boolean into a string)
+ * back into real booleans, so they survive schema validation instead of silently collapsing to
+ * the field's `false` default.
+ */
+export function migrateSpellBooleanFields(source: Record<string, unknown>): void {
+  for (const key of ["isRitual", "isEnchantment"] as const) {
+    const value = source[key];
+    if (typeof value === "string") {
+      source[key] = value.trim().replace(/,$/, "") === "true";
+    }
+  }
+}

--- a/test/setup/foundryMockFunctions.js
+++ b/test/setup/foundryMockFunctions.js
@@ -635,6 +635,11 @@ const DataMockFields = (() => {
   class NumberField extends BaseField {}
   class BooleanField extends BaseField {}
   class ArrayField extends BaseField {
+    element;
+    constructor(element, options = {}) {
+      super(options);
+      this.element = element;
+    }
     clean(value) {
       if (!Array.isArray(value)) {
         return [];
@@ -652,9 +657,11 @@ const DataMockFields = (() => {
   }
   class SchemaField extends BaseField {
     schema;
+    fields;
     constructor(schema, options = {}) {
       super(options);
       this.schema = schema;
+      this.fields = schema;
     }
     clean(value) {
       const out = {};


### PR DESCRIPTION
## Summary

- `WeaponDataModel.migrateData()` now rewrites the invalid `damageType: "cut"` (not a valid choice: crush/slash/impale/parry/special) to `"slash"`. This value shipped in old bundled compendiums and, until recently, the wiki module's natural-weapon "Claw" attacks — items carrying it fail schema validation and throw "Failed to initialize Item" on load.
- `RuneMagicDataModel`/`SpiritMagicDataModel.migrateData()` now coerce legacy string-typed `isRitual`/`isEnchantment` values (e.g. `"true,"` from a trailing-comma authoring typo on the "Ban" spell) back to real booleans.
- Both fixes run on every document construction, so already-affected items self-heal the next time an affected world loads — no data migration script or GM action required for items that are still failing validation.
- Fixed a pre-existing gap in the test mock (`ArrayField` didn't expose `.element`, `SchemaField` didn't expose `.fields`) that meant no test could previously exercise `migrateData`'s nested-schema coercion path.

Note: this does *not* retroactively fix items that already imported successfully with a silently-wrong default before this fix existed (e.g. a Claw attack that got coerced to "Crush" instead of "Slash", or a Ban spell stored as non-ritual) — that data now looks valid and can't be distinguished from intentional values, so it needs manual correction. Release notes will call this out separately.

Closes #986

## Test plan
- [x] `pnpm vitest run` — 49 files / 446 tests pass
- [x] `pnpm tsc --noEmit` — clean
- [x] New unit tests cover: `cut`→`slash` rewrite, valid values untouched, missing `usage` no-op, `isRitual`/`isEnchantment` string coercion (trailing comma and plain string), already-boolean values untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)