### PR TITLE
fix: tokenize missed cult-tab border-radius, trim resolved doc items

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -472,23 +472,23 @@ here as a named pattern rather than enumerated tokens.
 
 ## Known Inconsistencies (not yet migrated)
 
-Carried over from the pre-redesign audit — resolve these by replacing the
-literal with the token above, not by adding new one-off values:
+#971's mechanical migration (row-hover/row-active, `danger`, heading-border,
+and the critical-state/edit-mode backgrounds, plus the border-radius scale)
+landed in #995. What's left is tracked in #996, since it risks an actual
+visual change rather than a value-preserving substitution:
 
-- Raw `rgb(139 90 43 / 18%)` / `/ 30%)` still appear as literals in several
-  rules instead of `colors.row-hover` / `colors.row-active`.
-- `#901010` appears as a literal in `actorsheet-v2.css` (combat "strike"
-  and "wounded-border") even though `colors.danger` already exists.
-- Heading border color `#782e22` (h1/h2/h3 underlines) now has a token
-  (`colors.heading-border`); migrating the `actorsheet-v2.css` literal to it
-  is tracked by #971.
-- State backgrounds for dead/unconscious/wounded/shock (`#620000d0`) and
-  edit-mode (`#007300d0`) now have tokens (`colors.critical-state-bg`,
-  `colors.edit-mode-bg`); migrating the literals is tracked by #971.
 - Font sizes still mix `px`, Foundry's px-based `--font-size-*`, keyword
   sizes (`small`, `x-small`), and the `rem` scale above.
-- Border-radius values outside the `rounded` scale still appear ad hoc in
-  a few places (e.g. `50px` used directly instead of `rounded.full`).
+- Spacing still mixes `px`, `rem`, `em`, and `ch` for what are really a
+  handful of intended sizes expressed inconsistently.
+- `rgb(139 90 43 / 32%)` / `/ 50%)` — a brighter variant of `row-hover` /
+  `row-active` used on dodge/spirit-combat rows — has no token yet; worth
+  deciding whether it earns one.
+- `border-radius: 2px` (one spot in `actorsheet-v2.css`) doesn't cleanly
+  map onto the `rounded` scale.
+
+Also carried over, unrelated to the above:
+
 - `income-skill-border` (`--rqg-income-skill-border`) duplicates
   `unassigned-rm-border`'s exact value in both themes (`#7b6245` dark,
   `#a8926b` light) — worth collapsing to one token once a shared name is

--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -216,7 +216,7 @@
         gap: 4px;
         padding: 4px 10px;
         border: 1px solid var(--color-border-dark-secondary, #7b6245);
-        border-radius: 6px 6px 0 0;
+        border-radius: var(--rqg-radius-md) var(--rqg-radius-md) 0 0;
         border-bottom: none;
         cursor: pointer;
         background: var(--rqg-row-active);


### PR DESCRIPTION
## Summary

- Tokenizes `nav.cult-tabs .item`'s `border-radius: 6px 6px 0 0` to `var(--rqg-radius-md) var(--rqg-radius-md) 0 0` — this 4-value shorthand slipped through #995's migration since that pass only matched single-value `border-radius: Npx;`. Matches what DESIGN.md's `cult-tab` component already documents (`rounded: "{rounded.md} {rounded.md} 0 0"`).
- Trims DESIGN.md's Known Inconsistencies list now that #995 landed: removes the 4 items it resolved (row-hover/active literals, `#901010`, heading-border, critical-state/edit-mode backgrounds), updates the border-radius bullet to point at the real remaining straggler (`2px` at one spot, not the now-fixed `50px` example).
- Splits the rest of #971's original scope (font-size mixing, spacing-unit consolidation, the `32%`/`50%` row-tint variants) into #996, since those risk an actual visual change rather than a value-preserving substitution — no Foundry instance to verify against here.

Refs #971

## Test plan

- [x] `pnpm dlx @google/design.md lint DESIGN.md` — 0 errors, 0 warnings
- [x] `pnpm lint:styles`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build:system`
- [x] Visual check in Foundry: cult-tab corner radius (should be visually unchanged — same 6px value, just tokenized)