### PR TITLE
feat: add Experience Roll Session for batch-resolving pending experience checks

### DIFF
--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -69,6 +69,8 @@ import type { RuneMagicItem } from "@item-model/rune-magic-data-model.ts";
 import type { GearItem } from "@item-model/gear-data-model.ts";
 import type { RqgActiveEffect } from "../active-effect/rqg-active-effect.ts";
 import { ActorWizard } from "../applications/actor-wizard-application";
+import { ExperienceRollSession } from "../applications/experience-roll-session/experience-roll-session";
+import { getEligibleExperienceRollEntries } from "../rolls/improvement-roll/experience-roll-eligibility";
 import { actorWizardFlags } from "../data-model/shared/rqg-document-flags";
 import {
   equippedStatuses,
@@ -209,6 +211,19 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         action: "openActorWizard",
         onClick: () => {
           new ActorWizard(this.actor, {}).render({ force: true });
+        },
+      });
+    }
+    const experienceRollCount = getEligibleExperienceRollEntries(this.actor).length;
+    if (experienceRollCount > 0) {
+      controls.unshift({
+        icon: "fa-solid fa-arrow-trend-up",
+        label: localize("RQG.Actor.ExperienceRollSession.HeaderButton", {
+          count: String(experienceRollCount),
+        }),
+        action: "openExperienceRollSession",
+        onClick: () => {
+          new ExperienceRollSession(this.actor).render({ force: true });
         },
       });
     }

--- a/src/applications/experience-roll-session/experience-roll-session-body.hbs
+++ b/src/applications/experience-roll-session/experience-roll-session-body.hbs
@@ -1,0 +1,50 @@
+<section class="experience-roll-session-body">
+  {{#if isEmpty}}
+    <p class="experience-roll-session-empty">{{localize "RQG.Actor.ExperienceRollSession.EmptyState"}}</p>
+  {{else}}
+    {{#each groups}}
+      <fieldset class="experience-roll-session-group">
+        <legend>{{label}}</legend>
+        {{#each rows}}
+          <div class="experience-roll-session-row {{rowStateClass}}">
+            <div class="experience-roll-session-row-name">
+              {{#if img}}<img src="{{img}}">{{/if}}
+              <span>{{name}}</span>
+              <span class="experience-roll-session-row-value">{{currentValueDisplay}}</span>
+            </div>
+
+            {{#if resolved}}
+              <span class="experience-roll-session-outcome success-level-{{resolved.successLevel}}">
+                <i class="fa-solid fa-{{#if resolved.increased}}check{{else}}times{{/if}}"></i>
+                {{resolved.outcomeText}}
+              </span>
+              {{#if resolved.gainDisplay}}
+                <span class="experience-roll-session-chip">
+                  <i class="fa-solid {{resolved.gainIcon}}"></i> +{{resolved.gainDisplay}}
+                </span>
+              {{/if}}
+              {{#if resolved.valueChangeDisplay}}
+                <span class="experience-roll-session-value-change">{{resolved.valueChangeDisplay}}</span>
+              {{/if}}
+            {{else if rollable}}
+              <span class="experience-roll-session-chip" data-tooltip="{{{targetTooltip}}}">
+                <i class="fa-solid fa-bullseye"></i>
+                {{#if comparatorSymbol}}{{comparatorSymbol}} {{/if}}{{targetDisplay}}
+              </span>
+              <span class="experience-roll-session-chip">
+                <i class="fa-solid {{gainIcon}}"></i> +{{gainFormula}}{{valueSuffix}}
+              </span>
+              <button type="button" class="experience-roll-session-roll-btn" data-action="rollRow" data-row-id="{{id}}">
+                {{localize "RQG.Actor.ExperienceRollSession.Roll"}}
+              </button>
+            {{else}}
+              <span class="experience-roll-session-disabled-reason">
+                <i class="fa-solid fa-lock"></i> {{disabledReasonText}}
+              </span>
+            {{/if}}
+          </div>
+        {{/each}}
+      </fieldset>
+    {{/each}}
+  {{/if}}
+</section>

--- a/src/applications/experience-roll-session/experience-roll-session-header.hbs
+++ b/src/applications/experience-roll-session/experience-roll-session-header.hbs
@@ -1,0 +1,23 @@
+<section class="experience-roll-session-header">
+  <div class="experience-roll-session-gain-toggle split-button" role="group">
+    <button
+      type="button"
+      class="ui-control"
+      data-action="setGainKind"
+      data-gain-kind="fixed"
+      aria-pressed="{{#if (eq gainKind "fixed")}}true{{else}}false{{/if}}"
+      {{#unless canRollAll}}disabled{{/unless}}
+    ><i class="fa-solid fa-hashtag"></i> {{localize "RQG.Actor.ExperienceRollSession.GainFixed"}}</button>
+    <button
+      type="button"
+      class="ui-control"
+      data-action="setGainKind"
+      data-gain-kind="random"
+      aria-pressed="{{#if (eq gainKind "random")}}true{{else}}false{{/if}}"
+      {{#unless canRollAll}}disabled{{/unless}}
+    ><i class="fa-solid fa-dice"></i> {{localize "RQG.Actor.ExperienceRollSession.GainRandom"}}</button>
+  </div>
+  <button type="button" data-action="rollAll" {{#unless canRollAll}}disabled{{/unless}}>
+    <i class="fa-solid fa-dice"></i> {{localize "RQG.Actor.ExperienceRollSession.RollAll"}}
+  </button>
+</section>

--- a/src/applications/experience-roll-session/experience-roll-session.css
+++ b/src/applications/experience-roll-session/experience-roll-session.css
@@ -1,0 +1,155 @@
+@layer system.base {
+  .experience-roll-session {
+    & .window-content {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+    }
+
+    & .experience-roll-session-header {
+      align-items: center;
+      border-bottom: 1px solid var(--color-border-light-secondary);
+      display: flex;
+      gap: 0.5rem;
+      justify-content: space-between;
+      padding-bottom: 0.5rem;
+    }
+
+    /* Same control Foundry's own chat log uses for its message-mode picker (public/gm/blind/self):
+       .split-button + button.ui-control, with aria-pressed carrying the active state. Reusing it
+       gets the border-joining, hover, focus and active treatment for free instead of inventing a
+       one-off toggle look - the only override needed is width/padding, since .ui-control is sized
+       for a single icon glyph and this toggle carries text labels instead. */
+    & .experience-roll-session-gain-toggle {
+      width: max-content;
+
+      & .ui-control {
+        font-size: var(--font-size-12);
+        font-weight: 500;
+        height: auto;
+        padding: 0.25rem 0.7rem;
+        width: auto;
+      }
+    }
+
+    & .experience-roll-session-body {
+      display: flex;
+      flex: 1 1 auto;
+      flex-direction: column;
+      gap: 0.65rem;
+      min-height: 0;
+      overflow-y: auto;
+    }
+
+    & .experience-roll-session-empty {
+      color: var(--color-text-secondary);
+      font-style: italic;
+      text-align: center;
+    }
+
+    /* Each item type gets its own fieldset - the same grouping convention the weapon usage tabs
+       use (.standard-form fieldset/legend, from Foundry's own form CSS), tinted and squared off
+       rather than left as Foundry's plain unfilled, rounded default. POW's odd-one-out math reads
+       as its own small decision instead of one more table row. */
+    & .experience-roll-session-group {
+      background: color-mix(in srgb, var(--color-border-light-secondary) 12%, transparent);
+      border-radius: 0;
+      gap: 0.35rem;
+    }
+
+    /* One flex-wrap line per row: name/value ride the left, target/gain/cult-bonus chips and
+       the Roll button ride the right, wrapping to a second line only when a row (POW, with its
+       extra cult-bonus chip) genuinely doesn't fit - never a mandated two-line layout. */
+    & .experience-roll-session-row {
+      align-items: center;
+      border-bottom: 1px dotted var(--color-border-light-tertiary);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem 0.5rem;
+      padding: 0.35rem 0;
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      &.disabled {
+        opacity: 0.6;
+      }
+
+      &.resolved {
+        opacity: 0.8;
+      }
+    }
+
+    & .experience-roll-session-row-name {
+      align-items: center;
+      display: flex;
+      flex: 1 1 auto;
+      gap: 0.35rem;
+      min-width: 8rem;
+
+      & img {
+        border: none;
+        height: 1.5em;
+        width: 1.5em;
+      }
+    }
+
+    & .experience-roll-session-row-value {
+      color: var(--color-text-secondary);
+      font-size: var(--font-size-12);
+    }
+
+    /* Target/gain all read as the same pill shape, so the row scans as "here are this check's
+       numbers" rather than differently-styled fragments of text. */
+    & .experience-roll-session-chip {
+      align-items: center;
+      background: color-mix(in srgb, var(--color-text-secondary) 15%, transparent);
+      border-radius: 999px;
+      display: inline-flex;
+      font-size: var(--font-size-13);
+      gap: 0.3rem;
+      padding: 0.08rem 0.55rem;
+      white-space: nowrap;
+
+      &[data-tooltip] {
+        cursor: help;
+      }
+    }
+
+    & .experience-roll-session-roll-btn {
+      margin-left: auto;
+    }
+
+    & .experience-roll-session-disabled-reason {
+      color: var(--color-text-secondary);
+      font-size: var(--font-size-12);
+      font-style: italic;
+      margin-left: auto;
+      text-align: right;
+    }
+
+    & .experience-roll-session-outcome {
+      align-items: center;
+      display: inline-flex;
+      font-size: var(--font-size-13);
+      gap: 0.35rem;
+      margin-left: auto;
+
+      &.success-level-2 {
+        color: var(--color-level-success, #1a7f37);
+      }
+
+      &.success-level-3 {
+        color: var(--color-level-error, #b00020);
+      }
+    }
+
+    & .experience-roll-session-value-change {
+      color: var(--color-text-secondary);
+      font-size: var(--font-size-12);
+      font-variant-numeric: tabular-nums;
+    }
+  }
+}

--- a/src/applications/experience-roll-session/experience-roll-session.ts
+++ b/src/applications/experience-roll-session/experience-roll-session.ts
@@ -1,0 +1,198 @@
+import type { CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
+import { systemId } from "../../system/config";
+import { templatePaths } from "../../system/load-handlebars-templates";
+import { getRequiredDomDataset, localize } from "../../system/util";
+import { getSpeakerCompat } from "../../system/fvtt-type-compat";
+import {
+  buildExperienceRollRowView,
+  type ExperienceRollEntry,
+  type ExperienceRollGainKind,
+  type ExperienceRollRowGroup,
+  getEligibleExperienceRollEntries,
+  getEligibleExperienceRollEntry,
+  groupExperienceRollRows,
+  rollAllExperienceRollEntries,
+  rollExperienceRollEntry,
+} from "../../rolls/improvement-roll/experience-roll-eligibility";
+import type { ImprovementResult } from "../../rolls/improvement-roll/improvement-roll.types";
+import {
+  showImprovementChatMessage,
+  showImprovementSummaryChatMessage,
+} from "../../rolls/improvement-roll/improvement-roll-presenter";
+
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+type ExperienceRollSessionContext = {
+  actorName: string;
+  groups: ExperienceRollRowGroup[];
+  isEmpty: boolean;
+  gainKind: ExperienceRollGainKind;
+  canRollAll: boolean;
+};
+
+/**
+ * Single-screen session for resolving every pending experience check on an adventurer at once
+ * (#912): abilities and POW alike, one Roll per row plus a Roll All. Eligibility is derived from
+ * live actor state on every render, so closing and reopening mid-session just shows whatever is
+ * still pending - the only session-local state is the fixed/random gain toggle and the set of rows
+ * this instance has already resolved, kept around so their outcome stays visible instead of
+ * vanishing the moment their hasExperience flag clears.
+ */
+export class ExperienceRollSession extends HandlebarsApplicationMixin(
+  ApplicationV2<ExperienceRollSessionContext>,
+) {
+  private readonly actor: CharacterActor;
+  private gainKind: ExperienceRollGainKind = "random";
+  private readonly resolvedThisSession = new Map<
+    string,
+    { entry: ExperienceRollEntry; result: ImprovementResult }
+  >();
+
+  static override DEFAULT_OPTIONS = {
+    id: "experience-roll-session",
+    classes: [systemId, "experience-roll-session"],
+    window: {
+      icon: "fa-solid fa-arrow-trend-up",
+      contentClasses: ["standard-form"],
+      resizable: true,
+    },
+    position: {
+      width: 560,
+      height: "auto" as const,
+    },
+    actions: {
+      rollRow: ExperienceRollSession.onRollRow,
+      rollAll: ExperienceRollSession.onRollAll,
+      setGainKind: ExperienceRollSession.onSetGainKind,
+    },
+  } satisfies foundry.applications.api.ApplicationV2.DefaultOptions;
+
+  static override PARTS = {
+    header: {
+      template: templatePaths.experienceRollSessionHeader,
+    },
+    body: {
+      template: templatePaths.experienceRollSessionBody,
+      scrollable: [""],
+    },
+  };
+
+  constructor(actor: CharacterActor) {
+    super();
+    this.actor = actor;
+  }
+
+  override get title(): string {
+    return localize("RQG.Actor.ExperienceRollSession.Title", { actorName: this.actor.name ?? "" });
+  }
+
+  override async _prepareContext(): Promise<ExperienceRollSessionContext> {
+    const actorName = this.actor.name ?? "";
+    const speaker = getSpeakerCompat({ actor: this.actor });
+    const liveEntries = getEligibleExperienceRollEntries(this.actor);
+    const liveIds = new Set(liveEntries.map((entry) => entry.id));
+
+    const rows = [
+      ...liveEntries.map((entry) =>
+        buildExperienceRollRowView(entry, this.gainKind, actorName, speaker),
+      ),
+      // Rows this instance already resolved keep showing their outcome even though the fresh
+      // eligibility list no longer includes them (their hasExperience flag is now cleared).
+      ...[...this.resolvedThisSession.values()]
+        .filter(({ entry }) => !liveIds.has(entry.id))
+        .map(({ entry, result }) =>
+          buildExperienceRollRowView(entry, this.gainKind, actorName, speaker, result),
+        ),
+    ];
+
+    const groups = groupExperienceRollRows(rows);
+
+    return {
+      actorName,
+      groups,
+      isEmpty: groups.length === 0,
+      gainKind: this.gainKind,
+      canRollAll: liveEntries.some((entry) => entry.rollable),
+    };
+  }
+
+  private static async onRollRow(
+    this: ExperienceRollSession,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): Promise<void> {
+    // Disabled immediately (rather than after the first await) so a fast double-click can't fire
+    // a second rollExperienceRollEntry before this row's actor.update() has cleared hasExperience -
+    // the render() below replaces this element regardless of which branch returns.
+    (target as HTMLButtonElement).disabled = true;
+
+    const id = getRequiredDomDataset(target, "row-id");
+    // Snapshot the entry being rolled purely to keep it visible afterwards - the actual roll
+    // re-derives and revalidates eligibility from live actor data itself (see
+    // rollExperienceRollEntry), the same "rebuild from live source on submit" rule the per-item
+    // improve dialogs follow.
+    const entry = getEligibleExperienceRollEntry(this.actor, id);
+    const actorName = this.actor.name ?? "";
+    const speaker = getSpeakerCompat({ actor: this.actor });
+
+    const resolution = await rollExperienceRollEntry(
+      this.actor,
+      id,
+      this.gainKind,
+      actorName,
+      speaker,
+    );
+
+    if (!resolution) {
+      ui.notifications?.error(localize("RQG.Actor.ExperienceRollSession.SourceNoLongerAvailable"));
+      await this.render();
+      return;
+    }
+
+    if (entry) {
+      this.resolvedThisSession.set(id, { entry, result: resolution.result });
+    }
+    await showImprovementChatMessage(resolution);
+    await this.render();
+  }
+
+  private static async onRollAll(
+    this: ExperienceRollSession,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): Promise<void> {
+    (target as HTMLButtonElement).disabled = true;
+
+    const actorName = this.actor.name ?? "";
+    const speaker = getSpeakerCompat({ actor: this.actor });
+
+    const results = await rollAllExperienceRollEntries(
+      this.actor,
+      this.gainKind,
+      actorName,
+      speaker,
+    );
+    if (results.length === 0) {
+      await this.render();
+      return;
+    }
+
+    for (const { entry, resolution } of results) {
+      this.resolvedThisSession.set(entry.id, { entry, result: resolution.result });
+    }
+    await showImprovementSummaryChatMessage(
+      results.map(({ resolution }) => resolution),
+      speaker,
+    );
+    await this.render();
+  }
+
+  private static onSetGainKind(
+    this: ExperienceRollSession,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): void {
+    this.gainKind = getRequiredDomDataset(target, "gain-kind") === "fixed" ? "fixed" : "random";
+    void this.render();
+  }
+}

--- a/src/applications/experience-roll-session/experience-roll-session.ts
+++ b/src/applications/experience-roll-session/experience-roll-session.ts
@@ -9,7 +9,6 @@ import {
   type ExperienceRollGainKind,
   type ExperienceRollRowGroup,
   getEligibleExperienceRollEntries,
-  getEligibleExperienceRollEntry,
   groupExperienceRollRows,
   rollAllExperienceRollEntries,
   rollExperienceRollEntry,
@@ -133,13 +132,10 @@ export class ExperienceRollSession extends HandlebarsApplicationMixin(
     (target as HTMLButtonElement).disabled = true;
 
     const id = getRequiredDomDataset(target, "row-id");
-    // Snapshot the entry being rolled purely to keep it visible afterwards - the actual roll
-    // re-derives and revalidates eligibility from live actor data itself (see
-    // rollExperienceRollEntry), the same "rebuild from live source on submit" rule the per-item
-    // improve dialogs follow.
-    const entry = getEligibleExperienceRollEntry(this.actor, id);
-
-    const resolution = await rollExperienceRollEntry(
+    // rollExperienceRollEntry re-derives and revalidates eligibility from live actor data itself
+    // (the same "rebuild from live source on submit" rule the per-item improve dialogs follow),
+    // and hands the revalidated entry back so this row can keep showing its outcome afterward.
+    const rolled = await rollExperienceRollEntry(
       this.actor,
       id,
       this.gainKind,
@@ -147,18 +143,16 @@ export class ExperienceRollSession extends HandlebarsApplicationMixin(
       this.speaker,
     );
 
-    if (!resolution) {
+    if (!rolled) {
       ui.notifications?.error(localize("RQG.Actor.ExperienceRollSession.SourceNoLongerAvailable"));
       await this.render();
       return;
     }
 
-    if (entry) {
-      this.resolvedThisSession.set(id, { entry, result: resolution.result });
-    }
+    this.resolvedThisSession.set(id, { entry: rolled.entry, result: rolled.resolution.result });
     // Independent of each other - the chat message doesn't gate the re-render - so run them
     // concurrently rather than stacking the chat card's dice-so-nice wait behind the render.
-    await Promise.all([showImprovementChatMessage(resolution), this.render()]);
+    await Promise.all([showImprovementChatMessage(rolled.resolution), this.render()]);
   }
 
   private static async onRollAll(

--- a/src/applications/experience-roll-session/experience-roll-session.ts
+++ b/src/applications/experience-roll-session/experience-roll-session.ts
@@ -82,13 +82,21 @@ export class ExperienceRollSession extends HandlebarsApplicationMixin(
     this.actor = actor;
   }
 
+  private get actorName(): string {
+    return this.actor.name ?? "";
+  }
+
+  private get speaker(): ChatMessage.SpeakerData {
+    return getSpeakerCompat({ actor: this.actor });
+  }
+
   override get title(): string {
-    return localize("RQG.Actor.ExperienceRollSession.Title", { actorName: this.actor.name ?? "" });
+    return localize("RQG.Actor.ExperienceRollSession.Title", { actorName: this.actorName });
   }
 
   override async _prepareContext(): Promise<ExperienceRollSessionContext> {
-    const actorName = this.actor.name ?? "";
-    const speaker = getSpeakerCompat({ actor: this.actor });
+    const actorName = this.actorName;
+    const speaker = this.speaker;
     const liveEntries = getEligibleExperienceRollEntries(this.actor);
     const liveIds = new Set(liveEntries.map((entry) => entry.id));
 
@@ -132,15 +140,13 @@ export class ExperienceRollSession extends HandlebarsApplicationMixin(
     // rollExperienceRollEntry), the same "rebuild from live source on submit" rule the per-item
     // improve dialogs follow.
     const entry = getEligibleExperienceRollEntry(this.actor, id);
-    const actorName = this.actor.name ?? "";
-    const speaker = getSpeakerCompat({ actor: this.actor });
 
     const resolution = await rollExperienceRollEntry(
       this.actor,
       id,
       this.gainKind,
-      actorName,
-      speaker,
+      this.actorName,
+      this.speaker,
     );
 
     if (!resolution) {
@@ -152,8 +158,9 @@ export class ExperienceRollSession extends HandlebarsApplicationMixin(
     if (entry) {
       this.resolvedThisSession.set(id, { entry, result: resolution.result });
     }
-    await showImprovementChatMessage(resolution);
-    await this.render();
+    // Independent of each other - the chat message doesn't gate the re-render - so run them
+    // concurrently rather than stacking the chat card's dice-so-nice wait behind the render.
+    await Promise.all([showImprovementChatMessage(resolution), this.render()]);
   }
 
   private static async onRollAll(
@@ -163,14 +170,11 @@ export class ExperienceRollSession extends HandlebarsApplicationMixin(
   ): Promise<void> {
     (target as HTMLButtonElement).disabled = true;
 
-    const actorName = this.actor.name ?? "";
-    const speaker = getSpeakerCompat({ actor: this.actor });
-
     const results = await rollAllExperienceRollEntries(
       this.actor,
       this.gainKind,
-      actorName,
-      speaker,
+      this.actorName,
+      this.speaker,
     );
     if (results.length === 0) {
       await this.render();
@@ -180,11 +184,13 @@ export class ExperienceRollSession extends HandlebarsApplicationMixin(
     for (const { entry, resolution } of results) {
       this.resolvedThisSession.set(entry.id, { entry, result: resolution.result });
     }
-    await showImprovementSummaryChatMessage(
-      results.map(({ resolution }) => resolution),
-      speaker,
-    );
-    await this.render();
+    await Promise.all([
+      showImprovementSummaryChatMessage(
+        results.map(({ resolution }) => resolution),
+        this.speaker,
+      ),
+      this.render(),
+    ]);
   }
 
   private static onSetGainKind(

--- a/src/applications/experience-roll-session/experience-roll-session.ts
+++ b/src/applications/experience-roll-session/experience-roll-session.ts
@@ -23,7 +23,6 @@ import {
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 type ExperienceRollSessionContext = {
-  actorName: string;
   groups: ExperienceRollRowGroup[];
   isEmpty: boolean;
   gainKind: ExperienceRollGainKind;
@@ -116,7 +115,6 @@ export class ExperienceRollSession extends HandlebarsApplicationMixin(
     const groups = groupExperienceRollRows(rows);
 
     return {
-      actorName,
       groups,
       isEmpty: groups.length === 0,
       gainKind: this.gainKind,
@@ -169,12 +167,13 @@ export class ExperienceRollSession extends HandlebarsApplicationMixin(
     target: HTMLElement,
   ): Promise<void> {
     (target as HTMLButtonElement).disabled = true;
+    const speaker = this.speaker;
 
     const results = await rollAllExperienceRollEntries(
       this.actor,
       this.gainKind,
       this.actorName,
-      this.speaker,
+      speaker,
     );
     if (results.length === 0) {
       await this.render();
@@ -187,7 +186,7 @@ export class ExperienceRollSession extends HandlebarsApplicationMixin(
     await Promise.all([
       showImprovementSummaryChatMessage(
         results.map(({ resolution }) => resolution),
-        this.speaker,
+        speaker,
       ),
       this.render(),
     ]);

--- a/src/applications/improve-dialogs/improve-characteristic-dialog.ts
+++ b/src/applications/improve-dialogs/improve-characteristic-dialog.ts
@@ -14,6 +14,7 @@ import {
   syncImprovementSelectionUi,
 } from "./improve-dialog-shared";
 import {
+  applyCharacteristicGain,
   buildCharacteristicAdapter,
   buildCharacteristicImprovementRequest,
   type CharacteristicImprovementData,
@@ -209,26 +210,12 @@ class ImproveCharacteristicDialog extends HandlebarsApplicationMixin(
     );
     const resolution = await resolveImprovement(request);
     await showImprovementChatMessage(resolution);
-    await this.applyCharacteristicGain(improvementData, resolution.result.gain);
-  }
-
-  private async applyCharacteristicGain(
-    improvementData: CharacteristicImprovementData,
-    gain: number,
-  ): Promise<void> {
-    const charUpdate: any = {
-      system: {
-        characteristics: {
-          [this.characteristicName]: { value: improvementData.chance + gain },
-        },
-      },
-    };
-
-    if (improvementData.hasExperience) {
-      charUpdate.system.characteristics[this.characteristicName].hasExperience = false;
-    }
-
-    await this.actor.update(charUpdate);
+    await applyCharacteristicGain(
+      this.actor,
+      this.characteristicName,
+      improvementData,
+      resolution.result.gain,
+    );
   }
 }
 

--- a/src/rolls/improvement-roll/characteristic-improvement-adapter.ts
+++ b/src/rolls/improvement-roll/characteristic-improvement-adapter.ts
@@ -65,6 +65,31 @@ export function isSupportedCharacteristicGainType(
 }
 
 /**
+ * Applies a resolved gain to a characteristic: writes the new value and clears hasExperience only
+ * when it was actually set (training/research gains never had it set to begin with).
+ */
+export async function applyCharacteristicGain(
+  actor: RqgActor,
+  characteristicName: keyof Characteristics,
+  improvementData: CharacteristicImprovementData,
+  gain: number,
+): Promise<void> {
+  const charUpdate: any = {
+    system: {
+      characteristics: {
+        [characteristicName]: { value: improvementData.chance + gain },
+      },
+    },
+  };
+
+  if (improvementData.hasExperience) {
+    charUpdate.system.characteristics[characteristicName].hasExperience = false;
+  }
+
+  await actor.update(charUpdate);
+}
+
+/**
  * Maps a chosen gain type onto the shared improvement contract.
  *
  * Characteristic improvements are roll-under: the POW-gain-roll style check gains when the roll

--- a/src/rolls/improvement-roll/experience-roll-eligibility.test.ts
+++ b/src/rolls/improvement-roll/experience-roll-eligibility.test.ts
@@ -346,11 +346,11 @@ describe("rollExperienceRollEntry", () => {
     };
     queue = [{ total: 1 }, { total: 2 }]; // gate: 1 <= 40 succeeds; gain: 1d3-1 -> 2
 
-    const resolution = await rollExperienceRollEntry(actor, "power", "random", "Vasana", speaker);
+    const rolled = await rollExperienceRollEntry(actor, "power", "random", "Vasana", speaker);
 
-    expect(resolution).toBeDefined();
-    expect(resolution!.result.request.gate).toMatchObject({ comparator: "roll-under" });
-    expect(resolution!.result.succeeded).toBe(true);
+    expect(rolled).toBeDefined();
+    expect(rolled!.resolution.result.request.gate).toMatchObject({ comparator: "roll-under" });
+    expect(rolled!.resolution.result.succeeded).toBe(true);
     expect(actor.update).toHaveBeenCalledWith(
       expect.objectContaining({
         system: expect.objectContaining({
@@ -367,11 +367,11 @@ describe("rollExperienceRollEntry", () => {
     const actor = characterActor({ items: [skill] });
     queue = [{ total: 99 }, { total: 4 }]; // gate: 99 > threshold succeeds; gain: 4
 
-    const resolution = await rollExperienceRollEntry(actor, "skill1", "random", "Vasana", speaker);
+    const rolled = await rollExperienceRollEntry(actor, "skill1", "random", "Vasana", speaker);
 
-    expect(resolution).toBeDefined();
-    expect(resolution!.result.request.gate).toMatchObject({ comparator: "roll-over" });
-    expect(resolution!.result.succeeded).toBe(true);
+    expect(rolled).toBeDefined();
+    expect(rolled!.resolution.result.request.gate).toMatchObject({ comparator: "roll-over" });
+    expect(rolled!.resolution.result.succeeded).toBe(true);
     expect(skill.system.applyChanceGain).toHaveBeenCalledWith(4);
   });
 
@@ -380,10 +380,10 @@ describe("rollExperienceRollEntry", () => {
     const actor = characterActor({ items: [skill] });
     queue = [{ total: 1 }]; // gate: 1 > 40 fails, no gain roll happens
 
-    const resolution = await rollExperienceRollEntry(actor, "skill1", "random", "Vasana", speaker);
+    const rolled = await rollExperienceRollEntry(actor, "skill1", "random", "Vasana", speaker);
 
-    expect(resolution!.result.succeeded).toBe(false);
-    expect(resolution!.result.gain).toBe(0);
+    expect(rolled!.resolution.result.succeeded).toBe(false);
+    expect(rolled!.resolution.result.gain).toBe(0);
     expect(skill.system.applyChanceGain).toHaveBeenCalledWith(0);
   });
 });

--- a/src/rolls/improvement-roll/experience-roll-eligibility.test.ts
+++ b/src/rolls/improvement-roll/experience-roll-eligibility.test.ts
@@ -1,0 +1,447 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Queued outcomes the fake Roll hands out, in the order the resolver constructs rolls
+ * (gate, then gain) - mirrors improvement-roll.test.ts's fake since resolveImprovement is
+ * exercised indirectly through rollExperienceRollEntry/rollAllExperienceRollEntries here. */
+type QueuedRoll = { total: number };
+let queue: QueuedRoll[] = [];
+
+class FakeRoll {
+  formula: string;
+  total: number | undefined;
+
+  constructor(formula: string) {
+    this.formula = formula;
+  }
+
+  async evaluate(): Promise<this> {
+    this.total = queue.shift()?.total ?? 1;
+    return this;
+  }
+}
+
+(globalThis as any).foundry.dice.Roll = FakeRoll;
+
+// Imported after the Roll stub is in place - `import Roll = foundry.dice.Roll` in
+// improvement-roll.ts captures the binding at module evaluation time.
+const {
+  buildExperienceRollRowView,
+  getEligibleExperienceRollEntries,
+  groupExperienceRollRows,
+  rollAllExperienceRollEntries,
+  rollExperienceRollEntry,
+} = await import("./experience-roll-eligibility");
+
+function createSkillItem(overrides: Partial<any> = {}) {
+  return {
+    id: "skill1",
+    type: "skill",
+    name: "Sword",
+    img: "sword.png",
+    system: { category: "meleeWeapons", applyChanceGain: vi.fn() },
+    _source: { system: { baseChance: 40, gainedChance: 0, hasExperience: true } },
+    ...overrides,
+  } as any;
+}
+
+function characterActor(overrides: Partial<any> = {}) {
+  const neutral = { value: 13 };
+  const actor: any = {
+    type: "character",
+    items: [],
+    update: vi.fn(),
+    _source: {
+      system: {
+        characteristics: {
+          strength: neutral,
+          constitution: neutral,
+          size: neutral,
+          dexterity: neutral,
+          intelligence: neutral,
+          power: { value: 13, hasExperience: false, formula: "3d6" },
+          charisma: neutral,
+        },
+        attributes: { isCreature: false },
+      },
+    },
+    ...overrides,
+  };
+  for (const item of actor.items) {
+    item.parent = actor;
+  }
+  // Mirrors Foundry's real Collection#get, which getEligibleExperienceRollEntry relies on.
+  actor.items.get = (id: string) => actor.items.find((item: any) => item.id === id);
+  return actor;
+}
+
+beforeEach(() => {
+  queue = [];
+  const evaluate = vi.fn(async () => ({ total: 18 }));
+  const evaluateSync = vi.fn(() => ({ total: 18 }));
+  vi.stubGlobal("Roll", {
+    create: vi.fn(() => ({ evaluate, evaluateSync })),
+  });
+});
+
+describe("getEligibleExperienceRollEntries", () => {
+  it("returns an empty list when nothing has a pending experience check", () => {
+    const actor = characterActor();
+    expect(getEligibleExperienceRollEntries(actor)).toEqual([]);
+  });
+
+  it("collects an ability item with hasExperience set", () => {
+    const actor = characterActor({ items: [createSkillItem()] });
+
+    const entries = getEligibleExperienceRollEntries(actor);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ id: "skill1", kind: "skill", rollable: true });
+  });
+
+  it("ignores ability items without hasExperience set", () => {
+    const actor = characterActor({
+      items: [
+        createSkillItem({
+          _source: { system: { baseChance: 40, gainedChance: 0, hasExperience: false } },
+        }),
+      ],
+    });
+
+    expect(getEligibleExperienceRollEntries(actor)).toEqual([]);
+  });
+
+  it("ignores non-ability item types", () => {
+    const gear = { id: "gear1", type: "gear", _source: { system: {} } };
+    const actor = characterActor({ items: [gear] });
+
+    expect(getEligibleExperienceRollEntries(actor)).toEqual([]);
+  });
+
+  it("collects POW when its source hasExperience flag is set", () => {
+    const actor = characterActor();
+    actor._source.system.characteristics.power.hasExperience = true;
+
+    const entries = getEligibleExperienceRollEntries(actor);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ id: "power", kind: "power", rollable: true });
+  });
+
+  it("lists POW at species max as disabled with a reason rather than dropping it", () => {
+    const actor = characterActor();
+    actor._source.system.characteristics.power = {
+      value: 21,
+      hasExperience: true,
+      formula: "3d6",
+    };
+
+    const entries = getEligibleExperienceRollEntries(actor);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.rollable).toBe(false);
+    expect(entries[0]!.disabledReasonText).toBeTruthy();
+  });
+
+  it("lists a Rune at its 100% cap as disabled with a reason", () => {
+    const rune = {
+      id: "rune1",
+      type: "rune",
+      name: "Fire",
+      img: null,
+      system: { rune: "Fire", applyChanceGain: vi.fn() },
+      _source: { system: { chance: 100, hasExperience: true } },
+    };
+    const actor = characterActor({ items: [rune] });
+
+    const entries = getEligibleExperienceRollEntries(actor);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.rollable).toBe(false);
+    expect(entries[0]!.disabledReasonText).toBeTruthy();
+  });
+
+  it("mixes abilities and POW in one list", () => {
+    const actor = characterActor({ items: [createSkillItem()] });
+    actor._source.system.characteristics.power.hasExperience = true;
+
+    const entries = getEligibleExperienceRollEntries(actor);
+
+    expect(entries.map((e) => e.kind).sort()).toEqual(["power", "skill"]);
+  });
+});
+
+describe("buildExperienceRollRowView", () => {
+  const speaker = {} as ChatMessage.SpeakerData;
+
+  it("shows abilities as roll-over (with a > symbol) and POW as roll-under (no symbol)", () => {
+    const actor = characterActor({ items: [createSkillItem()] });
+    actor._source.system.characteristics.power.hasExperience = true;
+
+    const entries = getEligibleExperienceRollEntries(actor);
+    const rows = entries.map((entry) =>
+      buildExperienceRollRowView(entry, "random", "Vasana", speaker),
+    );
+
+    const skillRow = rows.find((r) => r.kind === "skill")!;
+    const powerRow = rows.find((r) => r.kind === "power")!;
+
+    expect(skillRow.comparatorSymbol).toBe(">");
+    expect(powerRow.comparatorSymbol).toBe("");
+  });
+
+  it("surfaces the cult standing bonus in the POW row's target tooltip", () => {
+    const actor = characterActor({
+      items: [{ type: "cult", system: { joinedCults: [{ rank: "runePriest" }] } }],
+    });
+    actor._source.system.characteristics.power.hasExperience = true;
+
+    const entries = getEligibleExperienceRollEntries(actor);
+    const row = buildExperienceRollRowView(entries[0]!, "random", "Vasana", speaker);
+
+    expect(row.targetTooltip).toContain("20");
+    expect(row.targetTooltip).toContain("RQG.Actor.RuneMagic.CultRank.runePriest");
+  });
+
+  it("fills in the resolved outcome when a result is passed in", () => {
+    const actor = characterActor({ items: [createSkillItem()] });
+
+    const entries = getEligibleExperienceRollEntries(actor);
+    const row = buildExperienceRollRowView(entries[0]!, "random", "Vasana", speaker, {
+      request: {
+        source: "experience",
+        name: "Sword",
+        typeLocName: "Skill",
+        actorName: "Vasana",
+        currentValue: 40,
+        valueSuffix: "%",
+        gain: { kind: "random", formula: "1d6" },
+        gateBreakdownChips: [],
+        speaker,
+      } as any,
+      succeeded: true,
+      gain: 3,
+      previousValue: 40,
+      newValue: 43,
+    });
+
+    expect(row.resolved?.increased).toBe(true);
+    expect(row.resolved?.gainDisplay).toBe("3%");
+  });
+
+  it("treats a passed gate that rolls a 0 gain as not increased, not a false success", () => {
+    const actor = characterActor({ items: [createSkillItem()] });
+
+    const entries = getEligibleExperienceRollEntries(actor);
+    const row = buildExperienceRollRowView(entries[0]!, "random", "Vasana", speaker, {
+      request: {
+        source: "experience",
+        name: "Sword",
+        typeLocName: "Skill",
+        actorName: "Vasana",
+        currentValue: 40,
+        valueSuffix: "%",
+        gain: { kind: "random", formula: "1d6-1" },
+        gateBreakdownChips: [],
+        speaker,
+      } as any,
+      succeeded: true,
+      gain: 0,
+      previousValue: 40,
+      newValue: 40,
+    });
+
+    expect(row.resolved?.increased).toBe(false);
+    expect(row.resolved?.gainDisplay).toBe("0%");
+    expect(row.resolved?.valueChangeDisplay).toBeUndefined();
+  });
+
+  it("shows the fixed/random icon matching the current toggle for a pending row", () => {
+    const actor = characterActor({ items: [createSkillItem()] });
+
+    const entries = getEligibleExperienceRollEntries(actor);
+    const fixedRow = buildExperienceRollRowView(entries[0]!, "fixed", "Vasana", speaker);
+    const randomRow = buildExperienceRollRowView(entries[0]!, "random", "Vasana", speaker);
+
+    expect(fixedRow.gainIcon).toBe("fa-hashtag");
+    expect(randomRow.gainIcon).toBe("fa-dice");
+  });
+
+  it("shows a resolved row's icon for the gain kind it was actually rolled with, not the current toggle", () => {
+    const actor = characterActor({ items: [createSkillItem()] });
+
+    const entries = getEligibleExperienceRollEntries(actor);
+    // Rolled while "fixed" was selected, but the toggle has since moved to "random".
+    const row = buildExperienceRollRowView(entries[0]!, "random", "Vasana", speaker, {
+      request: {
+        source: "experience",
+        name: "Sword",
+        typeLocName: "Skill",
+        actorName: "Vasana",
+        currentValue: 40,
+        valueSuffix: "%",
+        gain: { kind: "fixed", formula: "3" },
+        gateBreakdownChips: [],
+        speaker,
+      } as any,
+      succeeded: true,
+      gain: 3,
+      previousValue: 40,
+      newValue: 43,
+    });
+
+    expect(row.resolved?.gainIcon).toBe("fa-hashtag");
+  });
+});
+
+describe("groupExperienceRollRows", () => {
+  it("groups by kind in power/rune/passion/skill order and drops empty groups", () => {
+    const rows = [
+      { kind: "power", typeLocName: "Characteristic" },
+      { kind: "rune", typeLocName: "Rune" },
+      { kind: "skill", typeLocName: "Skill" },
+      { kind: "skill", typeLocName: "Skill" },
+    ] as any;
+
+    const groups = groupExperienceRollRows(rows);
+
+    expect(groups.map((g) => g.kind)).toEqual(["power", "rune", "skill"]);
+    expect(groups.find((g) => g.kind === "skill")?.rows).toHaveLength(2);
+  });
+
+  it("returns an empty list for no rows", () => {
+    expect(groupExperienceRollRows([])).toEqual([]);
+  });
+});
+
+describe("rollExperienceRollEntry", () => {
+  const speaker = {} as ChatMessage.SpeakerData;
+
+  it("returns undefined and does not write when the entry is no longer eligible", async () => {
+    const actor = characterActor();
+
+    const result = await rollExperienceRollEntry(actor, "power", "random", "Vasana", speaker);
+
+    expect(result).toBeUndefined();
+    expect(actor.update).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for a disabled (species-max) entry rather than rolling it", async () => {
+    const actor = characterActor();
+    actor._source.system.characteristics.power = {
+      value: 21,
+      hasExperience: true,
+      formula: "3d6",
+    };
+
+    const result = await rollExperienceRollEntry(actor, "power", "random", "Vasana", speaker);
+
+    expect(result).toBeUndefined();
+    expect(actor.update).not.toHaveBeenCalled();
+  });
+
+  it("rolls POW under (speciesMax - POW) x 5 and applies the gain, clearing hasExperience", async () => {
+    const actor = characterActor();
+    actor._source.system.characteristics.power = {
+      value: 13,
+      hasExperience: true,
+      formula: "3d6",
+    };
+    queue = [{ total: 1 }, { total: 2 }]; // gate: 1 <= 40 succeeds; gain: 1d3-1 -> 2
+
+    const resolution = await rollExperienceRollEntry(actor, "power", "random", "Vasana", speaker);
+
+    expect(resolution).toBeDefined();
+    expect(resolution!.result.request.gate).toMatchObject({ comparator: "roll-under" });
+    expect(resolution!.result.succeeded).toBe(true);
+    expect(actor.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.objectContaining({
+          characteristics: expect.objectContaining({
+            power: expect.objectContaining({ hasExperience: false, value: 15 }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("rolls an ability over its chance and applies the gain through the item", async () => {
+    const skill = createSkillItem();
+    const actor = characterActor({ items: [skill] });
+    queue = [{ total: 99 }, { total: 4 }]; // gate: 99 > threshold succeeds; gain: 4
+
+    const resolution = await rollExperienceRollEntry(actor, "skill1", "random", "Vasana", speaker);
+
+    expect(resolution).toBeDefined();
+    expect(resolution!.result.request.gate).toMatchObject({ comparator: "roll-over" });
+    expect(resolution!.result.succeeded).toBe(true);
+    expect(skill.system.applyChanceGain).toHaveBeenCalledWith(4);
+  });
+
+  it("fails the gate without applying any gain", async () => {
+    const skill = createSkillItem();
+    const actor = characterActor({ items: [skill] });
+    queue = [{ total: 1 }]; // gate: 1 > 40 fails, no gain roll happens
+
+    const resolution = await rollExperienceRollEntry(actor, "skill1", "random", "Vasana", speaker);
+
+    expect(resolution!.result.succeeded).toBe(false);
+    expect(resolution!.result.gain).toBe(0);
+    expect(skill.system.applyChanceGain).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("rollAllExperienceRollEntries", () => {
+  const speaker = {} as ChatMessage.SpeakerData;
+
+  it("returns one resolution per rollable entry over a mixed queue", async () => {
+    const skill = createSkillItem();
+    const actor = characterActor({ items: [skill] });
+    actor._source.system.characteristics.power.hasExperience = true;
+    queue = [
+      { total: 1 },
+      { total: 2 }, // POW gate succeeds, gain 2 (POW rolls first - see below)
+      { total: 99 },
+      { total: 4 }, // skill gate succeeds, gain 4
+    ];
+
+    const resolutions = await rollAllExperienceRollEntries(actor, "random", "Vasana", speaker);
+
+    expect(resolutions).toHaveLength(2);
+    expect(actor.update).toHaveBeenCalledTimes(1);
+    expect(skill.system.applyChanceGain).toHaveBeenCalledTimes(1);
+  });
+
+  it("rolls POW before abilities, since a POW gain can shift a skill category modifier for the rest of the batch", async () => {
+    const skill = createSkillItem();
+    const actor = characterActor({ items: [skill] });
+    actor._source.system.characteristics.power.hasExperience = true;
+    queue = [{ total: 1 }, { total: 2 }, { total: 99 }, { total: 4 }];
+
+    const results = await rollAllExperienceRollEntries(actor, "random", "Vasana", speaker);
+
+    expect(results[0]!.entry.kind).toBe("power");
+    expect(results[1]!.entry.kind).toBe("skill");
+  });
+
+  it("skips disabled entries and returns an empty list when nothing is rollable", async () => {
+    const actor = characterActor();
+    actor._source.system.characteristics.power = {
+      value: 21,
+      hasExperience: true,
+      formula: "3d6",
+    };
+
+    const resolutions = await rollAllExperienceRollEntries(actor, "random", "Vasana", speaker);
+
+    expect(resolutions).toEqual([]);
+    expect(actor.update).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty list for an empty queue", async () => {
+    const actor = characterActor();
+
+    const resolutions = await rollAllExperienceRollEntries(actor, "random", "Vasana", speaker);
+
+    expect(resolutions).toEqual([]);
+  });
+});

--- a/src/rolls/improvement-roll/experience-roll-eligibility.test.ts
+++ b/src/rolls/improvement-roll/experience-roll-eligibility.test.ts
@@ -44,6 +44,30 @@ function createSkillItem(overrides: Partial<any> = {}) {
   } as any;
 }
 
+/** A resolved ImprovementResult for a 40%-base Sword skill, passed to buildExperienceRollRowView -
+ * shared shape for the "resolved row" tests below, which only vary gain/succeeded/newValue/request.gain. */
+function resolvedResult({ request: requestOverrides, ...overrides }: Partial<any> = {}) {
+  return {
+    request: {
+      source: "experience",
+      name: "Sword",
+      typeLocName: "Skill",
+      actorName: "Vasana",
+      currentValue: 40,
+      valueSuffix: "%",
+      gain: { kind: "random", formula: "1d6" },
+      gateBreakdownChips: [],
+      speaker: {},
+      ...requestOverrides,
+    },
+    succeeded: true,
+    gain: 3,
+    previousValue: 40,
+    newValue: 43,
+    ...overrides,
+  } as any;
+}
+
 function characterActor(overrides: Partial<any> = {}) {
   const neutral = { value: 13 };
   const actor: any = {
@@ -206,23 +230,13 @@ describe("buildExperienceRollRowView", () => {
     const actor = characterActor({ items: [createSkillItem()] });
 
     const entries = getEligibleExperienceRollEntries(actor);
-    const row = buildExperienceRollRowView(entries[0]!, "random", "Vasana", speaker, {
-      request: {
-        source: "experience",
-        name: "Sword",
-        typeLocName: "Skill",
-        actorName: "Vasana",
-        currentValue: 40,
-        valueSuffix: "%",
-        gain: { kind: "random", formula: "1d6" },
-        gateBreakdownChips: [],
-        speaker,
-      } as any,
-      succeeded: true,
-      gain: 3,
-      previousValue: 40,
-      newValue: 43,
-    });
+    const row = buildExperienceRollRowView(
+      entries[0]!,
+      "random",
+      "Vasana",
+      speaker,
+      resolvedResult(),
+    );
 
     expect(row.resolved?.increased).toBe(true);
     expect(row.resolved?.gainDisplay).toBe("3%");
@@ -232,23 +246,17 @@ describe("buildExperienceRollRowView", () => {
     const actor = characterActor({ items: [createSkillItem()] });
 
     const entries = getEligibleExperienceRollEntries(actor);
-    const row = buildExperienceRollRowView(entries[0]!, "random", "Vasana", speaker, {
-      request: {
-        source: "experience",
-        name: "Sword",
-        typeLocName: "Skill",
-        actorName: "Vasana",
-        currentValue: 40,
-        valueSuffix: "%",
-        gain: { kind: "random", formula: "1d6-1" },
-        gateBreakdownChips: [],
-        speaker,
-      } as any,
-      succeeded: true,
-      gain: 0,
-      previousValue: 40,
-      newValue: 40,
-    });
+    const row = buildExperienceRollRowView(
+      entries[0]!,
+      "random",
+      "Vasana",
+      speaker,
+      resolvedResult({
+        request: { gain: { kind: "random", formula: "1d6-1" } },
+        gain: 0,
+        newValue: 40,
+      }),
+    );
 
     expect(row.resolved?.increased).toBe(false);
     expect(row.resolved?.gainDisplay).toBe("0%");
@@ -271,23 +279,13 @@ describe("buildExperienceRollRowView", () => {
 
     const entries = getEligibleExperienceRollEntries(actor);
     // Rolled while "fixed" was selected, but the toggle has since moved to "random".
-    const row = buildExperienceRollRowView(entries[0]!, "random", "Vasana", speaker, {
-      request: {
-        source: "experience",
-        name: "Sword",
-        typeLocName: "Skill",
-        actorName: "Vasana",
-        currentValue: 40,
-        valueSuffix: "%",
-        gain: { kind: "fixed", formula: "3" },
-        gateBreakdownChips: [],
-        speaker,
-      } as any,
-      succeeded: true,
-      gain: 3,
-      previousValue: 40,
-      newValue: 43,
-    });
+    const row = buildExperienceRollRowView(
+      entries[0]!,
+      "random",
+      "Vasana",
+      speaker,
+      resolvedResult({ request: { gain: { kind: "fixed", formula: "3" } } }),
+    );
 
     expect(row.resolved?.gainIcon).toBe("fa-hashtag");
   });

--- a/src/rolls/improvement-roll/experience-roll-eligibility.ts
+++ b/src/rolls/improvement-roll/experience-roll-eligibility.ts
@@ -95,7 +95,7 @@ export function getEligibleExperienceRollEntries(actor: CharacterActor): Experie
  * revalidates against on every roll, so a Roll All batch (or a lone row click) only ever pays for the
  * one entry's adapter build (including POW's dice-formula evaluation) instead of the whole actor's.
  */
-export function getEligibleExperienceRollEntry(
+function getEligibleExperienceRollEntry(
   actor: CharacterActor,
   entryId: string,
 ): ExperienceRollEntry | undefined {
@@ -321,11 +321,17 @@ async function applyExperienceRollGain(
   await entry.item.system.applyChanceGain(gain);
 }
 
+export type ExperienceRollAllResult = {
+  entry: ExperienceRollEntry;
+  resolution: ImprovementResolution;
+};
+
 /**
  * Rolls a single entry by id, re-deriving eligibility from live actor data first - the entry
  * handed in by the caller can have gone stale (another route cleared the flag, or pushed a Rune to
  * its cap) while the session was open, mirroring the per-item improve dialogs' submit-time
- * revalidation.
+ * revalidation. Returns the revalidated entry alongside the resolution so a single-row caller
+ * doesn't need its own separate lookup just to keep that row visible afterward.
  */
 export async function rollExperienceRollEntry(
   actor: CharacterActor,
@@ -333,7 +339,7 @@ export async function rollExperienceRollEntry(
   gainKind: ExperienceRollGainKind,
   actorName: string,
   speaker: ChatMessage.SpeakerData,
-): Promise<ImprovementResolution | undefined> {
+): Promise<ExperienceRollAllResult | undefined> {
   const liveEntry = getEligibleExperienceRollEntry(actor, entryId);
   if (!liveEntry || !liveEntry.rollable) {
     return undefined;
@@ -342,13 +348,8 @@ export async function rollExperienceRollEntry(
   const request = buildExperienceRollRequest(liveEntry, gainKind, actorName, speaker);
   const resolution = await resolveImprovement(request);
   await applyExperienceRollGain(actor, liveEntry, resolution.result.gain);
-  return resolution;
+  return { entry: liveEntry, resolution };
 }
-
-export type ExperienceRollAllResult = {
-  entry: ExperienceRollEntry;
-  resolution: ImprovementResolution;
-};
 
 /**
  * Rolls every currently-rollable entry, sequentially - each write completes before the next
@@ -380,9 +381,13 @@ export async function rollAllExperienceRollEntries(
     if (!entry.rollable) {
       continue;
     }
-    const resolution = await rollExperienceRollEntry(actor, entry.id, gainKind, actorName, speaker);
-    if (resolution) {
-      results.push({ entry, resolution });
+    const rolled = await rollExperienceRollEntry(actor, entry.id, gainKind, actorName, speaker);
+    if (rolled) {
+      // Keeps this batch's own pre-roll snapshot rather than rolled.entry (which reflects
+      // whatever state the actor was in for THIS specific roll) - later rows in the batch would
+      // otherwise show a POW-shifted category modifier baked into a "before" value the player
+      // never saw, since the whole batch's rows were all rendered from the same initial snapshot.
+      results.push({ entry, resolution: rolled.resolution });
     }
   }
   return results;

--- a/src/rolls/improvement-roll/experience-roll-eligibility.ts
+++ b/src/rolls/improvement-roll/experience-roll-eligibility.ts
@@ -106,6 +106,9 @@ export function getEligibleExperienceRollEntry(
   return item ? buildAbilityEntryIfEligible(item) : undefined;
 }
 
+// Typed against isDocumentSubType's own parameter, not RqgItem: the two call sites below pass the
+// document type actor.items actually yields (iteration and .get() both produce a structurally
+// narrower type than the hand-written RqgItem class), which fails RqgItem's stricter shape.
 function buildAbilityEntryIfEligible<T extends Parameters<typeof isDocumentSubType>[0]>(
   item: T,
 ): ExperienceRollAbilityEntry | undefined {

--- a/src/rolls/improvement-roll/experience-roll-eligibility.ts
+++ b/src/rolls/improvement-roll/experience-roll-eligibility.ts
@@ -1,0 +1,386 @@
+import { type AbilityItem, abilityItemTypes } from "@item-model/item-types.ts";
+import type { CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
+import { isDocumentSubType, localize } from "../../system/util";
+import { AbilitySuccessLevelEnum } from "../ability-roll/ability-roll.defs";
+import {
+  type AbilityImprovementData,
+  type AbilityType,
+  buildAbilityImprovementData,
+  buildAbilityImprovementRequest,
+} from "./ability-improvement-adapter";
+import {
+  applyCharacteristicGain,
+  buildCharacteristicAdapter,
+  buildCharacteristicImprovementRequest,
+  type CharacteristicImprovementData,
+} from "./characteristic-improvement-adapter";
+import { getGateDisplay } from "./improvement-roll-presenter";
+import { resolveImprovement } from "./improvement-roll";
+import type {
+  ImprovementDetailRow,
+  ImprovementRequest,
+  ImprovementResolution,
+  ImprovementResult,
+} from "./improvement-roll.types";
+
+/** Every source of an experience-driven improvement the session can list. POW is the only
+ * characteristic with an experience path (Core p.418) - the rest improve via training/research only. */
+export type ExperienceRollEntryKind = AbilityType | "power";
+
+type ExperienceRollEntryBase = {
+  id: string;
+  kind: ExperienceRollEntryKind;
+  name: string;
+  typeLocName: string;
+  img: string | null;
+  currentValueDisplay: string;
+  /** Mirrors the adapter's canExperience - false only when hasExperience is set but the source is
+   * otherwise capped (a Rune at 100%, POW at species max, Core p.415/p.418). */
+  rollable: boolean;
+  disabledReasonText?: string;
+};
+
+export type ExperienceRollAbilityEntry = ExperienceRollEntryBase & {
+  kind: AbilityType;
+  item: AbilityItem;
+  improvementData: AbilityImprovementData;
+};
+
+export type ExperienceRollCharacteristicEntry = ExperienceRollEntryBase & {
+  kind: "power";
+  improvementData: CharacteristicImprovementData;
+};
+
+export type ExperienceRollEntry = ExperienceRollAbilityEntry | ExperienceRollCharacteristicEntry;
+
+export type ExperienceRollGainKind = "fixed" | "random";
+
+/** Same icon the session's own fixed/random toggle uses (RQG.ExperienceRollSession.GainFixed/
+ * GainRandom), so a row's gain chip always shows the method it actually used - the current
+ * toggle for a pending row, or whatever was selected at roll time for a resolved one, which can
+ * differ if the toggle was flipped mid-session. */
+function getGainKindIcon(gainKind: ExperienceRollGainKind): string {
+  return gainKind === "fixed" ? "fa-hashtag" : "fa-dice";
+}
+
+/**
+ * Collects every ability (skill/passion/rune) and POW with a pending experience check, abilities
+ * and POW alike, via the #910 adapters - the eligibility rule the header button and session both
+ * key off (Core p.415, p.418).
+ *
+ * An entry with hasExperience set but no longer rollable (a Rune at its 100% cap, POW at species
+ * max) is still included, disabled with a reason, rather than silently dropped - otherwise the
+ * flag would stay set forever with no visible explanation.
+ */
+export function getEligibleExperienceRollEntries(actor: CharacterActor): ExperienceRollEntry[] {
+  const entries: ExperienceRollEntry[] = [];
+
+  for (const item of actor.items) {
+    const entry = buildAbilityEntryIfEligible(item);
+    if (entry) {
+      entries.push(entry);
+    }
+  }
+
+  const powerEntry = buildPowerEntryIfEligible(actor);
+  if (powerEntry) {
+    entries.push(powerEntry);
+  }
+
+  return entries;
+}
+
+/**
+ * Looks up a single entry by id without rebuilding the rest of the list - what rollExperienceRollEntry
+ * revalidates against on every roll, so a Roll All batch (or a lone row click) only ever pays for the
+ * one entry's adapter build (including POW's dice-formula evaluation) instead of the whole actor's.
+ */
+export function getEligibleExperienceRollEntry(
+  actor: CharacterActor,
+  entryId: string,
+): ExperienceRollEntry | undefined {
+  if (entryId === "power") {
+    return buildPowerEntryIfEligible(actor);
+  }
+  const item = actor.items.get(entryId);
+  return item ? buildAbilityEntryIfEligible(item) : undefined;
+}
+
+function buildAbilityEntryIfEligible<T extends Parameters<typeof isDocumentSubType>[0]>(
+  item: T,
+): ExperienceRollAbilityEntry | undefined {
+  if (!isDocumentSubType<AbilityItem>(item, abilityItemTypes)) {
+    return undefined;
+  }
+  const sourceHasExperience = Boolean(
+    (item._source.system as { hasExperience?: boolean }).hasExperience,
+  );
+  if (!sourceHasExperience) {
+    return undefined;
+  }
+
+  const improvementData = buildAbilityImprovementData(item);
+  return {
+    id: item.id ?? "",
+    kind: improvementData.abilityType,
+    name: improvementData.name,
+    typeLocName: improvementData.typeLocName,
+    img: improvementData.img,
+    currentValueDisplay: improvementData.currentValueDisplay,
+    rollable: improvementData.canExperience,
+    disabledReasonText: improvementData.atRuneCap
+      ? localize("RQG.Dialog.improveAbilityDialog.sourceUnavailableRuneCap")
+      : undefined,
+    item,
+    improvementData,
+  };
+}
+
+function buildPowerEntryIfEligible(
+  actor: CharacterActor,
+): ExperienceRollCharacteristicEntry | undefined {
+  const powerHasExperience = Boolean(actor._source.system.characteristics.power.hasExperience);
+  if (!powerHasExperience) {
+    return undefined;
+  }
+
+  const improvementData = buildCharacteristicAdapter(actor, "power");
+  return {
+    id: "power",
+    kind: "power",
+    name: improvementData.name,
+    typeLocName: improvementData.typeLocName,
+    img: null,
+    currentValueDisplay: improvementData.currentValueDisplay,
+    rollable: improvementData.canExperience,
+    disabledReasonText: improvementData.atSpeciesMax
+      ? localize("RQG.Dialog.improveAbilityDialog.sourceUnavailableSpeciesMax", {
+          name: improvementData.name,
+        })
+      : undefined,
+    improvementData,
+  };
+}
+
+/** Builds the normalized request for an entry's experience gain, at whatever fixed/random kind is
+ * currently selected - the same #910 adapters the per-item improve dialogs use, so the session
+ * never reimplements the ability/POW roll-over/roll-under split itself. */
+export function buildExperienceRollRequest(
+  entry: ExperienceRollEntry,
+  gainKind: ExperienceRollGainKind,
+  actorName: string,
+  speaker: ChatMessage.SpeakerData,
+): ImprovementRequest {
+  const gainType = `experience-gain-${gainKind}` as const;
+  return entry.kind === "power"
+    ? buildCharacteristicImprovementRequest(entry.improvementData, gainType, actorName, speaker)
+    : buildAbilityImprovementRequest(entry.improvementData, gainType, actorName, speaker);
+}
+
+/** Mirrors improvement-roll-tooltip.hbs's per-chip markup (`<b>{{value}}</b><sub><i>{{label}}</i></sub>`)
+ * so the row's target tooltip reads identically to the same breakdown once it shows up in chat -
+ * built directly rather than through renderTemplate so this stays a synchronous, pure builder. */
+function buildGateBreakdownTooltipHtml(chips: readonly ImprovementDetailRow[]): string {
+  return chips.map((chip) => `<b>${chip.value}</b><sub><i>${chip.label}</i></sub>`).join(" ");
+}
+
+export type ExperienceRollRowView = {
+  id: string;
+  kind: ExperienceRollEntryKind;
+  name: string;
+  typeLocName: string;
+  img: string | null;
+  currentValueDisplay: string;
+  comparatorSymbol: string;
+  targetDisplay: number;
+  /** How the target was derived (e.g. "(species max − POW) × 5 + cult bonus"), the same
+   * breakdown #910's chat card shows in its gate roll's expandable details - rendered here as a
+   * hover tooltip on the target instead, since the row has no click-to-expand affordance. */
+  targetTooltip: string;
+  gainFormula: string;
+  /** Icon for the (not yet rolled) gain chip - the session's current fixed/random toggle. */
+  gainIcon: string;
+  valueSuffix: string;
+  rollable: boolean;
+  disabledReasonText?: string;
+  /** Row state modifier class ("resolved"/"disabled"/""), computed here rather than in the
+   * template so the three-way row-state logic lives with the rest of the row-view construction. */
+  rowStateClass: string;
+  resolved?: {
+    /** Whether the value actually went up - not the same as the gate roll succeeding, since a
+     * random gain formula (e.g. POW's 1d3-1) can roll 0: the check passed but nothing changed. */
+    increased: boolean;
+    successLevel: AbilitySuccessLevelEnum;
+    outcomeText: string;
+    gainDisplay?: string;
+    /** Icon for the already-rolled gain chip - whatever the toggle was set to at roll time,
+     * which can differ from the session's current toggle if it was flipped since. */
+    gainIcon: string;
+    valueChangeDisplay?: string;
+  };
+};
+
+/** Row data for the session template: target and comparator direction always come from the
+ * request the adapters built, never hardcoded here - a mixed ability/POW queue must not collapse
+ * onto a single "roll under/over X" convention (Core p.415 vs p.418). */
+export function buildExperienceRollRowView(
+  entry: ExperienceRollEntry,
+  gainKind: ExperienceRollGainKind,
+  actorName: string,
+  speaker: ChatMessage.SpeakerData,
+  resolved?: ImprovementResult,
+): ExperienceRollRowView {
+  const request = buildExperienceRollRequest(entry, gainKind, actorName, speaker);
+  const gateDisplay = request.gate ? getGateDisplay(request.gate) : undefined;
+  // A passed gate can still roll a 0 gain (POW's 1d3-1, e.g.) - "increased" tracks whether the
+  // value actually moved, not just whether the gate roll passed, so the label/color never claims
+  // a gain that didn't happen.
+  const increased = Boolean(resolved?.succeeded && resolved.gain > 0);
+
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    name: entry.name,
+    typeLocName: entry.typeLocName,
+    img: entry.img,
+    currentValueDisplay: entry.currentValueDisplay,
+    comparatorSymbol: gateDisplay?.symbol ?? "",
+    targetDisplay: gateDisplay?.threshold ?? 0,
+    targetTooltip: buildGateBreakdownTooltipHtml(request.gateBreakdownChips),
+    gainFormula: request.gain.formula,
+    gainIcon: getGainKindIcon(gainKind),
+    valueSuffix: request.valueSuffix,
+    rollable: entry.rollable,
+    disabledReasonText: entry.disabledReasonText,
+    rowStateClass: resolved ? "resolved" : entry.rollable ? "" : "disabled",
+    resolved: resolved
+      ? {
+          increased,
+          successLevel: increased
+            ? AbilitySuccessLevelEnum.Success
+            : AbilitySuccessLevelEnum.Failure,
+          outcomeText: localize(
+            increased
+              ? "RQG.Roll.ImprovementRoll.Increased"
+              : "RQG.Roll.ImprovementRoll.FailedToIncrease",
+          ),
+          // Still shown on a passed-but-zero gain roll, so a "+0%" distinguishes "the check
+          // passed but the die came up empty" from an outright gate failure (no roll at all).
+          gainDisplay: resolved.succeeded ? `${resolved.gain}${request.valueSuffix}` : undefined,
+          gainIcon: getGainKindIcon(resolved.request.gain.kind),
+          valueChangeDisplay: increased
+            ? localize("RQG.Roll.ImprovementRoll.ValueChange", {
+                from: `${resolved.previousValue}${request.valueSuffix}`,
+                to: `${resolved.newValue}${request.valueSuffix}`,
+              })
+            : undefined,
+        }
+      : undefined,
+  };
+}
+
+export type ExperienceRollRowGroup = {
+  kind: ExperienceRollEntryKind;
+  label: string;
+  rows: ExperienceRollRowView[];
+};
+
+/** Groups rows by item type, POW in its own group (Core p.418's target/gain read differently from
+ * every ability row) - keeps a mixed queue readable rather than one flat list. POW leads (and
+ * runes/passions ahead of skills) since a POW gain can shift the skill category modifiers rolled
+ * further down the list - see rollAllExperienceRollEntries. */
+export function groupExperienceRollRows(rows: ExperienceRollRowView[]): ExperienceRollRowGroup[] {
+  const order: ExperienceRollEntryKind[] = ["power", "rune", "passion", "skill"];
+  return order
+    .map((kind) => ({
+      kind,
+      label: rows.find((row) => row.kind === kind)?.typeLocName ?? "",
+      rows: rows.filter((row) => row.kind === kind),
+    }))
+    .filter((group) => group.rows.length > 0);
+}
+
+/**
+ * Applies a resolved gain back to the actor: abilities go through their item's own
+ * applyChanceGain (skills store the gain separately in gainedChance), POW goes through the same
+ * shared applyCharacteristicGain the per-item improve dialog uses (Core p.418).
+ */
+async function applyExperienceRollGain(
+  actor: CharacterActor,
+  entry: ExperienceRollEntry,
+  gain: number,
+): Promise<void> {
+  if (entry.kind === "power") {
+    await applyCharacteristicGain(actor, "power", entry.improvementData, gain);
+    return;
+  }
+
+  await entry.item.system.applyChanceGain(gain);
+}
+
+/**
+ * Rolls a single entry by id, re-deriving eligibility from live actor data first - the entry
+ * handed in by the caller can have gone stale (another route cleared the flag, or pushed a Rune to
+ * its cap) while the session was open, mirroring the per-item improve dialogs' submit-time
+ * revalidation.
+ */
+export async function rollExperienceRollEntry(
+  actor: CharacterActor,
+  entryId: string,
+  gainKind: ExperienceRollGainKind,
+  actorName: string,
+  speaker: ChatMessage.SpeakerData,
+): Promise<ImprovementResolution | undefined> {
+  const liveEntry = getEligibleExperienceRollEntry(actor, entryId);
+  if (!liveEntry || !liveEntry.rollable) {
+    return undefined;
+  }
+
+  const request = buildExperienceRollRequest(liveEntry, gainKind, actorName, speaker);
+  const resolution = await resolveImprovement(request);
+  await applyExperienceRollGain(actor, liveEntry, resolution.result.gain);
+  return resolution;
+}
+
+export type ExperienceRollAllResult = {
+  entry: ExperienceRollEntry;
+  resolution: ImprovementResolution;
+};
+
+/**
+ * Rolls every currently-rollable entry, sequentially - each write completes before the next
+ * entry's gate roll happens, so there is no race between roll-all's own writes (Core p.415/p.418
+ * results never depend on each other, but the actor document does). Pairs each resolution with the
+ * entry it came from so a caller can keep that row visible/inert without re-deriving it.
+ *
+ * POW goes first: it feeds several skill category modifiers (Agility, Communication, Knowledge,
+ * Magic, Manipulation, Perception and the weapon skills all read POW's derived modifier - Stealth
+ * too, though POW works against it there), recomputed live from source data on every roll. A POW
+ * gain that crosses one of those bands only helps abilities rolled after it, so resolving it first
+ * gives the rest of this batch the best odds a bulk roll can offer - a player rolling row by row
+ * still has full manual control to sequence around this (e.g. rolling Stealth before POW) instead.
+ */
+export async function rollAllExperienceRollEntries(
+  actor: CharacterActor,
+  gainKind: ExperienceRollGainKind,
+  actorName: string,
+  speaker: ChatMessage.SpeakerData,
+): Promise<ExperienceRollAllResult[]> {
+  const entries = getEligibleExperienceRollEntries(actor);
+  const orderedEntries = [
+    ...entries.filter((entry) => entry.kind === "power"),
+    ...entries.filter((entry) => entry.kind !== "power"),
+  ];
+
+  const results: ExperienceRollAllResult[] = [];
+  for (const entry of orderedEntries) {
+    if (!entry.rollable) {
+      continue;
+    }
+    const resolution = await rollExperienceRollEntry(actor, entry.id, gainKind, actorName, speaker);
+    if (resolution) {
+      results.push({ entry, resolution });
+    }
+  }
+  return results;
+}

--- a/src/rolls/improvement-roll/improvement-roll-card-body.hbs
+++ b/src/rolls/improvement-roll/improvement-roll-card-body.hbs
@@ -1,0 +1,25 @@
+{{#if showGateRoll}}
+  <div class="dice-roll">
+    <div class="dice-result">
+      <div class="dice-total success-level-{{gateSuccessLevel}}">
+        <div class="outcome">{{gateOutcomeText}}</div>
+        <div data-tooltip="{{gateFormula}}"><i class="fa-solid fa-dice"></i>{{gateTotal}}</div>
+        <div class="target" data-only-owner-visible-uuid="{{speakerUuid}}"><i class="fa-solid fa-bullseye"></i> {{#if comparatorSymbol}}{{comparatorSymbol}} {{/if}}{{threshold}}</div>
+      </div>
+    </div>
+    {{{gateTooltip}}}
+  </div>
+{{/if}}
+
+{{#if showGainRoll}}
+  <div class="dice-roll">
+    <div class="dice-result">
+      <div class="dice-total">
+        <div class="outcome">{{gainLabel}}</div>
+        <div><i class="fa-solid fa-dice"></i>{{gainDisplay}}</div>
+      </div>
+    </div>
+    {{{gainTooltip}}}
+  </div>
+  <div class="improvement-value-change" data-only-owner-visible-uuid="{{speakerUuid}}">{{valueChange}}</div>
+{{/if}}

--- a/src/rolls/improvement-roll/improvement-roll-presenter.ts
+++ b/src/rolls/improvement-roll/improvement-roll-presenter.ts
@@ -35,16 +35,37 @@ const GAIN_TOOLTIP_SOURCE_LABEL_KEYS: Record<ImprovementSource, string> = {
   training: "RQG.Dialog.improveAbilityDialog.throughTraining",
 };
 
+/** Per-entry view model shared by the single-card and roll-all summary templates - everything
+ * #910's showImprovementChatMessage needs to render one improvement's two roll blocks. */
+type ImprovementCardView = {
+  name: string;
+  typeLocName: string;
+  img?: string | null;
+  sourceTag: string;
+  showGateRoll: boolean;
+  gateSuccessLevel: AbilitySuccessLevelEnum;
+  gateOutcomeText: string;
+  gateFormula?: string;
+  gateTotal?: number;
+  comparatorSymbol?: string;
+  threshold?: number;
+  gateTooltip?: string;
+  showGainRoll: boolean;
+  gainLabel: string;
+  gainDisplay?: string;
+  gainTooltip?: string;
+  valueChange?: string;
+  speakerUuid: string | undefined;
+};
+
 /**
- * Renders one chat card per improvement action from the normalized resolver result. Knows nothing
- * about abilities or characteristics - everything domain specific arrives as detail rows and
- * comparator policy on the request.
- *
- * The card is two independently-expandable roll blocks: a gate roll (skipped for ungated sources
- * like ability training) and, only when the gate succeeded (or there was none), a gain roll
- * followed by a plain "before → after" line.
+ * Builds the normalized view for one improvement's chat card from the resolver result. Knows
+ * nothing about abilities or characteristics - everything domain specific arrives as detail rows
+ * and comparator policy on the request.
  */
-export async function showImprovementChatMessage(resolution: ImprovementResolution): Promise<void> {
+async function buildImprovementCardView(
+  resolution: ImprovementResolution,
+): Promise<ImprovementCardView> {
   const { result, gateRoll, gainRoll } = resolution;
   const { request } = result;
   const showGateRoll = request.gate != null;
@@ -58,36 +79,55 @@ export async function showImprovementChatMessage(resolution: ImprovementResoluti
     showGainRoll && gainRoll ? renderGainTooltip(gainRoll, request.source, speakerUuid) : undefined,
   ]);
 
+  return {
+    name: request.name,
+    typeLocName: request.typeLocName,
+    img: request.img,
+    sourceTag: localize(TITLE_SOURCE_TAG_KEYS[request.source]),
+
+    showGateRoll,
+    // Reuses the roll card success/failure colouring and wording of the other RQG roll cards.
+    gateSuccessLevel: result.succeeded
+      ? AbilitySuccessLevelEnum.Success
+      : AbilitySuccessLevelEnum.Failure,
+    gateOutcomeText: localize(
+      `RQG.Game.AbilityResultEnum.${result.succeeded ? AbilitySuccessLevelEnum.Success : AbilitySuccessLevelEnum.Failure}`,
+    ),
+    gateFormula: gateRoll?.formula,
+    gateTotal: result.gateTotal,
+    comparatorSymbol: gateDisplay?.symbol,
+    threshold: gateDisplay?.threshold,
+    gateTooltip,
+
+    showGainRoll,
+    gainLabel: localize("RQG.Roll.ImprovementRoll.Gain"),
+    gainDisplay: showGainRoll ? `${result.gain}${request.valueSuffix}` : undefined,
+    gainTooltip,
+    valueChange: showGainRoll
+      ? localize("RQG.Roll.ImprovementRoll.ValueChange", {
+          from: `${result.previousValue}${request.valueSuffix}`,
+          to: `${result.newValue}${request.valueSuffix}`,
+        })
+      : undefined,
+
+    speakerUuid,
+  };
+}
+
+/**
+ * Renders one chat card per improvement action from the normalized resolver result.
+ *
+ * The card is two independently-expandable roll blocks: a gate roll (skipped for ungated sources
+ * like ability training) and, only when the gate succeeded (or there was none), a gain roll
+ * followed by a plain "before → after" line.
+ */
+export async function showImprovementChatMessage(resolution: ImprovementResolution): Promise<void> {
+  const { request } = resolution.result;
+  const view = await buildImprovementCardView(resolution);
+
   const content = await foundry.applications.handlebars.renderTemplate(
     templatePaths.improvementRoll,
-    {
-      showGateRoll,
-      // Reuses the roll card success/failure colouring and wording of the other RQG roll cards.
-      gateSuccessLevel: result.succeeded
-        ? AbilitySuccessLevelEnum.Success
-        : AbilitySuccessLevelEnum.Failure,
-      gateOutcomeText: localize(
-        `RQG.Game.AbilityResultEnum.${result.succeeded ? AbilitySuccessLevelEnum.Success : AbilitySuccessLevelEnum.Failure}`,
-      ),
-      gateFormula: gateRoll?.formula,
-      gateTotal: result.gateTotal,
-      comparatorSymbol: gateDisplay?.symbol,
-      threshold: gateDisplay?.threshold,
-      gateTooltip,
-
-      showGainRoll,
-      gainLabel: localize("RQG.Roll.ImprovementRoll.Gain"),
-      gainDisplay: showGainRoll ? `${result.gain}${request.valueSuffix}` : undefined,
-      gainTooltip,
-      valueChange: showGainRoll
-        ? localize("RQG.Roll.ImprovementRoll.ValueChange", {
-            from: `${result.previousValue}${request.valueSuffix}`,
-            to: `${result.newValue}${request.valueSuffix}`,
-          })
-        : undefined,
-
-      speakerUuid,
-    },
+    view,
   );
 
   activateChatTab();
@@ -96,9 +136,53 @@ export async function showImprovementChatMessage(resolution: ImprovementResoluti
       speaker: request.speaker,
       flavor: buildFlavor(request),
       content: content,
-      rolls: [gateRoll, gainRoll].filter(isTruthy),
+      rolls: [resolution.gateRoll, resolution.gainRoll].filter(isTruthy),
     },
-    { rollMode: "roll" },
+    // TEMP(v14-types): fvtt-types doesn't know about messageMode yet - rollMode is deprecated since v14.
+    { messageMode: "public" } as unknown as Record<string, unknown>,
+  );
+
+  if (message?.id != null) {
+    await game.dice3d?.waitFor3DAnimationByMessageID(message.id);
+  }
+}
+
+/**
+ * Renders a roll-all operation as a single chat card listing every improvement with its outcome,
+ * rather than one card per improvement - a second presenter mode over the same normalized
+ * resolver contract #910's showImprovementChatMessage uses, so it never reaches into domain data
+ * itself. Each entry keeps its own expandable gate/gain roll details (see improvement-roll.hbs's
+ * per-entry dice-roll blocks, enriched independently by rqg-chat-message.ts for every message).
+ */
+export async function showImprovementSummaryChatMessage(
+  resolutions: ImprovementResolution[],
+  speaker: ChatMessage.SpeakerData,
+): Promise<void> {
+  if (resolutions.length === 0) {
+    return;
+  }
+
+  const entries = await Promise.all(
+    resolutions.map((resolution) => buildImprovementCardView(resolution)),
+  );
+
+  const content = await foundry.applications.handlebars.renderTemplate(
+    templatePaths.improvementRollSummary,
+    { entries },
+  );
+
+  activateChatTab();
+  const message = await ChatMessage.create(
+    {
+      speaker,
+      flavor: buildSummaryFlavor(resolutions.length),
+      content,
+      rolls: resolutions
+        .flatMap((resolution) => [resolution.gateRoll, resolution.gainRoll])
+        .filter(isTruthy),
+    },
+    // TEMP(v14-types): fvtt-types doesn't know about messageMode yet - rollMode is deprecated since v14.
+    { messageMode: "public" } as unknown as Record<string, unknown>,
   );
 
   if (message?.id != null) {
@@ -121,6 +205,14 @@ function buildFlavor(request: ImprovementResult["request"]): string {
 <span class="roll-action">${request.name}</span>
 <span>${request.typeLocName}</span>
 <span class="improvement-source-tag">· ${sourceTag}</span>`;
+}
+
+/** Flavor for a roll-all summary card - one line for the whole message, since each entry already
+ * carries its own name/type/source header inside the content (see improvement-roll-summary.hbs). */
+function buildSummaryFlavor(count: number): string {
+  return `
+<i class="fa-fw fa-solid fa-arrow-trend-up improvement-icon"></i>
+<span class="roll-action">${localize("RQG.Roll.ImprovementRoll.SummaryTitle", { count: String(count) })}</span>`;
 }
 
 /**

--- a/src/rolls/improvement-roll/improvement-roll-presenter.ts
+++ b/src/rolls/improvement-roll/improvement-roll-presenter.ts
@@ -35,6 +35,9 @@ const GAIN_TOOLTIP_SOURCE_LABEL_KEYS: Record<ImprovementSource, string> = {
   training: "RQG.Dialog.improveAbilityDialog.throughTraining",
 };
 
+// TEMP(v14-types): fvtt-types doesn't know about messageMode yet - rollMode is deprecated since v14.
+const PUBLIC_MESSAGE_MODE = { messageMode: "public" } as unknown as Record<string, unknown>;
+
 /** Per-entry view model shared by the single-card and roll-all summary templates - everything
  * #910's showImprovementChatMessage needs to render one improvement's two roll blocks. */
 type ImprovementCardView = {
@@ -138,8 +141,7 @@ export async function showImprovementChatMessage(resolution: ImprovementResoluti
       content: content,
       rolls: [resolution.gateRoll, resolution.gainRoll].filter(isTruthy),
     },
-    // TEMP(v14-types): fvtt-types doesn't know about messageMode yet - rollMode is deprecated since v14.
-    { messageMode: "public" } as unknown as Record<string, unknown>,
+    PUBLIC_MESSAGE_MODE,
   );
 
   if (message?.id != null) {
@@ -181,8 +183,7 @@ export async function showImprovementSummaryChatMessage(
         .flatMap((resolution) => [resolution.gateRoll, resolution.gainRoll])
         .filter(isTruthy),
     },
-    // TEMP(v14-types): fvtt-types doesn't know about messageMode yet - rollMode is deprecated since v14.
-    { messageMode: "public" } as unknown as Record<string, unknown>,
+    PUBLIC_MESSAGE_MODE,
   );
 
   if (message?.id != null) {

--- a/src/rolls/improvement-roll/improvement-roll-summary.hbs
+++ b/src/rolls/improvement-roll/improvement-roll-summary.hbs
@@ -1,0 +1,14 @@
+<div class="improvement-roll-summary">
+  {{#each entries}}
+    <div class="improvement-roll improvement-roll-summary-entry">
+      <div class="improvement-roll-summary-entry-header">
+        {{#if img}}<img src="{{img}}">{{/if}}
+        <i class="fa-fw fa-solid fa-arrow-trend-up improvement-icon"></i>
+        <span class="roll-action">{{name}}</span>
+        <span>{{typeLocName}}</span>
+        <span class="improvement-source-tag">· {{sourceTag}}</span>
+      </div>
+      {{> improvementRollCardBody}}
+    </div>
+  {{/each}}
+</div>

--- a/src/rolls/improvement-roll/improvement-roll.css
+++ b/src/rolls/improvement-roll/improvement-roll.css
@@ -24,5 +24,43 @@
         opacity: 0.8;
       }
     }
+
+    & .improvement-roll-summary {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+
+      & .improvement-roll-summary-entry {
+        border-top: 1px solid var(--color-border-light-secondary);
+        padding-top: 0.5rem;
+
+        &:first-child {
+          border-top: none;
+          padding-top: 0;
+        }
+      }
+
+      & .improvement-roll-summary-entry-header {
+        align-items: center;
+        display: flex;
+        gap: 0.25rem;
+        margin-bottom: 0.25rem;
+
+        & img {
+          border: none;
+          height: 1.5em;
+          width: 1.5em;
+        }
+
+        & .improvement-icon {
+          color: var(--color-text-dark-secondary);
+        }
+
+        & .improvement-source-tag {
+          font-size: var(--font-size-12);
+          color: var(--color-text-dark-secondary);
+        }
+      }
+    }
   }
 }

--- a/src/rolls/improvement-roll/improvement-roll.hbs
+++ b/src/rolls/improvement-roll/improvement-roll.hbs
@@ -1,27 +1,3 @@
 <div class="improvement-roll">
-  {{#if showGateRoll}}
-    <div class="dice-roll">
-      <div class="dice-result">
-        <div class="dice-total success-level-{{gateSuccessLevel}}">
-          <div class="outcome">{{gateOutcomeText}}</div>
-          <div data-tooltip="{{gateFormula}}"><i class="fa-solid fa-dice"></i>{{gateTotal}}</div>
-          <div class="target" data-only-owner-visible-uuid="{{speakerUuid}}"><i class="fa-solid fa-bullseye"></i> {{#if comparatorSymbol}}{{comparatorSymbol}} {{/if}}{{threshold}}</div>
-        </div>
-      </div>
-      {{{gateTooltip}}}
-    </div>
-  {{/if}}
-
-  {{#if showGainRoll}}
-    <div class="dice-roll">
-      <div class="dice-result">
-        <div class="dice-total">
-          <div class="outcome">{{gainLabel}}</div>
-          <div><i class="fa-solid fa-dice"></i>{{gainDisplay}}</div>
-        </div>
-      </div>
-      {{{gainTooltip}}}
-    </div>
-    <div class="improvement-value-change" data-only-owner-visible-uuid="{{speakerUuid}}">{{valueChange}}</div>
-  {{/if}}
+  {{> improvementRollCardBody}}
 </div>

--- a/src/rqg.css
+++ b/src/rqg.css
@@ -5,6 +5,7 @@
 @import url("./rolls/improvement-roll/improvement-roll.css");
 @import url("./applications/rqid-editor/rqid-editor.css");
 @import url("./applications/rqid-batch-editor/rqid-batch-editor.css");
+@import url("./applications/experience-roll-session/experience-roll-session.css");
 @import url("./items/itemsheets.css");
 @import url("./items/itemsheets-v2.css");
 @import url("./items/hit-location-item/hit-location-wound-dialogs.css");

--- a/src/system/load-handlebars-templates.ts
+++ b/src/system/load-handlebars-templates.ts
@@ -91,6 +91,7 @@ export const templatePaths = {
   improvementRollGainTooltip:
     "systems/rqg/rolls/improvement-roll/improvement-roll-gain-tooltip.hbs",
   improvementRoll: "systems/rqg/rolls/improvement-roll/improvement-roll.hbs",
+  improvementRollSummary: "systems/rqg/rolls/improvement-roll/improvement-roll-summary.hbs",
 
   // Chat
   chatMessage: "systems/rqg/chat/chat-message.hbs",
@@ -100,6 +101,12 @@ export const templatePaths = {
 
   // Actor Wizard
   actorWizardApplication: "systems/rqg/applications/actor-wizard-application.hbs",
+
+  // Experience Roll Session
+  experienceRollSessionHeader:
+    "systems/rqg/applications/experience-roll-session/experience-roll-session-header.hbs",
+  experienceRollSessionBody:
+    "systems/rqg/applications/experience-roll-session/experience-roll-session-body.hbs",
 
   // Applications & Dialogs
   dialogRuneMagicCult: "systems/rqg/items/rune-magic-item/rune-magic-cult-dialog.hbs",
@@ -214,6 +221,9 @@ export const loadHandlebarsTemplates = async function () {
     // Item sheet parts
     itemActiveEffects: "systems/rqg/items/sheet-parts/item-active-effects.hbs",
     itemCommonPhysical: "systems/rqg/items/sheet-parts/item-common-physical.hbs",
+
+    // Dice & Rolls
+    improvementRollCardBody: "systems/rqg/rolls/improvement-roll/improvement-roll-card-body.hbs",
 
     // Application sheet parts
     improveDialogSourceChooser:

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -249,6 +249,16 @@
         "SwitchToPlayMode": "Switch to Play Mode",
         "Badge": "✦ edit mode ✦"
       },
+      "ExperienceRollSession": {
+        "HeaderButton": "Experience Rolls ({count})",
+        "Title": "Experience Roll Session - {actorName}",
+        "RollAll": "Roll All",
+        "Roll": "Roll",
+        "GainFixed": "Fixed",
+        "GainRandom": "Random",
+        "EmptyState": "No pending experience checks.",
+        "SourceNoLongerAvailable": "That experience check is no longer available."
+      },
       "Gear": {
         "AddNewGearUniqueTip": "Add New Gear",
         "AddNewGearCurrencyTip": "Add New Currency",
@@ -1165,7 +1175,10 @@
           "training": "training"
         },
         "ValueChange": "{from} → {to}",
-        "Gain": "Gain"
+        "Gain": "Gain",
+        "SummaryTitle": "Experience Roll Session ({count})",
+        "Increased": "Increased",
+        "FailedToIncrease": "Failed to Increase"
       }
     },
     "Hotbar": {


### PR DESCRIPTION
## Summary

- Adds an Experience Roll Session dialog, opened from a new actor-sheet header button, that lists every pending ability (skill/passion/rune) and POW experience check on a character at once, with per-row Roll buttons and a Roll All action.
- A fixed/random gain toggle applies to the whole session; each row's target, gain formula, and result reuse the same #910/#991 adapters the per-item improve dialogs use, so nothing about ability/POW improvement logic is reimplemented.
- Refactors the improvement roll chat-card presenter so its per-item card view is shared between a single roll and the new batch/Roll All summary card.

Closes #912.

## Test plan

- [x] `tsc --noEmit`
- [x] `vitest run` (551 tests passing, including new `experience-roll-eligibility.test.ts` coverage for eligibility, request building, single/batch rolling, and row-view construction)
- [x] i18n audit (no unused/missing keys)
- [x] Manual: open a character sheet with pending experience checks, resolve rows individually and via Roll All, confirm POW rolls before dependent skill category modifiers in a mixed batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)