### PR TITLE
feat: Allied Spirit Rune Point sharing (#957)

### DIFF
--- a/buildScripts/generate-schema/field-to-json-schema.test.ts
+++ b/buildScripts/generate-schema/field-to-json-schema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   ArrayFieldShim,
   BooleanFieldShim,
+  DocumentUUIDFieldShim,
   NumberFieldShim,
   SchemaFieldShim,
   StringFieldShim,
@@ -67,6 +68,12 @@ describe("fieldToJsonSchema", () => {
       additionalProperties: false,
       required: ["rqid"],
     });
+  });
+
+  it("converts a nullable DocumentUUIDField into a nullable string type, not an object", () => {
+    const field = new DocumentUUIDFieldShim({ nullable: true });
+
+    expect(fieldToJsonSchema(field)).toEqual({ type: ["string", "null"] });
   });
 
   it("throws for an unsupported field type", () => {

--- a/buildScripts/generate-schema/field-to-json-schema.ts
+++ b/buildScripts/generate-schema/field-to-json-schema.ts
@@ -33,13 +33,13 @@ export function fieldToJsonSchema(field: unknown): JsonSchemaNode {
     const options = fieldOptions(field);
     const schema: JsonSchemaNode = { type: typeWithNull("string", isNullable(options)) };
     if (options["choices"] && typeof options["choices"] === "object") {
-      schema.enum = Object.keys(options["choices"] as Record<string, unknown>);
+      schema["enum"] = Object.keys(options["choices"] as Record<string, unknown>);
     }
     if (options["blank"] === false) {
-      schema.minLength = 1;
+      schema["minLength"] = 1;
     }
     if (typeof options["initial"] === "string") {
-      schema.default = options["initial"];
+      schema["default"] = options["initial"];
     }
     return schema;
   }
@@ -50,13 +50,13 @@ export function fieldToJsonSchema(field: unknown): JsonSchemaNode {
       type: typeWithNull(options["integer"] === true ? "integer" : "number", isNullable(options)),
     };
     if (typeof options["min"] === "number") {
-      schema.minimum = options["min"];
+      schema["minimum"] = options["min"];
     }
     if (typeof options["max"] === "number") {
-      schema.maximum = options["max"];
+      schema["maximum"] = options["max"];
     }
     if (typeof options["initial"] === "number") {
-      schema.default = options["initial"];
+      schema["default"] = options["initial"];
     }
     return schema;
   }
@@ -65,7 +65,7 @@ export function fieldToJsonSchema(field: unknown): JsonSchemaNode {
     const options = fieldOptions(field);
     const schema: JsonSchemaNode = { type: typeWithNull("boolean", isNullable(options)) };
     if (typeof options["initial"] === "boolean") {
-      schema.default = options["initial"];
+      schema["default"] = options["initial"];
     }
     return schema;
   }
@@ -82,8 +82,13 @@ export function fieldToJsonSchema(field: unknown): JsonSchemaNode {
     return schemaToJsonSchema(field.fields, isNullable(fieldOptions(field)));
   }
 
-  if (field instanceof ObjectFieldShim || field instanceof DocumentUUIDFieldShim) {
+  if (field instanceof ObjectFieldShim) {
     return { type: typeWithNull("object", isNullable(fieldOptions(field))) };
+  }
+
+  if (field instanceof DocumentUUIDFieldShim) {
+    // Stores a plain uuid string (e.g. "Actor.abc123"), not the referenced document itself.
+    return { type: typeWithNull("string", isNullable(fieldOptions(field))) };
   }
 
   const kind = (field as { constructor?: { name?: string } })?.constructor?.name ?? typeof field;
@@ -125,7 +130,7 @@ export function schemaToJsonSchema(
     additionalProperties: false,
   };
   if (required.length > 0) {
-    schema.required = required;
+    schema["required"] = required;
   }
   return schema;
 }

--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -851,6 +851,7 @@
           }
         }
       }
+
     }
 
 /* --- Vertical tab navigation (rotated left edge, matching V1) --- */
@@ -1810,6 +1811,51 @@
 
         &.default-usage {
           font-weight: bold;
+        }
+      }
+
+      & .spirit-bond-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: 1rem;
+
+        & .allied-spirit-link {
+          display: flex;
+          gap: 0.5rem;
+          align-items: center;
+          color: var(--rqg-unassigned-rm-text);
+          background: var(--rqg-unassigned-rm-bg);
+          border: 1px solid var(--rqg-unassigned-rm-border);
+          border-radius: var(--rqg-radius-sm);
+          padding: 4px 8px;
+
+          &.empty {
+            opacity: 0.7;
+            border-style: dashed;
+          }
+
+          &.view-only {
+            cursor: default;
+          }
+
+          & .allied-spirit-icon {
+            height: 20px;
+            width: 20px;
+            object-fit: contain;
+            vertical-align: middle;
+            flex: 0 0 auto;
+          }
+
+          & .allied-spirit-label {
+            opacity: 0.8;
+          }
+
+          & [data-action="unlinkAlliedSpirit"] {
+            color: var(--rqg-unassigned-rm-action);
+            text-shadow: none;
+            margin-left: auto;
+          }
         }
       }
 

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -82,6 +82,8 @@ import { ItemTree } from "../items/shared/item-tree";
 import { confirmActorItemDelete } from "./confirm-item-delete-dialog";
 import { getSpeakerCompat } from "../system/fvtt-type-compat";
 import {
+  getAlliedSpirit,
+  getBondedPriest,
   getStorageItems,
   getTotalStoredMagicPoints,
   MAGIC_POINT_SOURCE_DRAG_TYPE,
@@ -169,6 +171,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       addPassion: RqgActorSheetV2._addPassionAction,
       addGear: RqgActorSheetV2._addGearAction,
       openMagicPointSources: RqgActorSheetV2._openMagicPointSourcesAction,
+      unlinkAlliedSpirit: RqgActorSheetV2._unlinkAlliedSpiritAction,
     },
   } satisfies foundry.applications.api.ApplicationV2.DefaultOptions;
 
@@ -255,7 +258,13 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     // duplicate() on a DataModel only returns _source data, missing prepare-phase derived values.
     const system = { ...this.actor.system } as CharacterActor["system"];
     const spiritMagicPointSum = CharacterDataModel.getSpiritMagicPointSum(this.actor);
-    const magicPointStorageItems = getStorageItems(this.actor);
+    const alliedSpirit = getAlliedSpirit(this.actor);
+    const boundPriest = getBondedPriest(this.actor);
+    // Already resolved above (alliedSpirit tries this direction first, boundPriest the other) -
+    // pass it through rather than letting getStorageItems/getTotalStoredMagicPoints re-resolve
+    // the allied bond (and, on the ally side, re-walk game.actors.contents) themselves.
+    const alliedBondActor = alliedSpirit ?? boundPriest;
+    const magicPointStorageItems = getStorageItems(this.actor, alliedBondActor);
     const incorrectRunes: RqgItem[] = [];
     const embeddedItems = await DataPrep.organizeEmbeddedItems(this.actor, incorrectRunes);
     const itemTree = new ItemTree(this.actor.items.contents);
@@ -351,8 +360,14 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       spiritMagicPointSum: spiritMagicPointSum,
       sorcerySkillCount: CharacterDataModel.getSorcerySkillCount(this.actor),
       freeInt: CharacterDataModel.getFreeInt(this.actor, spiritMagicPointSum),
-      hasMagicPointStorageItems: magicPointStorageItems.length > 0,
-      totalStoredMagicPoints: getTotalStoredMagicPoints(this.actor, magicPointStorageItems),
+      showMagicPointSourcesButton: magicPointStorageItems.length > 0 || alliedBondActor != null,
+      totalStoredMagicPoints: getTotalStoredMagicPoints(
+        this.actor,
+        magicPointStorageItems,
+        alliedBondActor,
+      ),
+      alliedSpirit: alliedSpirit ? { uuid: alliedSpirit.uuid ?? "" } : undefined,
+      boundPriest: boundPriest ? { uuid: boundPriest.uuid ?? "" } : undefined,
 
       enrichedBiography: await foundry.applications.ux.TextEditor.implementation.enrichHTML(
         system.background.biography ?? "",
@@ -1123,6 +1138,16 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     }).render({ force: true });
   }
 
+  private static async _unlinkAlliedSpiritAction(this: RqgActorSheetV2): Promise<void> {
+    if (!this.actor.isOwner) {
+      ui.notifications?.warn(
+        localize("RQG.Actor.Notification.NotActorOwnerWarn", { actorName: this.actor.name }),
+      );
+      return;
+    }
+    await this.actor.update({ system: { alliedSpiritActorUuid: null } });
+  }
+
   /**
    * Sync combatants to match the desired set of active SRs.
    * Reuses existing combatants by updating their initiative to minimise
@@ -1328,9 +1353,12 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     this._clearDragState();
   }
 
-  private _getDropzoneFromEvent(event: DragEvent): HTMLElement | null {
+  private _getDropzoneFromEvent(
+    event: DragEvent,
+    selector: string = "[data-dropzone]",
+  ): HTMLElement | null {
     const directTarget = getEventTargetElement(event);
-    const directDropzone = directTarget?.closest<HTMLElement>("[data-dropzone]") ?? null;
+    const directDropzone = directTarget?.closest<HTMLElement>(selector) ?? null;
     if (directDropzone) {
       return directDropzone;
     }
@@ -1339,17 +1367,17 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       if (!isFoundryElementInstanceOf(pathNode, HTMLElement)) {
         continue;
       }
-      if (pathNode.matches("[data-dropzone]")) {
+      if (pathNode.matches(selector)) {
         return pathNode;
       }
-      const parentDropzone = pathNode.closest<HTMLElement>("[data-dropzone]");
+      const parentDropzone = pathNode.closest<HTMLElement>(selector);
       if (parentDropzone) {
         return parentDropzone;
       }
     }
 
     const hitElement = event.view?.document?.elementFromPoint(event.clientX, event.clientY);
-    const hitDropzone = hitElement?.closest<HTMLElement>("[data-dropzone]") ?? null;
+    const hitDropzone = hitElement?.closest<HTMLElement>(selector) ?? null;
     if (hitDropzone) {
       return hitDropzone;
     }
@@ -1373,7 +1401,10 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     // dragover — browsers block reading the payload, and sidebar drags expose no
     // reliable hints. Acceptance is validated against the real payload on drop,
     // where a rejected drop produces an explicit notification.
-    const candidateDropzone = this._getDropzoneFromEvent(event);
+    const candidateDropzone = this._getDropzoneFromEvent(
+      event,
+      "[data-dropzone], [data-allied-spirit-dropzone]",
+    );
     this._setActiveDropzone(candidateDropzone);
 
     // When hovering a nested dropzone, the item-reorder indicators (which only
@@ -2147,6 +2178,11 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       return;
     }
 
+    if (this._getDropzoneFromEvent(event, "[data-allied-spirit-dropzone]")) {
+      await this._onDropAlliedSpirit(event);
+      return;
+    }
+
     const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(
       event,
     ) as ActorSheet.DropData;
@@ -2164,10 +2200,11 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     }
 
     // The character sheet body only accepts these document kinds. Anything else
-    // (e.g. a Journal Entry dropped outside the background tab's dropzones) would
-    // otherwise be silently ignored by the parent handler, so reject it with a
-    // clear, localized reason instead.
-    const bodySupportedDocumentNames = ["Item", "Folder", "ActiveEffect", "Actor"];
+    // (e.g. a Journal Entry dropped outside the background tab's dropzones, or an
+    // Actor dropped outside the Allied Spirit dropzone) would otherwise be
+    // silently ignored by the parent handler, so reject it with a clear,
+    // localized reason instead.
+    const bodySupportedDocumentNames = ["Item", "Folder", "ActiveEffect"];
     if (data?.type && !bodySupportedDocumentNames.includes(data.type)) {
       ui.notifications?.warn(
         localize("RQG.Actor.Notification.CantDropDocumentHereWarn", {
@@ -2179,6 +2216,47 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
 
     // For all other types, delegate to parent
     await super._onDrop(event);
+  }
+
+  /**
+   * Link the dropped Actor as this actor's Allied Spirit (#957) - just a pointer field, no
+   * validation of the ally's own stats/cult; that's GM-adjudicated roleplay, same as the bond
+   * itself.
+   */
+  private async _onDropAlliedSpirit(event: DragEvent): Promise<void> {
+    if (!this.actor.isOwner) {
+      ui.notifications?.warn(
+        localize("RQG.Actor.Notification.NotActorOwnerWarn", { actorName: this.actor.name }),
+      );
+      return;
+    }
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(
+      event,
+    ) as ActorSheet.DropData;
+    // fvtt-types' DropData.Actor is only typed as { type: "Actor" }, missing the uuid Foundry
+    // actually includes for a standard document-link drag - read it the same untyped way the
+    // compendium branch above reads its own extra fields (e.g. "collection").
+    const droppedActorUuid = hasOwnProperty(data, "uuid") ? data.uuid : undefined;
+    if (data?.type !== "Actor" || typeof droppedActorUuid !== "string") {
+      ui.notifications?.warn(localize("RQG.Actor.RuneMagic.AlliedSpiritDropRequiresActorWarn"));
+      return;
+    }
+    const droppedActor = await fromUuid(droppedActorUuid);
+    if (
+      !(droppedActor instanceof Actor) ||
+      !isDocumentSubType<CharacterActor>(
+        droppedActor as unknown as RqgActor,
+        ActorTypeEnum.Character,
+      )
+    ) {
+      ui.notifications?.warn(localize("RQG.Actor.RuneMagic.AlliedSpiritDropRequiresCharacterWarn"));
+      return;
+    }
+    if (droppedActor.uuid === this.actor.uuid) {
+      ui.notifications?.warn(localize("RQG.Actor.RuneMagic.AlliedSpiritCannotLinkSelfWarn"));
+      return;
+    }
+    await this.actor.update({ system: { alliedSpiritActorUuid: droppedActor.uuid } });
   }
 
   private async _onDropCompendium(event: DragEvent, data: ActorSheet.DropData): Promise<RqgItem[]> {

--- a/src/actors/rqg-actor-sheet-v2.types.ts
+++ b/src/actors/rqg-actor-sheet-v2.types.ts
@@ -92,10 +92,20 @@ export interface RqgActorSheetV2Context {
   /** INT remaining after spirit magic. */
   freeInt: number;
 
-  /** Whether the actor has any Magic Point storage items (see #956) - controls whether the header shows the Magic Point Sources popout button. */
-  hasMagicPointStorageItems: boolean;
+  /** Whether the actor has any Magic Point storage items (see #956) or a usable Allied Spirit
+   *  bond partner (#957, either direction - see getAlliedBondActor) - controls whether the header
+   *  shows the Magic Point Sources popout button (it's also the "Magic Point Source Order" list,
+   *  not just storage items). */
+  showMagicPointSourcesButton: boolean;
   /** Sum of current/max Magic Points across all storage items, shown next to the header button. */
   totalStoredMagicPoints: { value: number; max: number };
+  /** The linked Allied Spirit actor (#957), only when usable by the current user (owned) - see
+   *  getAlliedSpirit. Undefined otherwise, including when no ally is linked at all. Shown in the
+   *  header as the actor-managed side of the bond. */
+  alliedSpirit: { uuid: string } | undefined;
+  /** The Character actor that has *this* actor linked as its Allied Spirit (#957) - the
+   *  reciprocal, read-only side of the bond - see getBondedPriest. Undefined otherwise. */
+  boundPriest: { uuid: string } | undefined;
 
   /** Enriched biography HTML. */
   enrichedBiography: string;

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
@@ -413,7 +413,39 @@
   </div>{{!-- /.combat-weapons-column --}}
   </div>{{!-- /.combat-tab-row --}}
 
-  {{!-- Allies & Notes --}}
+  {{!-- Allied Spirit bond (#957): actor-wide, editable only in edit mode. --}}
+  <div class="spirit-bond-row fullwidth">
+    {{#edit-mode system.editMode "all"}}
+      <div class="allied-spirit-link{{#unless alliedSpirit}} empty{{/unless}}" data-allied-spirit-dropzone
+           data-tooltip="{{localize "RQG.Actor.RuneMagic.AlliedSpiritDropHint"}}">
+        {{#if alliedSpirit}}
+          <span class="allied-spirit-label">{{localize "RQG.Actor.RuneMagic.AlliedSpiritLabel"}}</span>
+          {{toAnchor alliedSpirit.uuid}}
+          <a data-action="unlinkAlliedSpirit" data-tooltip="{{localize "RQG.Actor.RuneMagic.UnlinkAlliedSpiritTitle"}}">
+            <i class="fas fa-unlink"></i>
+          </a>
+        {{else}}
+          <img class="rune allied-spirit-icon" src="systems/rqg/assets/images/runes/spirit.svg">
+          <span class="allied-spirit-hint">{{localize "RQG.Actor.RuneMagic.AlliedSpiritDropHint"}}</span>
+        {{/if}}
+      </div>
+    {{else}}
+      {{#if alliedSpirit}}
+        <div class="allied-spirit-link view-only">
+          <span class="allied-spirit-label">{{localize "RQG.Actor.RuneMagic.AlliedSpiritLabel"}}</span>
+          {{toAnchor alliedSpirit.uuid}}
+        </div>
+      {{/if}}
+    {{/edit-mode}}
+    {{#if boundPriest}}
+      <div class="allied-spirit-link view-only">
+        <span class="allied-spirit-label">{{localize "RQG.Actor.RuneMagic.AllyOfLabel"}}</span>
+        {{toAnchor boundPriest.uuid}}
+      </div>
+    {{/if}}
+  </div>
+
+  {{!-- Notes --}}
   <div class="allies-section fullwidth">
     <h2 class="section-heading">{{localize "RQG.Actor.Attributes.AlliesAndNotes"}}</h2>
     <prose-mirror name="system.allies" value="{{system.allies}}" toggled>{{{enrichedAllies}}}</prose-mirror>

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-header.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-header.hbs
@@ -117,7 +117,7 @@
                      value="{{system.attributes.magicPoints.value}}" size="2">
               / {{system.attributes.magicPoints.max}}
             </span>
-            {{#if hasMagicPointStorageItems}}
+            {{#if showMagicPointSourcesButton}}
               <a class="mp-storage-toggle" data-action="openMagicPointSources" data-actor-id="{{id}}">
                 <span class="mp-storage-icon"></span>
                 <span class="mp-storage-total">{{totalStoredMagicPoints.value}}/{{totalStoredMagicPoints.max}}</span>

--- a/src/applications/magic-point-sources-app/magic-point-sources-app.hbs
+++ b/src/applications/magic-point-sources-app/magic-point-sources-app.hbs
@@ -4,8 +4,11 @@
     <div class="magic-point-source-row" data-source-id="{{id}}">
       <span class="magic-point-source-handle grip-icon"></span>
       <span class="magic-point-source-priority">{{#if priority}}{{priority}}{{/if}}</span>
+      <span class="magic-point-source-icon">
+        {{#if img}}<img src="{{img}}">{{/if}}
+      </span>
       <span class="magic-point-source-name">
-        {{#if isSelf}}
+        {{#if (eq kind "self")}}
           {{localize "RQG.Dialog.Common.MagicPointSourceOptions.Self"}}
         {{else}}
           {{name}}
@@ -20,9 +23,13 @@
           </button>
         {{/if}}
       </span>
-      {{#if isSelf}}
+      {{#if (eq kind "self")}}
         <input type="number" min="0" max="99" size="2"
                name="system.attributes.magicPoints.value"
+               value="{{value}}">
+      {{else if (eq kind "ally")}}
+        <input type="number" min="0" max="{{this.max}}" size="2"
+               name="ally.system.attributes.magicPoints.value"
                value="{{value}}">
       {{else}}
         <input type="number" min="0" max="{{this.max}}" size="2"

--- a/src/applications/magic-point-sources-app/magic-point-sources-app.ts
+++ b/src/applications/magic-point-sources-app/magic-point-sources-app.ts
@@ -3,7 +3,9 @@ import type { CharacterActor } from "../../data-model/actor-data/rqg-actor-data"
 import { systemId } from "../../system/config";
 import { templatePaths } from "../../system/load-handlebars-templates";
 import {
+  ALLY_MAGIC_POINT_SOURCE,
   feedStorageFromSelf,
+  getAlliedBondActor,
   getMagicPointDrawOrder,
   getMaxTransferableToStorage,
   getStorageItems,
@@ -13,7 +15,10 @@ import {
   setMagicPointDrawOrder,
 } from "../../system/magic-point-source";
 import { isFoundryElementInstanceOf, requireValue } from "../../system/util";
-import type { MagicPointSourcesAppContext } from "./magic-point-sources-app.types.ts";
+import type {
+  MagicPointSourcesAppContext,
+  MagicPointSourcesAppRow,
+} from "./magic-point-sources-app.types.ts";
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
@@ -164,24 +169,42 @@ export class MagicPointSourcesApp extends HandlebarsApplicationMixin(
   override async _prepareContext(): Promise<MagicPointSourcesAppContext> {
     let priority = 0;
     const rows = getMagicPointDrawOrder(this.actor).map((entry) => {
-      const base =
-        entry.type === "self"
-          ? {
-              id: SELF_MAGIC_POINT_SOURCE,
-              isSelf: true,
-              name: "",
-              value: Number(this.actor.system.attributes.magicPoints.value) || 0,
-              max: Number(this.actor.system.attributes.magicPoints.max) || 0,
-              feedMax: 0,
-            }
-          : {
-              id: entry.item.id ?? "",
-              isSelf: false,
-              name: entry.item.name ?? "",
-              value: Number(entry.item.system.storedMagicPoints?.value) || 0,
-              max: Number(entry.item.system.storedMagicPoints?.max) || 0,
-              feedMax: getMaxTransferableToStorage(this.actor, entry.item),
-            };
+      let base: Omit<MagicPointSourcesAppRow, "priority">;
+      switch (entry.type) {
+        case "self":
+          base = {
+            id: SELF_MAGIC_POINT_SOURCE,
+            kind: "self",
+            img: this.actor.img ?? undefined,
+            name: "",
+            value: Number(this.actor.system.attributes.magicPoints.value) || 0,
+            max: Number(this.actor.system.attributes.magicPoints.max) || 0,
+            feedMax: 0,
+          };
+          break;
+        case "ally":
+          base = {
+            id: ALLY_MAGIC_POINT_SOURCE,
+            kind: "ally",
+            img: entry.actor.img ?? undefined,
+            name: entry.actor.name ?? "",
+            value: Number(entry.actor.system.attributes.magicPoints.value) || 0,
+            max: Number(entry.actor.system.attributes.magicPoints.max) || 0,
+            feedMax: 0,
+          };
+          break;
+        case "item":
+          base = {
+            id: entry.item.id ?? "",
+            kind: "item",
+            img: entry.item.img ?? undefined,
+            name: entry.item.name ?? "",
+            value: Number(entry.item.system.storedMagicPoints?.value) || 0,
+            max: Number(entry.item.system.storedMagicPoints?.max) || 0,
+            feedMax: getMaxTransferableToStorage(this.actor, entry.item),
+          };
+          break;
+      }
       // Depleted sources (0 points left) never get drawn from by "auto", so they're excluded
       // from the priority numbering entirely rather than breaking the sequence.
       return { ...base, priority: base.value > 0 ? ++priority : null };
@@ -200,9 +223,11 @@ export class MagicPointSourcesApp extends HandlebarsApplicationMixin(
   }
 
   /**
-   * Form fields are named "system.attributes.magicPoints.value" (self) or
-   * "items.<itemId>.system.storedMagicPoints.value" (a storage item), so the submitted data is
-   * split by that prefix and routed to the actor or the specific owning item.
+   * Form fields are named "system.attributes.magicPoints.value" (self),
+   * "items.<itemId>.system.storedMagicPoints.value" (a storage item), or
+   * "ally.system.attributes.magicPoints.value" (a linked Allied Spirit bond partner, #957 - see
+   * getAlliedBondActor), so the submitted data is split by prefix and routed to the actor, the
+   * specific owning item, or the bonded actor.
    */
   protected static async onSubmit(
     _event: SubmitEvent | Event,
@@ -213,8 +238,13 @@ export class MagicPointSourcesApp extends HandlebarsApplicationMixin(
     const data = formData.object as Record<string, unknown>;
 
     const actorUpdate: Record<string, unknown> = {};
+    const allyUpdate: Record<string, unknown> = {};
     const itemUpdatesById = new Map<string, Record<string, unknown>>();
     for (const [key, value] of Object.entries(data)) {
+      if (key.startsWith("ally.")) {
+        allyUpdate[key.slice("ally.".length)] = value;
+        continue;
+      }
       const itemFieldMatch = /^items\.([^.]+)\.(.+)$/.exec(key);
       if (!itemFieldMatch) {
         actorUpdate[key] = value;
@@ -234,6 +264,11 @@ export class MagicPointSourcesApp extends HandlebarsApplicationMixin(
       const item = app.actor.items.get(itemId);
       requireValue(item, `Couldn't find item [${itemId}] to edit its Magic Point storage`);
       await item.update(itemUpdate);
+    }
+    if (Object.keys(allyUpdate).length > 0) {
+      const ally = getAlliedBondActor(app.actor);
+      requireValue(ally, "Couldn't find the linked Allied Spirit to edit its Magic Points");
+      await ally.update(allyUpdate);
     }
 
     await app.render();

--- a/src/applications/magic-point-sources-app/magic-point-sources-app.types.ts
+++ b/src/applications/magic-point-sources-app/magic-point-sources-app.types.ts
@@ -1,12 +1,18 @@
 export type MagicPointSourcesAppRow = {
   id: string;
-  isSelf: boolean;
+  /** Mirrors MagicPointDrawOrderEntry's "self" | "item" | "ally" union (see
+   *  magic-point-source.ts) - "ally" is a linked Allied Spirit bond partner (#957), either
+   *  direction, see getAlliedBondActor. */
+  kind: "self" | "item" | "ally";
+  /** Icon shown before the name - the item's img for a storage item, the actor's img for the
+   *  ally or self rows. */
+  img: string | undefined;
   name: string;
   value: number;
   max: number;
   /** 1-based draw priority among rows that still have points left; null once depleted. */
   priority: number | null;
-  /** Max points this row could receive from self right now; 0 (and unused) for the self row. */
+  /** Max points this row could receive from self right now; 0 (and unused) for self/ally rows. */
   feedMax: number;
 };
 

--- a/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-data.types.ts
+++ b/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-data.types.ts
@@ -27,6 +27,8 @@ export type RuneMagicRollDialogContext = RollHeaderData &
     ritualOptions: SelectOptionData<number>[];
     magicPointSourceOptions: SelectOptionData<string>[];
     showMagicPointSource: boolean;
+    runePointSourceOptions: SelectOptionData<string>[];
+    showRunePointSource: boolean;
   };
 
 export type RuneMagicRollDialogFormData = {
@@ -34,6 +36,7 @@ export type RuneMagicRollDialogFormData = {
   usedRuneId: string; // id of embedded rune
   boost: number;
   magicPointSource: string;
+  runePointSource: string;
   augmentModifier: number;
   meditateModifier: number;
   otherModifier: number;

--- a/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.hbs
+++ b/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.hbs
@@ -13,6 +13,15 @@
       {{localize "RQG.Actor.RuneMagic.RunePoints"}}
     </div>
 
+    {{#if showRunePointSource}}
+      <label>
+        {{localize "RQG.Dialog.RuneMagicRoll.RunePointSource"}}
+      </label>
+      <select name="runePointSource">
+        {{selectOptions runePointSourceOptions selected=formData.runePointSource localize=true}}
+      </select>
+    {{/if}}
+
     {{#if isOneUse}}
       <label>{{localize "RQG.Dialog.RuneMagicRoll.OneUseHeader"}}</label>
       <div class="warning">{{localize "RQG.Dialog.RuneMagicRoll.OneUseDescription"}}</div>

--- a/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.ts
+++ b/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.ts
@@ -27,6 +27,7 @@ import {
   AUTO_MAGIC_POINT_SOURCE,
   getMagicPointSourceOptions,
 } from "../../system/magic-point-source";
+import { getRunePointSourceOptions, SELF_RUNE_POINT_SOURCE } from "../../system/rune-point-source";
 
 const logger = new RqgLogger("RuneMagicRollDialogV2");
 
@@ -151,6 +152,11 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
     // case, regardless of any Magic Point Source Order preference set for regular Spirit Magic
     // Magic Point spending.
     formData.magicPointSource ??= AUTO_MAGIC_POINT_SOURCE;
+    // Rune Points are always spent when casting (unlike the Magic Point boost, which is
+    // optional), so - unlike magicPointSource above - this picker's default doesn't depend on
+    // any other field: "self" is always the safe default, and the picker only even appears when
+    // there's a shared-cult ally to draw from (see showRunePointSource below).
+    formData.runePointSource ??= SELF_RUNE_POINT_SOURCE;
     formData.augmentModifier ??= 0;
     formData.meditateModifier ??= 0;
     formData.otherModifier ??= 0;
@@ -160,6 +166,10 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
 
     const usedRune = eligibleRunes.find((r) => r.id === formData.usedRuneId);
     const magicPointSourceOptions = getMagicPointSourceOptions(this.spellItem.actor);
+    const runePointSourceOptions = getRunePointSourceOptions(
+      this.spellItem.actor,
+      this.spellItem.system.getCult(),
+    );
 
     return {
       formData: formData,
@@ -174,6 +184,8 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
       ritualOptions: RuneMagicRollDialogV2.ritualOptions,
       magicPointSourceOptions: magicPointSourceOptions,
       showMagicPointSource: magicPointSourceOptions.length > 0 && Number(formData.boost) > 0,
+      runePointSourceOptions: runePointSourceOptions,
+      showRunePointSource: runePointSourceOptions.length > 0,
 
       // RollHeader
       rollType: localize("TYPES.Item.runeMagic"),
@@ -253,6 +265,7 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
       levelUsed: formDataObject.levelUsed,
       magicPointBoost: formDataObject.boost,
       magicPointSource: formDataObject.magicPointSource,
+      runePointSource: formDataObject.runePointSource,
       modifiers: [
         {
           value: Number(formDataObject.augmentModifier),
@@ -278,6 +291,7 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
       formDataObject.levelUsed,
       formDataObject.boost,
       formDataObject.magicPointSource,
+      formDataObject.runePointSource,
     );
     if (validationError) {
       ui.notifications?.warn(validationError);

--- a/src/data-model/actor-data/character-data-model.ts
+++ b/src/data-model/actor-data/character-data-model.ts
@@ -18,7 +18,8 @@ import {
 } from "../item-data/cult-priority";
 import { isDocumentSubType } from "../../system/util";
 
-const { BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
+const { BooleanField, DocumentUUIDField, NumberField, SchemaField, StringField } =
+  foundry.data.fields;
 
 function characteristicSchemaField(formula: string) {
   return new SchemaField({
@@ -86,6 +87,16 @@ function defineCharacterSchema() {
     allies: new StringField({ blank: true, nullable: false, initial: "" }),
     editMode: new BooleanField({ nullable: false, initial: true }),
     extendedName: new StringField({ blank: true, nullable: false, initial: "" }),
+
+    /** The Character actor playing this actor's Allied Spirit (Core p.277, #957) - a bonded
+     *  ally sharing Magic Points and Rune Points bidirectionally. Cardinality of one per
+     *  priest is not enforced by code (GM-adjudicated, per the rule). */
+    alliedSpiritActorUuid: new DocumentUUIDField({
+      blank: false,
+      nullable: true,
+      initial: undefined,
+      required: false,
+    }),
 
     attributes: new SchemaField({
       magicPoints: derivedResourceSchemaField(),

--- a/src/data-model/item-data/rune-magic-data-model.ts
+++ b/src/data-model/item-data/rune-magic-data-model.ts
@@ -15,6 +15,11 @@ import {
   getAvailableMagicPoints,
   type MagicPointSourceSelection,
 } from "../../system/magic-point-source";
+import {
+  getAvailableRunePoints,
+  type RunePointSourceSelection,
+  SELF_RUNE_POINT_SOURCE,
+} from "../../system/rune-point-source";
 import type { CultItem } from "./cult-data-model";
 import type { RuneItem } from "./rune-data-model";
 import { toRqidString } from "../../system/api/rqid-validation";
@@ -136,10 +141,11 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
     runePointCost: number | undefined,
     magicPointsBoost: number = 0,
     magicPointSource?: MagicPointSourceSelection,
+    runePointSource: RunePointSourceSelection = SELF_RUNE_POINT_SOURCE,
   ): string | undefined {
     const cult = this.getCult();
     const actor = this.parent?.actor;
-    const availableRunePoints = Number(cult?.system.runePoints.value) || 0;
+    const availableRunePoints = getAvailableRunePoints(actor, cult, runePointSource);
     const availableMagicPoints = actor ? getAvailableMagicPoints(actor, magicPointSource) : 0;
     if (runePointCost == null || runePointCost > availableRunePoints) {
       return game.i18n?.format("RQG.Item.RuneMagic.validationNotEnoughRunePoints");
@@ -233,11 +239,13 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
     // Quick Roll (no dialog) never sets this, so fall back to Auto (drain stored sources first)
     // instead of always using the caster's own pool - matches the cast dialogs' default.
     const magicPointSource = options.magicPointSource ?? AUTO_MAGIC_POINT_SOURCE;
+    const runePointSource = options.runePointSource ?? SELF_RUNE_POINT_SOURCE;
 
     const validationError = this.getCastValidationError(
       levelUsedOrDefault,
       options.magicPointBoost,
       magicPointSource,
+      runePointSource,
     );
     if (validationError) {
       ui.notifications?.warn(validationError);
@@ -280,6 +288,7 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
       usedRune,
       runeMagicItemTyped,
       magicPointSource,
+      runePointSource,
     );
   }
 

--- a/src/data-model/json-schemas/generated/actor/character.schema.json
+++ b/src/data-model/json-schemas/generated/actor/character.schema.json
@@ -525,6 +525,12 @@
       "type": "string",
       "default": ""
     },
+    "alliedSpiritActorUuid": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "attributes": {
       "type": "object",
       "properties": {

--- a/src/items/rune-magic-item/rune-magic-casting.ts
+++ b/src/items/rune-magic-item/rune-magic-casting.ts
@@ -11,6 +11,11 @@ import {
   SELF_MAGIC_POINT_SOURCE,
   spendMagicPoints,
 } from "../../system/magic-point-source";
+import {
+  type RunePointSourceSelection,
+  SELF_RUNE_POINT_SOURCE,
+  spendRunePoints,
+} from "../../system/rune-point-source";
 
 export async function handleRollResult(
   result: AbilitySuccessLevelEnum,
@@ -19,6 +24,7 @@ export async function handleRollResult(
   runeItem: RuneItem,
   runeMagicItem: RuneMagicItem,
   magicPointSource: MagicPointSourceSelection = SELF_MAGIC_POINT_SOURCE,
+  runePointSource: RunePointSourceSelection = SELF_RUNE_POINT_SOURCE,
 ): Promise<void> {
   assertDocumentSubType<RuneItem>(runeItem, ItemTypeEnum.Rune);
   assertDocumentSubType<RuneMagicItem>(runeMagicItem, ItemTypeEnum.RuneMagic);
@@ -36,6 +42,7 @@ export async function handleRollResult(
     cult,
     isOneUse,
     magicPointSource,
+    runePointSource,
   );
   if (result <= AbilitySuccessLevelEnum.Success) {
     await runeItem.awardExperience();
@@ -59,31 +66,18 @@ async function spendRuneAndMagicPoints(
   cult: CultItem,
   isOneUse: boolean,
   magicPointSource: MagicPointSourceSelection,
+  runePointSource: RunePointSourceSelection,
 ) {
   assertDocumentSubType<CultItem>(cult, ItemTypeEnum.Cult);
   assertDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character);
   // At this point if the current Rune Points or Magic Points are zero
   // it's too late. That validation happened earlier.
-  // Rune Points always come from the cult tied to the spell - unlike Magic Points, they don't
-  // get a source picker (see #956).
-  const newRunePointTotal = (cult.system.runePoints.value || 0) - runePoints;
-  let newRunePointMaxTotal = cult.system.runePoints.max || 0;
-  if (isOneUse) {
-    newRunePointMaxTotal -= runePoints;
-    if (newRunePointMaxTotal < (cult.system.runePoints.max || 0)) {
-      ui.notifications?.info(
-        localize("RQG.Item.RuneMagic.SpentOneUseRunePoints", {
-          actorName: actor?.name,
-          runePoints: runePoints.toString(),
-          cultName: cult.name,
-        }),
-      );
-    }
-  }
-  const updateCultItemRunePoints: Item.UpdateData = {
-    _id: cult?.id,
-    system: { runePoints: { value: newRunePointTotal, max: newRunePointMaxTotal } },
-  } as any; // runePoints is a cult-specific field not in the base Item update type
-  await actor?.updateEmbeddedDocuments("Item", [updateCultItemRunePoints]);
-  await spendMagicPoints(actor, magicPoints, magicPointSource);
+  // Rune Points and Magic Points are drawn from independent documents (the cult Item vs. the
+  // caster's/ally's Magic Points) with no data dependency between them, so they can be
+  // written concurrently rather than one awaited after the other - mirrors spendMagicPoints'
+  // own use of Promise.all for the same reason.
+  await Promise.all([
+    spendRunePoints(actor, cult, runePoints, runePointSource, isOneUse),
+    spendMagicPoints(actor, magicPoints, magicPointSource),
+  ]);
 }

--- a/src/rolls/rune-magic-roll/rune-magic-roll.types.ts
+++ b/src/rolls/rune-magic-roll/rune-magic-roll.types.ts
@@ -9,6 +9,7 @@ export type RuneMagicRollOptions = Partial<foundry.dice.terms.DiceTerm.Evaluatio
   levelUsed: number;
   magicPointBoost: number;
   magicPointSource?: string;
+  runePointSource?: string;
   modifiers: Modifier[];
   speaker: ChatMessage.SpeakerData;
   rollMode?: foundry.dice.Roll.Mode;
@@ -17,7 +18,12 @@ export type RuneMagicRollOptions = Partial<foundry.dice.terms.DiceTerm.Evaluatio
 export type RuneMagicRollImmediateOptions = Partial<
   Pick<
     RuneMagicRollOptions,
-    "levelUsed" | "magicPointBoost" | "magicPointSource" | "modifiers" | "rollMode"
+    | "levelUsed"
+    | "magicPointBoost"
+    | "magicPointSource"
+    | "runePointSource"
+    | "modifiers"
+    | "rollMode"
   >
 > & {
   usedRuneId?: string;

--- a/src/rqg.css
+++ b/src/rqg.css
@@ -1774,7 +1774,7 @@
 
     & .magic-point-source-row {
       display: grid;
-      grid-template-columns: 0.1rem 0.9rem minmax(0, 1fr) 1rem 2.2rem 3rem;
+      grid-template-columns: 0.1rem 0.9rem 26px minmax(0, 1fr) 1rem 2.2rem 3rem;
       align-items: center;
       column-gap: 0.3rem;
       cursor: grab;
@@ -1807,6 +1807,20 @@
         color: var(--rqg-color-main);
         font-weight: bold;
         text-align: right;
+      }
+
+      & .magic-point-source-icon {
+        display: block;
+        height: 26px;
+        width: 26px;
+
+        & img {
+          height: 100%;
+          width: 100%;
+          object-fit: contain;
+          border: none;
+          border-radius: var(--rqg-radius-sm);
+        }
       }
 
       & .magic-point-source-name {

--- a/src/system/magic-point-source.test.ts
+++ b/src/system/magic-point-source.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  ALLY_MAGIC_POINT_SOURCE,
   AUTO_MAGIC_POINT_SOURCE,
   feedStorageFromSelf,
+  getAlliedBondActor,
+  getAlliedSpirit,
   getAvailableMagicPoints,
+  getBondedPriest,
   getMagicPointDrawOrder,
   getMagicPointSourceOptions,
   getMaxTransferableToStorage,
@@ -18,11 +22,23 @@ function fakeActor(
   selfMp: number,
   storageItems: any[] = [],
   flags: { magicPointStorageOrder?: string[] } = {},
+  options: {
+    type?: string;
+    alliedSpiritActorUuid?: string;
+    uuid?: string;
+    isOwner?: boolean;
+  } = {},
 ) {
   const storedFlags = { ...flags };
   return {
+    type: options.type ?? "character",
+    uuid: options.uuid,
+    isOwner: options.isOwner ?? true,
     items: storageItems,
-    system: { attributes: { magicPoints: { value: selfMp } } },
+    system: {
+      attributes: { magicPoints: { value: selfMp } },
+      alliedSpiritActorUuid: options.alliedSpiritActorUuid,
+    },
     update: vi.fn(),
     updateEmbeddedDocuments: vi.fn(),
     getFlag: vi.fn((_scope: string, key: string) => (storedFlags as any)[key]),
@@ -31,6 +47,19 @@ function fakeActor(
       return Promise.resolve();
     }),
   } as any;
+}
+
+/** A fake Allied Spirit ally actor (#957) - `instanceof Actor` per the global stub in
+ *  test/setup/foundryMockFunctions.js, so it passes getAlliedSpirit's type-guard checks. */
+function fakeAlly(mpValue: number, mpMax: number, isOwner: boolean = true, name = "Whiskers") {
+  const ally = Object.create((globalThis as any).Actor.prototype);
+  return Object.assign(ally, {
+    name,
+    uuid: "Actor.ally1",
+    isOwner,
+    system: { attributes: { magicPoints: { value: mpValue, max: mpMax } } },
+    update: vi.fn(),
+  });
 }
 
 function crystal(
@@ -49,6 +78,120 @@ function crystal(
     update: vi.fn(),
   };
 }
+
+describe("getAlliedSpirit", () => {
+  it("returns undefined when no ally is linked", () => {
+    const actor = fakeActor(6);
+    expect(getAlliedSpirit(actor)).toBeUndefined();
+  });
+
+  it("returns undefined when the actor isn't a Character (e.g. no field for it)", () => {
+    const actor = fakeActor(6, [], {}, { type: "creature", alliedSpiritActorUuid: "Actor.x" });
+    expect(getAlliedSpirit(actor)).toBeUndefined();
+  });
+
+  it("returns undefined when the linked uuid doesn't resolve to an Actor", () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "Actor.missing" });
+    (globalThis as any).fromUuidSync.mockReturnValue(null);
+    expect(getAlliedSpirit(actor)).toBeUndefined();
+  });
+
+  it("returns undefined when the current user isn't Owner on the ally", () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "Actor.ally1" });
+    const ally = fakeAlly(4, 6, false);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+    expect(getAlliedSpirit(actor)).toBeUndefined();
+  });
+
+  it("returns the ally when linked, resolvable, and owned", () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "Actor.ally1" });
+    const ally = fakeAlly(4, 6, true);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+    expect(getAlliedSpirit(actor)).toBe(ally);
+  });
+});
+
+describe("getBondedPriest", () => {
+  it("returns undefined when no actor in the world links to this one", () => {
+    const ally = fakeActor(4, [], {}, { uuid: "Actor.ally1" });
+    (globalThis as any).game.actors.contents = [
+      fakeActor(6, [], {}, { uuid: "Actor.other", alliedSpiritActorUuid: "Actor.someone-else" }),
+    ];
+    expect(getBondedPriest(ally)).toBeUndefined();
+  });
+
+  it("returns the actor whose alliedSpiritActorUuid points back at this one", () => {
+    const ally = fakeActor(4, [], {}, { uuid: "Actor.ally1" });
+    const priest = fakeActor(
+      6,
+      [],
+      {},
+      { uuid: "Actor.priest1", alliedSpiritActorUuid: "Actor.ally1" },
+    );
+    (globalThis as any).game.actors.contents = [priest];
+    expect(getBondedPriest(ally)).toBe(priest);
+  });
+
+  it("ignores a linking actor that isn't a Character", () => {
+    const ally = fakeActor(4, [], {}, { uuid: "Actor.ally1" });
+    (globalThis as any).game.actors.contents = [
+      fakeActor(
+        6,
+        [],
+        {},
+        {
+          type: "creature",
+          uuid: "Actor.priest1",
+          alliedSpiritActorUuid: "Actor.ally1",
+        },
+      ),
+    ];
+    expect(getBondedPriest(ally)).toBeUndefined();
+  });
+
+  it("returns undefined when the current user doesn't own the linking priest", () => {
+    const ally = fakeActor(4, [], {}, { uuid: "Actor.ally1" });
+    (globalThis as any).game.actors.contents = [
+      fakeActor(
+        6,
+        [],
+        {},
+        {
+          uuid: "Actor.priest1",
+          alliedSpiritActorUuid: "Actor.ally1",
+          isOwner: false,
+        },
+      ),
+    ];
+    expect(getBondedPriest(ally)).toBeUndefined();
+  });
+});
+
+describe("getAlliedBondActor", () => {
+  it("returns the linked ally when this actor is the priest", () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "Actor.ally1" });
+    const ally = fakeAlly(4, 6, true);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+    expect(getAlliedBondActor(actor)).toBe(ally);
+  });
+
+  it("returns the bonded priest when this actor is the linked ally", () => {
+    const ally = fakeActor(4, [], {}, { uuid: "Actor.ally1" });
+    const priest = fakeActor(
+      6,
+      [],
+      {},
+      { uuid: "Actor.priest1", alliedSpiritActorUuid: "Actor.ally1" },
+    );
+    (globalThis as any).game.actors.contents = [priest];
+    expect(getAlliedBondActor(ally)).toBe(priest);
+  });
+
+  it("returns undefined when neither direction resolves", () => {
+    const actor = fakeActor(6, [], {}, { uuid: "Actor.lonely" });
+    expect(getAlliedBondActor(actor)).toBeUndefined();
+  });
+});
 
 describe("getAvailableMagicPoints", () => {
   it("defaults to the actor's own pool", () => {
@@ -76,6 +219,28 @@ describe("getAvailableMagicPoints", () => {
     const actor = fakeActor(6, [crystal("c1", "A", 0, 0)]);
     expect(getAvailableMagicPoints(actor, AUTO_MAGIC_POINT_SOURCE)).toBe(6);
   });
+
+  it("returns the linked ally's own Magic Points for the ally source", () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "Actor.ally1" });
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly(4, 6));
+    expect(getAvailableMagicPoints(actor, ALLY_MAGIC_POINT_SOURCE)).toBe(4);
+  });
+
+  it("returns 0 for the ally source when no ally is linked", () => {
+    const actor = fakeActor(6);
+    expect(getAvailableMagicPoints(actor, ALLY_MAGIC_POINT_SOURCE)).toBe(0);
+  });
+
+  it("includes a linked ally's Magic Points in the auto total", () => {
+    const actor = fakeActor(
+      6,
+      [crystal("c1", "A", 3, 5)],
+      {},
+      { alliedSpiritActorUuid: "Actor.ally1" },
+    );
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly(4, 6));
+    expect(getAvailableMagicPoints(actor, AUTO_MAGIC_POINT_SOURCE)).toBe(13);
+  });
 });
 
 describe("getTotalStoredMagicPoints", () => {
@@ -89,6 +254,24 @@ describe("getTotalStoredMagicPoints", () => {
     const precomputed = getStorageItems(actor);
     expect(getTotalStoredMagicPoints(actor, precomputed)).toEqual({ value: 3, max: 5 });
   });
+
+  it("includes a linked ally's Magic Points, not just storage items", () => {
+    const actor = fakeActor(6, [crystal("c1", "A", 3, 5)], {}, { alliedSpiritActorUuid: "x" });
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly(4, 6));
+    expect(getTotalStoredMagicPoints(actor)).toEqual({ value: 7, max: 11 });
+  });
+
+  it("counts an ally-only actor (no storage items) instead of reading 0/0", () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "x" });
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly(4, 6));
+    expect(getTotalStoredMagicPoints(actor)).toEqual({ value: 4, max: 6 });
+  });
+
+  it("accepts an already-resolved ally instead of re-resolving the bond", () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "x" });
+    const ally = fakeAlly(4, 6);
+    expect(getTotalStoredMagicPoints(actor, [], ally)).toEqual({ value: 4, max: 6 });
+  });
 });
 
 describe("getMagicPointSourceOptions", () => {
@@ -97,13 +280,47 @@ describe("getMagicPointSourceOptions", () => {
     expect(getMagicPointSourceOptions(actor)).toEqual([]);
   });
 
-  it("lists auto, self, then each storage item when any exist", () => {
+  it("lists auto, then storage items and self in the actor's draw order", () => {
     const actor = fakeActor(6, [crystal("c1", "Crystal A", 3, 5)]);
+    // Default draw order (no order flag set) is storage items first, self last - see
+    // getMagicPointDrawOrder - and this picker should mirror that exactly.
     expect(getMagicPointSourceOptions(actor)).toEqual([
       { value: "auto", label: "RQG.Dialog.Common.MagicPointSourceOptions.Auto" },
+      { value: "c1", label: "Crystal A" },
+      { value: "self", label: "RQG.Dialog.Common.MagicPointSourceOptions.Self" },
+    ]);
+  });
+
+  it("follows a custom magicPointStorageOrder flag, not a fixed self-first order", () => {
+    const actor = fakeActor(
+      6,
+      [crystal("c1", "Crystal A", 3, 5), crystal("c2", "Crystal B", 1, 1)],
+      {
+        magicPointStorageOrder: ["c2", "self", "c1"],
+      },
+    );
+    expect(getMagicPointSourceOptions(actor)).toEqual([
+      { value: "auto", label: "RQG.Dialog.Common.MagicPointSourceOptions.Auto" },
+      { value: "c2", label: "Crystal B" },
       { value: "self", label: "RQG.Dialog.Common.MagicPointSourceOptions.Self" },
       { value: "c1", label: "Crystal A" },
     ]);
+  });
+
+  it("is non-empty (auto/self/ally) when only an ally is linked, no storage items", () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "Actor.ally1" });
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly(4, 6, true, "Whiskers"));
+    expect(getMagicPointSourceOptions(actor)).toEqual([
+      { value: "auto", label: "RQG.Dialog.Common.MagicPointSourceOptions.Auto" },
+      { value: "self", label: "RQG.Dialog.Common.MagicPointSourceOptions.Self" },
+      { value: "ally", label: "Whiskers" },
+    ]);
+  });
+
+  it("omits the ally option when the current user doesn't own it", () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "Actor.ally1" });
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly(4, 6, false));
+    expect(getMagicPointSourceOptions(actor)).toEqual([]);
   });
 });
 
@@ -184,6 +401,65 @@ describe("getMagicPointDrawOrder", () => {
     const actor = fakeActor(6, [crystal("c1", "A", 1, 1)], {
       magicPointStorageOrder: ["c1"],
     });
+    expect(getMagicPointDrawOrder(actor)).toEqual([
+      { type: "item", item: actor.items[0] },
+      { type: "self" },
+    ]);
+  });
+
+  it("appends a linked ally last, below self, by default", () => {
+    const actor = fakeActor(
+      6,
+      [crystal("c1", "A", 1, 1)],
+      {},
+      { alliedSpiritActorUuid: "Actor.ally1" },
+    );
+    const ally = fakeAlly(4, 6);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+
+    expect(getMagicPointDrawOrder(actor)).toEqual([
+      { type: "item", item: actor.items[0] },
+      { type: "self" },
+      { type: "ally", actor: ally },
+    ]);
+  });
+
+  it("places the ally wherever it sits in the order flag", () => {
+    const actor = fakeActor(
+      6,
+      [crystal("c1", "A", 1, 1)],
+      { magicPointStorageOrder: ["ally", "c1", "self"] },
+      { alliedSpiritActorUuid: "Actor.ally1" },
+    );
+    const ally = fakeAlly(4, 6);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+
+    expect(getMagicPointDrawOrder(actor)).toEqual([
+      { type: "ally", actor: ally },
+      { type: "item", item: actor.items[0] },
+      { type: "self" },
+    ]);
+  });
+
+  it("appends the ally after self when the order flag predates the bond", () => {
+    const actor = fakeActor(
+      6,
+      [crystal("c1", "A", 1, 1)],
+      { magicPointStorageOrder: ["c1", "self"] },
+      { alliedSpiritActorUuid: "Actor.ally1" },
+    );
+    const ally = fakeAlly(4, 6);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+
+    expect(getMagicPointDrawOrder(actor)).toEqual([
+      { type: "item", item: actor.items[0] },
+      { type: "self" },
+      { type: "ally", actor: ally },
+    ]);
+  });
+
+  it("omits the ally entirely when none is linked", () => {
+    const actor = fakeActor(6, [crystal("c1", "A", 1, 1)]);
     expect(getMagicPointDrawOrder(actor)).toEqual([
       { type: "item", item: actor.items[0] },
       { type: "self" },
@@ -286,6 +562,78 @@ describe("spendMagicPoints", () => {
       { _id: "c1", system: { storedMagicPoints: { value: 0 } } },
     ]);
     expect(actor.update).not.toHaveBeenCalled();
+  });
+
+  it("draws from the linked ally, leaving the caster's own pool untouched", async () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "Actor.ally1" });
+    const ally = fakeAlly(4, 6);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+
+    await spendMagicPoints(actor, 3, ALLY_MAGIC_POINT_SOURCE);
+
+    expect(ally.update).toHaveBeenCalledWith(
+      foundry.utils.expandObject({ "system.attributes.magicPoints.value": 1 }),
+    );
+    expect(actor.update).not.toHaveBeenCalled();
+    expect(actor.updateEmbeddedDocuments).not.toHaveBeenCalled();
+  });
+
+  it("an explicit ally draw never overflows to self", async () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "Actor.ally1" });
+    const ally = fakeAlly(2, 6);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+
+    await spendMagicPoints(actor, 5, ALLY_MAGIC_POINT_SOURCE);
+
+    expect(ally.update).toHaveBeenCalledWith(
+      foundry.utils.expandObject({ "system.attributes.magicPoints.value": 0 }),
+    );
+    expect(actor.update).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the ally source is picked but no ally resolves", async () => {
+    const actor = fakeActor(6);
+    await spendMagicPoints(actor, 3, ALLY_MAGIC_POINT_SOURCE);
+
+    expect(actor.update).not.toHaveBeenCalled();
+    expect(actor.updateEmbeddedDocuments).not.toHaveBeenCalled();
+  });
+
+  it("auto drains storage and self before falling back to a linked ally", async () => {
+    const actor = fakeActor(
+      3,
+      [crystal("c1", "A", 2, 5)],
+      {},
+      { alliedSpiritActorUuid: "Actor.ally1" },
+    );
+    const ally = fakeAlly(4, 6);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+
+    // 2 from c1, 3 from self, remaining 2 from the ally (below self by default).
+    await spendMagicPoints(actor, 7, AUTO_MAGIC_POINT_SOURCE);
+
+    expect(actor.updateEmbeddedDocuments).toHaveBeenCalledWith("Item", [
+      { _id: "c1", system: { storedMagicPoints: { value: 0 } } },
+    ]);
+    expect(actor.update).toHaveBeenCalledWith(
+      foundry.utils.expandObject({ "system.attributes.magicPoints.value": 0 }),
+    );
+    expect(ally.update).toHaveBeenCalledWith(
+      foundry.utils.expandObject({ "system.attributes.magicPoints.value": 2 }),
+    );
+  });
+
+  it("auto never touches a linked ally when self and storage cover the amount", async () => {
+    const actor = fakeActor(6, [], {}, { alliedSpiritActorUuid: "Actor.ally1" });
+    const ally = fakeAlly(4, 6);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+
+    await spendMagicPoints(actor, 3, AUTO_MAGIC_POINT_SOURCE);
+
+    expect(ally.update).not.toHaveBeenCalled();
+    expect(actor.update).toHaveBeenCalledWith(
+      foundry.utils.expandObject({ "system.attributes.magicPoints.value": 3 }),
+    );
   });
 });
 

--- a/src/system/magic-point-source.ts
+++ b/src/system/magic-point-source.ts
@@ -4,12 +4,18 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import { isDocumentSubType } from "./util";
 import { magicPointStorageOrderFlag } from "../data-model/shared/rqg-document-flags";
 import { systemId } from "./config";
+import { ActorTypeEnum, type CharacterActor } from "../data-model/actor-data/rqg-actor-data";
 
 /**
  * Where to draw Magic Points from when casting Spirit/Rune Magic (#956).
  * "self" - the caster's own pool (default, matches pre-#956 behavior).
  * "auto" - drain the actor's storage items (e.g. POW-storing crystals) in order first,
  *          falling back to the caster's own pool for any remainder.
+ * "ally" - the caster's linked Allied Spirit bond partner's Magic Points (#957, either direction -
+ *          see getAlliedBondActor). Also included as part of "auto": Core p.277 treats the bond's
+ *          shared Magic Points the same as any other source, so "auto" drains storage items and
+ *          self before falling back to the ally. Named to match ALLY_RUNE_POINT_SOURCE in
+ *          rune-point-source.ts, which shares the same bond-partner concept.
  * Any other value is treated as the id of one of the actor's own storage items, and never
  * overflows to another source - the caster picked that source specifically.
  */
@@ -17,6 +23,64 @@ export type MagicPointSourceSelection = string;
 
 export const SELF_MAGIC_POINT_SOURCE = "self";
 export const AUTO_MAGIC_POINT_SOURCE = "auto";
+export const ALLY_MAGIC_POINT_SOURCE = "ally";
+
+/**
+ * The Character actor linked as `actor`'s Allied Spirit (#957), resolved via `fromUuidSync` (this
+ * is called from synchronous render/context-prep paths, matching the pattern used elsewhere for
+ * `DocumentUUIDField`s - see defence-dialog-v2.ts). Only returned when it's actually usable as a
+ * Magic Point source for the *current* user: the linked uuid resolves to an Actor, and that user
+ * has Owner permission on it. There's no separate "shown but not spendable" state - an ally the
+ * current user can't act on is treated the same as no ally at all, both for the picker and for the
+ * sheet display (see #957's design decision on this).
+ */
+export function getAlliedSpirit(actor: RqgActor): RqgActor | undefined {
+  if (!isDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character)) {
+    return undefined;
+  }
+  const uuid = actor.system.alliedSpiritActorUuid;
+  if (!uuid) {
+    return undefined;
+  }
+  const ally = fromUuidSync(uuid) as RqgActor | null;
+  if (!(ally instanceof Actor) || !ally.isOwner) {
+    return undefined;
+  }
+  return ally;
+}
+
+/**
+ * The Character actor that has `actor` linked as *its* Allied Spirit (#957) - the reverse of
+ * getAlliedSpirit. There's no second pointer field on the ally side; this is a live reverse
+ * scan of game.actors for one whose alliedSpiritActorUuid resolves to `actor`. Cheap in practice:
+ * game.actors.contents is already an in-memory client collection, and this is a single property
+ * comparison per actor, not a lookup or fromUuid resolve per candidate.
+ * Same "usable right now" gating as getAlliedSpirit (current user must own the priest actor too,
+ * for the bond to be usable from the ally's side).
+ */
+export function getBondedPriest(actor: RqgActor): RqgActor | undefined {
+  const priest = game.actors?.contents.find(
+    (candidate) =>
+      isDocumentSubType<CharacterActor>(
+        candidate as unknown as RqgActor,
+        ActorTypeEnum.Character,
+      ) && (candidate as unknown as CharacterActor).system.alliedSpiritActorUuid === actor.uuid,
+  ) as RqgActor | undefined;
+  return priest?.isOwner ? priest : undefined;
+}
+
+/**
+ * Either half of `actor`'s Allied Spirit bond (Core p.277), whichever side `actor` is on: the
+ * linked ally if `actor` is the priest (see getAlliedSpirit), or the priest if `actor` is the
+ * linked ally (see getBondedPriest). Core p.277: "An allied spirit is in continual mind-to-mind
+ * communication with the priest. They can use each other's magical abilities, including spell
+ * knowledge, magic points, and Rune points" - the bond is symmetric, so anywhere Magic/Rune Point
+ * sharing is resolved should go through this rather than getAlliedSpirit directly, which only
+ * ever looks the one direction (priest -> ally) needed for the sheet's own link-management UI.
+ */
+export function getAlliedBondActor(actor: RqgActor): RqgActor | undefined {
+  return getAlliedSpirit(actor) ?? getBondedPriest(actor);
+}
 
 /**
  * Marker MIME type set on the dataTransfer of an in-popout Magic Point Sources drag (see
@@ -26,7 +90,8 @@ export const AUTO_MAGIC_POINT_SOURCE = "auto";
  */
 export const MAGIC_POINT_SOURCE_DRAG_TYPE = "application/x-rqg-magic-point-source";
 
-export type MagicPointDrawOrderEntry = { type: "self" } | { type: "item"; item: PhysicalItem };
+export type MagicPointDrawOrderEntry =
+  { type: "self" } | { type: "item"; item: PhysicalItem } | { type: "ally"; actor: RqgActor };
 
 /**
  * A physical item only counts as a usable Magic Point source once it's equipped (RAW's "physical
@@ -48,29 +113,47 @@ function getStorageItemCandidates(actor: RqgActor): PhysicalItem[] {
 }
 
 /**
- * The actor's full Magic Point draw order - storage items and the caster's own pool ("self")
- * interleaved by priority. Entries listed in the actor's magicPointStorageOrder flag (item ids,
- * plus the literal "self") come first in that order; anything missing (new storage items, or
- * "self" if it was never placed) is appended, self last by default. This is both the "auto" draw
- * order and the row order shown in the Magic Point Sources popout.
+ * The actor's full Magic Point draw order - storage items, the caster's own pool ("self"), and a
+ * linked Allied Spirit bond partner (#957, either direction - see getAlliedBondActor), interleaved
+ * by priority. Entries listed in the actor's magicPointStorageOrder flag (item ids, plus the
+ * literals "self"/"ally") come first in that order; anything missing (new storage items, "self" if
+ * it was never placed, or a newly-linked ally) is appended - self before a not-yet-ordered ally, so
+ * a fresh bond starts last by default, below self. This is both the "auto" draw order (Core p.277:
+ * the bond lets each side use the other's Magic Points, same as any other source) and the row
+ * order shown in the Magic Point Sources popout.
+ *
+ * Accepts an already-resolved ally (e.g. from a caller that also needs it for something else, like
+ * sheet-header display) to avoid re-resolving the allied bond a second time - getBondedPriest's
+ * reverse-lookup side in particular walks game.actors.contents.
  */
-export function getMagicPointDrawOrder(actor: RqgActor): MagicPointDrawOrderEntry[] {
+export function getMagicPointDrawOrder(
+  actor: RqgActor,
+  ally: RqgActor | undefined = getAlliedBondActor(actor),
+): MagicPointDrawOrderEntry[] {
   const items = getStorageItemCandidates(actor);
   const order = actor.getFlag(systemId, magicPointStorageOrderFlag);
 
+  // The non-item sources, keyed by their order-flag id. A Map (rather than two separate
+  // `*Placed` flags) makes "find or append, and don't duplicate" a single generic rule below,
+  // shared between self and ally instead of one bespoke if-branch per source.
+  const singletons = new Map<string, MagicPointDrawOrderEntry>([
+    [SELF_MAGIC_POINT_SOURCE, { type: "self" }],
+  ]);
+  if (ally) {
+    singletons.set(ALLY_MAGIC_POINT_SOURCE, { type: "ally", actor: ally });
+  }
+
   if (!order || order.length === 0) {
-    return [...items.map((item) => ({ type: "item" as const, item })), { type: "self" as const }];
+    return [...items.map((item) => ({ type: "item" as const, item })), ...singletons.values()];
   }
 
   const itemsById = new Map(items.map((item) => [item.id, item]));
   const entries: MagicPointDrawOrderEntry[] = [];
-  let selfPlaced = false;
   for (const id of order) {
-    if (id === SELF_MAGIC_POINT_SOURCE) {
-      if (!selfPlaced) {
-        entries.push({ type: "self" });
-        selfPlaced = true;
-      }
+    const singleton = singletons.get(id);
+    if (singleton) {
+      entries.push(singleton);
+      singletons.delete(id);
       continue;
     }
     const item = itemsById.get(id);
@@ -90,40 +173,55 @@ export function getMagicPointDrawOrder(actor: RqgActor): MagicPointDrawOrderEntr
     const insertAt = selfIndex === -1 ? entries.length : selfIndex;
     entries.splice(insertAt, 0, ...remainingItems.map((item) => ({ type: "item" as const, item })));
   }
-  if (!selfPlaced) {
-    entries.push({ type: "self" });
-  }
+  // Any singleton never placed above (self and/or ally, e.g. the order flag predates the bond)
+  // is appended at the end, self before ally (Maps preserve insertion order).
+  entries.push(...singletons.values());
   return entries;
 }
 
 /**
- * Storage items in draw order (see getMagicPointDrawOrder), excluding "self".
+ * Storage items in draw order (see getMagicPointDrawOrder), excluding "self". Accepts an
+ * already-resolved ally - see getMagicPointDrawOrder.
  */
-export function getStorageItems(actor: RqgActor): PhysicalItem[] {
-  return getMagicPointDrawOrder(actor)
+export function getStorageItems(
+  actor: RqgActor,
+  ally: RqgActor | undefined = getAlliedBondActor(actor),
+): PhysicalItem[] {
+  return getMagicPointDrawOrder(actor, ally)
     .filter((entry): entry is { type: "item"; item: PhysicalItem } => entry.type === "item")
     .map((entry) => entry.item);
 }
 
 /**
- * Sum of current and max Magic Points across all of the actor's storage items - excludes self's
- * own pool. Shown as a running total next to the Magic Point Sources header icon.
+ * Sum of current and max Magic Points across all of the actor's storage items and, when linked, a
+ * usable Allied Spirit bond partner (#957) - excludes self's own pool. Shown as a running total
+ * next to the Magic Point Sources header icon, which is itself only shown when one of these
+ * sources is present (see showMagicPointSourcesButton), so the total must include the ally too or
+ * the badge misleadingly reads 0/0 for an ally-only actor.
  *
- * Accepts an already-computed storageItems list (e.g. from a caller that also needs it for
- * something else, like a render-time item count) to avoid re-walking the actor's items and
- * re-resolving the draw order a second time; defaults to computing it when not given.
+ * Accepts an already-computed storageItems list and/or ally (e.g. from a caller that also needs
+ * them for something else, like a render-time item count) to avoid re-walking the actor's items
+ * and re-resolving the allied bond a second time; both default to computing them when not given.
  */
 export function getTotalStoredMagicPoints(
   actor: RqgActor,
   storageItems: PhysicalItem[] = getStorageItems(actor),
+  ally: RqgActor | undefined = getAlliedBondActor(actor),
 ): { value: number; max: number } {
-  return storageItems.reduce(
+  const itemTotal = storageItems.reduce(
     (total, item) => ({
       value: total.value + (Number(item.system.storedMagicPoints?.value) || 0),
       max: total.max + (Number(item.system.storedMagicPoints?.max) || 0),
     }),
     { value: 0, max: 0 },
   );
+  if (!ally) {
+    return itemTotal;
+  }
+  return {
+    value: itemTotal.value + (Number(ally.system.attributes.magicPoints.value) || 0),
+    max: itemTotal.max + (Number(ally.system.attributes.magicPoints.max) || 0),
+  };
 }
 
 /**
@@ -152,21 +250,39 @@ export function moveSourceBefore(order: string[], id: string, beforeId: string |
 }
 
 /**
- * Options for a magic-point-source picker, excluding "auto"/"self" - only populated (non-empty)
- * when the actor actually has one or more storage items, since the dialog should only show a
- * picker at all when there is more than one possible source.
+ * Options for a magic-point-source picker, excluding "auto" - only populated (non-empty) when the
+ * actor actually has one or more storage items or a usable Allied Spirit bond partner (#957),
+ * since the dialog should only show a picker at all when there is more than one possible source.
+ * "Self"/ally/storage-item options are listed in the same order as the Magic Point Source Order
+ * popout (see getMagicPointDrawOrder) - "auto" is pinned first regardless, since it's a
+ * meta-option ("let the system decide") rather than a specific source pick.
  */
 export function getMagicPointSourceOptions(
   actor: RqgActor | null | undefined,
 ): SelectOptionData<string>[] {
-  const storageItems = actor ? getStorageItems(actor) : [];
-  if (storageItems.length === 0) {
+  const drawOrder = actor ? getMagicPointDrawOrder(actor) : [];
+  if (!drawOrder.some((entry) => entry.type !== "self")) {
     return [];
   }
   return [
     { value: AUTO_MAGIC_POINT_SOURCE, label: "RQG.Dialog.Common.MagicPointSourceOptions.Auto" },
-    { value: SELF_MAGIC_POINT_SOURCE, label: "RQG.Dialog.Common.MagicPointSourceOptions.Self" },
-    ...storageItems.map((item) => ({ value: item.id ?? "", label: item.name ?? "" })),
+    ...drawOrder.map((entry) => {
+      switch (entry.type) {
+        case "self":
+          return {
+            value: SELF_MAGIC_POINT_SOURCE,
+            label: "RQG.Dialog.Common.MagicPointSourceOptions.Self",
+          };
+        case "ally":
+          // Just the bond partner's name, not a templated "Allied Spirit (Name)" label: this
+          // option shows up from either side of the bond (see getAlliedBondActor), and "Allied
+          // Spirit" would read backwards when an ally casts using its bonded priest's Magic
+          // Points.
+          return { value: ALLY_MAGIC_POINT_SOURCE, label: entry.actor.name ?? "" };
+        case "item":
+          return { value: entry.item.id ?? "", label: entry.item.name ?? "" };
+      }
+    }),
   ];
 }
 
@@ -179,16 +295,30 @@ export function getAvailableMagicPoints(
     return selfAvailable;
   }
 
-  const storageItems = getStorageItems(actor);
-  if (selection === AUTO_MAGIC_POINT_SOURCE) {
-    const storedAvailable = storageItems.reduce(
-      (sum, item) => sum + (Number(item.system.storedMagicPoints?.value) || 0),
-      0,
-    );
-    return storedAvailable + selfAvailable;
+  if (selection === ALLY_MAGIC_POINT_SOURCE) {
+    const ally = getAlliedBondActor(actor);
+    return Number(ally?.system.attributes.magicPoints.value) || 0;
   }
 
-  const item = storageItems.find((i) => i.id === selection);
+  if (selection === AUTO_MAGIC_POINT_SOURCE) {
+    // A single draw-order pass instead of getStorageItems(actor) + getAlliedBondActor(actor)
+    // separately - both would otherwise resolve the allied bond a second time internally.
+    const drawOrder = getMagicPointDrawOrder(actor);
+    const storedAvailable = drawOrder.reduce(
+      (sum, entry) =>
+        entry.type === "item"
+          ? sum + (Number(entry.item.system.storedMagicPoints?.value) || 0)
+          : sum,
+      0,
+    );
+    const ally = drawOrder.find(
+      (entry): entry is { type: "ally"; actor: RqgActor } => entry.type === "ally",
+    )?.actor;
+    const allyAvailable = Number(ally?.system.attributes.magicPoints.value) || 0;
+    return storedAvailable + selfAvailable + allyAvailable;
+  }
+
+  const item = getStorageItems(actor).find((i) => i.id === selection);
   return Number(item?.system.storedMagicPoints?.value) || 0;
 }
 
@@ -229,22 +359,38 @@ export async function feedStorageFromSelf(actor: RqgActor, item: PhysicalItem): 
 }
 
 type MagicPointDraw = { item: PhysicalItem; amount: number };
+type MagicPointAllyDraw = { actor: RqgActor; amount: number };
 
 function resolveMagicPointDraws(
   actor: RqgActor,
   amount: number,
   selection: MagicPointSourceSelection,
-): { selfAmount: number; itemDraws: MagicPointDraw[] } {
+): { selfAmount: number; itemDraws: MagicPointDraw[]; allyDraw?: MagicPointAllyDraw } {
   if (selection === SELF_MAGIC_POINT_SOURCE) {
     return { selfAmount: amount, itemDraws: [] };
   }
 
+  if (selection === ALLY_MAGIC_POINT_SOURCE) {
+    // An explicitly picked single source never overflows - the caster chose that source on
+    // purpose (mirrors the single-storage-item case below).
+    const ally = getAlliedBondActor(actor);
+    const available = Number(ally?.system.attributes.magicPoints.value) || 0;
+    const draw = Math.min(available, amount);
+    return {
+      selfAmount: 0,
+      itemDraws: [],
+      allyDraw: ally && draw > 0 ? { actor: ally, amount: draw } : undefined,
+    };
+  }
+
   if (selection === AUTO_MAGIC_POINT_SOURCE) {
-    // Drain the actor's full draw order (storage items and self, interleaved by priority).
+    // Drain the actor's full draw order (storage items, self, and a linked ally, interleaved by
+    // priority).
     const selfAvailable = Number(actor.system.attributes.magicPoints.value) || 0;
     let remaining = amount;
     const itemDraws: MagicPointDraw[] = [];
     let selfAmount = 0;
+    let allyDraw: MagicPointAllyDraw | undefined;
     for (const entry of getMagicPointDrawOrder(actor)) {
       if (remaining <= 0) {
         break;
@@ -255,6 +401,15 @@ function resolveMagicPointDraws(
         remaining -= draw;
         continue;
       }
+      if (entry.type === "ally") {
+        const available = Number(entry.actor.system.attributes.magicPoints.value) || 0;
+        const draw = Math.min(available, remaining);
+        if (draw > 0) {
+          allyDraw = { actor: entry.actor, amount: draw };
+          remaining -= draw;
+        }
+        continue;
+      }
       const available = Number(entry.item.system.storedMagicPoints?.value) || 0;
       const draw = Math.min(available, remaining);
       if (draw > 0) {
@@ -262,7 +417,7 @@ function resolveMagicPointDraws(
         remaining -= draw;
       }
     }
-    return { selfAmount, itemDraws };
+    return { selfAmount, itemDraws, allyDraw };
   }
 
   // An explicitly picked single source never overflows - the caster chose that source on
@@ -290,10 +445,11 @@ export async function spendMagicPoints(
   if (amount <= 0) {
     return;
   }
-  const { selfAmount, itemDraws } = resolveMagicPointDraws(actor, amount, selection);
+  const { selfAmount, itemDraws, allyDraw } = resolveMagicPointDraws(actor, amount, selection);
 
-  // The item draws and the self-pool draw touch different documents with no data dependency
-  // between them, so they can be written concurrently rather than one awaited after the other.
+  // Item draws, the self-pool draw, and an ally draw all touch different documents with no data
+  // dependency between them, so they can be written concurrently rather than one awaited after
+  // the other.
   await Promise.all([
     itemDraws.length > 0
       ? actor.updateEmbeddedDocuments(
@@ -306,6 +462,14 @@ export async function spendMagicPoints(
               },
             },
           })),
+        )
+      : undefined,
+    allyDraw
+      ? allyDraw.actor.update(
+          foundry.utils.expandObject({
+            "system.attributes.magicPoints.value":
+              (Number(allyDraw.actor.system.attributes.magicPoints.value) || 0) - allyDraw.amount,
+          }),
         )
       : undefined,
     selfAmount > 0

--- a/src/system/rune-point-source.test.ts
+++ b/src/system/rune-point-source.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ALLY_RUNE_POINT_SOURCE,
+  getAlliedCultItem,
+  getAvailableRunePoints,
+  getRunePointSourceOptions,
+  SELF_RUNE_POINT_SOURCE,
+  spendRunePoints,
+} from "./rune-point-source";
+
+function fakeActor(
+  options: {
+    type?: string;
+    alliedSpiritActorUuid?: string;
+    uuid?: string;
+    isOwner?: boolean;
+  } = {},
+) {
+  return {
+    type: options.type ?? "character",
+    uuid: options.uuid,
+    isOwner: options.isOwner ?? true,
+    system: {
+      alliedSpiritActorUuid: options.alliedSpiritActorUuid,
+    },
+    updateEmbeddedDocuments: vi.fn(),
+  } as any;
+}
+
+/** A fake Cult item identified by rqid via the documentRqidFlags flag (see getCultRqid). */
+function fakeCult(id: string, name: string, rqid: string, rpValue: number, rpMax: number) {
+  return {
+    id,
+    name,
+    type: "cult",
+    system: { runePoints: { value: rpValue, max: rpMax } },
+    getFlag: vi.fn((_scope: string, key: string) =>
+      key === "documentRqidFlags" ? { id: rqid } : undefined,
+    ),
+  } as any;
+}
+
+/** A fake Allied Spirit bond partner actor - `instanceof Actor` per the global stub, so it
+ *  passes getAlliedSpirit's type-guard checks. Implements getBestEmbeddedDocumentByRqid the
+ *  same (simplified, no multi-match priority) way RqgActor does, since getAlliedCultItem uses it
+ *  to find the ally's matching cult. */
+function fakeAlly(cultItems: any[] = [], isOwner: boolean = true, name = "Whiskers") {
+  const ally = Object.create((globalThis as any).Actor.prototype);
+  return Object.assign(ally, {
+    name,
+    uuid: "Actor.ally1",
+    isOwner,
+    getBestEmbeddedDocumentByRqid: (rqid: string) =>
+      cultItems.find((i) => i.getFlag("rqg", "documentRqidFlags")?.id === rqid),
+    updateEmbeddedDocuments: vi.fn(),
+  });
+}
+
+describe("getAlliedCultItem", () => {
+  it("returns undefined when no bond partner is linked", () => {
+    const actor = fakeActor();
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 3);
+    expect(getAlliedCultItem(actor, cult)).toBeUndefined();
+  });
+
+  it("returns undefined when the bond partner has no Cult item at all", () => {
+    const actor = fakeActor({ alliedSpiritActorUuid: "Actor.ally1" });
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly([]));
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 3);
+    expect(getAlliedCultItem(actor, cult)).toBeUndefined();
+  });
+
+  it("returns undefined when the bond partner belongs to a different cult", () => {
+    const actor = fakeActor({ alliedSpiritActorUuid: "Actor.ally1" });
+    const allyCult = fakeCult("cult2", "Ernalda", "je.ernalda", 2, 2);
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly([allyCult]));
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 3);
+    expect(getAlliedCultItem(actor, cult)).toBeUndefined();
+  });
+
+  it("returns the bond partner's matching Cult item when rqids match", () => {
+    const actor = fakeActor({ alliedSpiritActorUuid: "Actor.ally1" });
+    const allyCult = fakeCult("cult2", "Orlanth", "je.orlanth", 2, 4);
+    const ally = fakeAlly([allyCult]);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 3);
+
+    expect(getAlliedCultItem(actor, cult)).toEqual({ actor: ally, cult: allyCult });
+  });
+
+  it("returns undefined when the caster's own cult item has no rqid to match on", () => {
+    const actor = fakeActor({ alliedSpiritActorUuid: "Actor.ally1" });
+    const allyCult = fakeCult("cult2", "Orlanth", "je.orlanth", 2, 4);
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly([allyCult]));
+    const cult = fakeCult("cult1", "Homebrew Cult", undefined as unknown as string, 3, 3);
+
+    expect(getAlliedCultItem(actor, cult)).toBeUndefined();
+  });
+});
+
+describe("getRunePointSourceOptions", () => {
+  it("is empty when there's no bond partner", () => {
+    const actor = fakeActor();
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 3);
+    expect(getRunePointSourceOptions(actor, cult)).toEqual([]);
+  });
+
+  it("lists self and the ally when the bond partner shares the same cult", () => {
+    const actor = fakeActor({ alliedSpiritActorUuid: "Actor.ally1" });
+    const allyCult = fakeCult("cult2", "Orlanth", "je.orlanth", 2, 4);
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly([allyCult], true, "Whiskers"));
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 3);
+
+    expect(getRunePointSourceOptions(actor, cult)).toEqual([
+      { value: "self", label: "RQG.Dialog.Common.RunePointSourceOptions.Self" },
+      { value: "ally", label: "Whiskers" },
+    ]);
+  });
+
+  it("is empty when the bond partner isn't initiated to this cult", () => {
+    const actor = fakeActor({ alliedSpiritActorUuid: "Actor.ally1" });
+    const allyCult = fakeCult("cult2", "Ernalda", "je.ernalda", 2, 2);
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly([allyCult]));
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 3);
+
+    expect(getRunePointSourceOptions(actor, cult)).toEqual([]);
+  });
+});
+
+describe("getAvailableRunePoints", () => {
+  it("defaults to the cult's own Rune Points", () => {
+    const actor = fakeActor();
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 5);
+    expect(getAvailableRunePoints(actor, cult)).toBe(3);
+    expect(getAvailableRunePoints(actor, cult, SELF_RUNE_POINT_SOURCE)).toBe(3);
+  });
+
+  it("returns the ally's Rune Points for that same cult when selected", () => {
+    const actor = fakeActor({ alliedSpiritActorUuid: "Actor.ally1" });
+    const allyCult = fakeCult("cult2", "Orlanth", "je.orlanth", 2, 4);
+    (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly([allyCult]));
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 3);
+
+    expect(getAvailableRunePoints(actor, cult, ALLY_RUNE_POINT_SOURCE)).toBe(2);
+  });
+
+  it("returns 0 for the ally source when no matching ally cult exists", () => {
+    const actor = fakeActor();
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 3);
+    expect(getAvailableRunePoints(actor, cult, ALLY_RUNE_POINT_SOURCE)).toBe(0);
+  });
+});
+
+describe("spendRunePoints", () => {
+  it("deducts from the caster's own cult for the self source (default)", async () => {
+    const actor = fakeActor();
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 5);
+
+    await spendRunePoints(actor, cult, 2);
+
+    expect(actor.updateEmbeddedDocuments).toHaveBeenCalledWith("Item", [
+      { _id: "cult1", system: { runePoints: { value: 1, max: 5 } } },
+    ]);
+  });
+
+  it("deducts from the ally's matching cult for the ally source", async () => {
+    const actor = fakeActor({ alliedSpiritActorUuid: "Actor.ally1" });
+    const allyCult = fakeCult("cult2", "Orlanth", "je.orlanth", 4, 4);
+    const ally = fakeAlly([allyCult]);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 3);
+
+    await spendRunePoints(actor, cult, 2, ALLY_RUNE_POINT_SOURCE);
+
+    expect(ally.updateEmbeddedDocuments).toHaveBeenCalledWith("Item", [
+      { _id: "cult2", system: { runePoints: { value: 2, max: 4 } } },
+    ]);
+    expect(actor.updateEmbeddedDocuments).not.toHaveBeenCalled();
+  });
+
+  it("also reduces max for a one-use spell and notifies", async () => {
+    const actor = fakeActor();
+    const cult = fakeCult("cult1", "Orlanth", "je.orlanth", 3, 5);
+
+    await spendRunePoints(actor, cult, 2, SELF_RUNE_POINT_SOURCE, true);
+
+    expect(actor.updateEmbeddedDocuments).toHaveBeenCalledWith("Item", [
+      { _id: "cult1", system: { runePoints: { value: 1, max: 3 } } },
+    ]);
+    expect(ui.notifications?.info).toHaveBeenCalled();
+  });
+});

--- a/src/system/rune-point-source.ts
+++ b/src/system/rune-point-source.ts
@@ -1,0 +1,128 @@
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import type { CultItem } from "@item-model/cult-data-model.ts";
+import type { RqidString } from "./api/rqid-api";
+import { localize } from "./util";
+import { systemId } from "./config";
+import { documentRqidFlags } from "../data-model/shared/rqg-document-flags";
+import { getAlliedBondActor } from "./magic-point-source";
+
+/**
+ * Where to draw Rune Points from when casting a Rune Magic spell (#957).
+ * "self" - the caster's own cult pool (default, matches pre-#957 behavior; unlike Magic Points,
+ *          Rune Points never had an "auto"/storage-item concept - they only ever came from the
+ *          cult tied to the spell).
+ * "ally" - the caster's linked Allied Spirit bond partner's Rune Points for that *same* cult (see
+ *          getAlliedCultItem). Only offered as an option when such a matching cult exists.
+ *
+ * Bond resolution and ownership gating (which side of the bond is usable, by whom) is not
+ * reimplemented here - getAlliedCultItem goes through getAlliedBondActor from
+ * magic-point-source.ts, the single source of truth also used for Magic Point sharing. A future
+ * change to that gating (e.g. tightening the isOwner check) applies to both Rune and Magic Point
+ * sharing automatically.
+ */
+export type RunePointSourceSelection = string;
+
+export const SELF_RUNE_POINT_SOURCE = "self";
+export const ALLY_RUNE_POINT_SOURCE = "ally";
+
+/**
+ * The rqid identifying which cult a Cult item represents (e.g. "je.orlanth") - the same compendium
+ * cult copied onto two different actors' sheets shares this id, unlike `deity` which is just
+ * display text and can vary (e.g. subcults).
+ */
+function getCultRqid(cult: CultItem): RqidString | undefined {
+  return cult.getFlag(systemId, documentRqidFlags)?.id;
+}
+
+/**
+ * The linked Allied Spirit bond partner's (#957, either direction - see getAlliedBondActor)
+ * embedded Cult item for the *same* cult as `cult`, matched by rqid. Core p.277: "An allied
+ * spirit is an initiate of the cult and can sacrifice for Rune points, just as a normal
+ * initiate" - the ally only shares Rune Points for the cult it's actually initiated to, not any
+ * cult either side happens to belong to.
+ */
+export function getAlliedCultItem(
+  actor: RqgActor,
+  cult: CultItem,
+): { actor: RqgActor; cult: CultItem } | undefined {
+  const ally = getAlliedBondActor(actor);
+  const cultRqid = getCultRqid(cult);
+  if (!ally || !cultRqid) {
+    return undefined;
+  }
+  const allyCult = ally.getBestEmbeddedDocumentByRqid(cultRqid) as CultItem | undefined;
+  return allyCult ? { actor: ally, cult: allyCult } : undefined;
+}
+
+/**
+ * Options for a Rune Point source picker, excluding "self" - only populated (non-empty) when the
+ * caster has a usable Allied Spirit bond partner (#957) who's also initiated to this same cult,
+ * since the dialog should only show a picker at all when there's a second possible source.
+ */
+export function getRunePointSourceOptions(
+  actor: RqgActor | null | undefined,
+  cult: CultItem | null | undefined,
+): SelectOptionData<string>[] {
+  const allied = actor && cult ? getAlliedCultItem(actor, cult) : undefined;
+  if (!allied) {
+    return [];
+  }
+  return [
+    { value: SELF_RUNE_POINT_SOURCE, label: "RQG.Dialog.Common.RunePointSourceOptions.Self" },
+    // Just the bond partner's name, not a templated "Allied Spirit (Name)" label - same reasoning
+    // as the "ally" case in getMagicPointSourceOptions (magic-point-source.ts).
+    { value: ALLY_RUNE_POINT_SOURCE, label: allied.actor.name ?? "" },
+  ];
+}
+
+export function getAvailableRunePoints(
+  actor: RqgActor | null | undefined,
+  cult: CultItem | null | undefined,
+  source: RunePointSourceSelection = SELF_RUNE_POINT_SOURCE,
+): number {
+  if (source === ALLY_RUNE_POINT_SOURCE && actor && cult) {
+    const allied = getAlliedCultItem(actor, cult);
+    return Number(allied?.cult.system.runePoints.value) || 0;
+  }
+  return Number(cult?.system.runePoints.value) || 0;
+}
+
+/**
+ * Deduct `amount` Rune Points from `cult`, or - when `source` is "ally" and a matching cult
+ * exists on the linked Allied Spirit bond partner (#957) - from the ally's Cult item instead (see
+ * getAlliedCultItem). `isOneUse` also reduces the target cult's max, matching a one-use Rune
+ * spell's cost (Core rules). Validation (is there enough available) is expected to have already
+ * happened via getAvailableRunePoints() - by this point a shortfall is simply drawn as far as it
+ * goes, mirroring spendMagicPoints in magic-point-source.ts.
+ */
+export async function spendRunePoints(
+  actor: RqgActor,
+  cult: CultItem,
+  amount: number,
+  source: RunePointSourceSelection = SELF_RUNE_POINT_SOURCE,
+  isOneUse: boolean = false,
+): Promise<void> {
+  const allied = source === ALLY_RUNE_POINT_SOURCE ? getAlliedCultItem(actor, cult) : undefined;
+  const targetActor = allied?.actor ?? actor;
+  const targetCult = allied?.cult ?? cult;
+
+  const newValue = (targetCult.system.runePoints.value || 0) - amount;
+  let newMax = targetCult.system.runePoints.max || 0;
+  if (isOneUse) {
+    newMax -= amount;
+    if (newMax < (targetCult.system.runePoints.max || 0)) {
+      ui.notifications?.info(
+        localize("RQG.Item.RuneMagic.SpentOneUseRunePoints", {
+          actorName: targetActor.name,
+          runePoints: amount.toString(),
+          cultName: targetCult.name,
+        }),
+      );
+    }
+  }
+  const updateCultItemRunePoints: Item.UpdateData = {
+    _id: targetCult.id,
+    system: { runePoints: { value: newValue, max: newMax } },
+  } as any; // runePoints is a cult-specific field not in the base Item update type
+  await targetActor.updateEmbeddedDocuments("Item", [updateCultItemRunePoints]);
+}

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -90,7 +90,7 @@
     },
     "Actor": {
       "Attributes": {
-        "AlliesAndNotes": "Allies & Notes",
+        "AlliesAndNotes": "Notes",
         "StrikeRank": "Strike Rank",
         "SizeAbbr": "SIZ",
         "DexterityAbbr": "DEX",
@@ -381,6 +381,13 @@
         "Stackable": "Stackable",
         "OneUse": "One Use",
         "Chance": "Chance",
+        "AlliedSpiritLabel": "Allied Spirit:",
+        "AllyOfLabel": "Ally of:",
+        "AlliedSpiritDropHint": "Drag an Actor here to link it as this character's Allied Spirit",
+        "UnlinkAlliedSpiritTitle": "Unlink Allied Spirit",
+        "AlliedSpiritDropRequiresActorWarn": "Drop an Actor to link it as an Allied Spirit",
+        "AlliedSpiritDropRequiresCharacterWarn": "Only a Character actor can be linked as an Allied Spirit",
+        "AlliedSpiritCannotLinkSelfWarn": "A character cannot be its own Allied Spirit",
         "CultRank": {
           "layMember": "Lay Member",
           "initiate": "Initiate",
@@ -585,6 +592,7 @@
         "MeditateRitual": "Meditate / Ritual",
         "Meditate": "meditate",
         "MagicPointSource": "Magic Point Source",
+        "RunePointSource": "Rune Point Source",
         "OneUseHeader": "One Use",
         "OneUseDescription": "Casting this spell will reduce both your current and total Rune Points for the cult!"
       },
@@ -623,6 +631,9 @@
         },
         "MagicPointSourceOptions": {
           "Auto": "Auto (use the Magic Point Source Order set in the header)",
+          "Self": "Self"
+        },
+        "RunePointSourceOptions": {
           "Self": "Self"
         },
         "MeditateOptions": {

--- a/test/setup/foundryMockFunctions.js
+++ b/test/setup/foundryMockFunctions.js
@@ -28,6 +28,9 @@ globalThis.game = {
   i18n: {
     format: vi.fn((key, data = {}) => `${key} + ${Object.entries(data).join()}`),
   },
+  actors: {
+    contents: [],
+  },
 };
 
 globalThis.ui = {
@@ -226,9 +229,22 @@ globalThis.navigator.clipboard = {
 };
 
 globalThis.fromUuid = vi.fn(async (_uuid) => null);
+globalThis.fromUuidSync = vi.fn((_uuid) => null);
 globalThis.ChatMessage = null;
 globalThis.Item = null;
+globalThis.Actor = class Actor {};
 globalThis.systemId = "rqg";
+
+// Reset per-test mutations to shared mocks (fromUuidSync return value, game.actors.contents)
+// so tests that configure them (e.g. Allied Spirit bond lookups) don't leak into later tests.
+// Guarded: some test files replace globalThis.game/fromUuidSync entirely with their own mocks.
+afterEach(() => {
+  globalThis.fromUuidSync?.mockReset?.();
+  globalThis.fromUuidSync?.mockReturnValue?.(null);
+  if (globalThis.game?.actors) {
+    globalThis.game.actors.contents = [];
+  }
+});
 
 // Simple Handlebars stub (add real features as needed)
 globalThis.Handlebars = {


### PR DESCRIPTION
## Summary

Phase 3 of #957 (Allied Spirit): a caster can now pick their linked Allied Spirit bond partner as the Rune Point source when casting Rune Magic, sharing Rune Points bidirectionally for whichever cult both sides are initiated to (Core p.277). This builds on the Phase 2 Magic Point link merged in #998.

- New `src/system/rune-point-source.ts` — mirrors the Magic Point picker in `magic-point-source.ts`, sharing its bond resolution/ownership gating (`getAlliedBondActor`) so future gating changes apply to both automatically.
- Fixes the schema generator emitting `"object"` instead of `"string"` for `DocumentUUIDField` (surfaced by the new `alliedSpiritActorUuid` field).
- Renames the internal "companion" terminology to "ally" throughout the Magic Point source code and tests, to match the `ALLY_MAGIC_POINT_SOURCE` / `ALLY_RUNE_POINT_SOURCE` naming already in use.

## Test plan
- [x] `vitest run` — 646 tests passing
- [x] `tsc --noEmit` — clean
- [x] `pnpm i18n:audit-unused` — no unused/missing keys
- [x] Manual check in Foundry: cast a Rune Magic spell as a priest with a linked Allied Spirit and confirm the "ally" Rune Point source draws from the bond partner's cult item