### PR TITLE
fix: include cults in Rqid coverage, warn on Allied Spirit cult mismatch

### DIFF
--- a/src/applications/rqid-batch-editor/rqid-batch-editor.ts
+++ b/src/applications/rqid-batch-editor/rqid-batch-editor.ts
@@ -27,6 +27,18 @@ import type {
   RqidBatchEditorOptions,
 } from "./rqid-batch-editor.types";
 
+/**
+ * Item types that must have an rqid for other RQG features to keep working. Used both to gate
+ * world migration (migrateWorld) and as the no-args default for the macro-facing
+ * game.system.api.migration.openRqidBatchEditor - kept as a single list so the two don't drift.
+ */
+export const DEFAULT_RQID_BATCH_ITEM_TYPES: ItemTypeEnum[] = [
+  ItemTypeEnum.Skill, // weapon skills need Rqid for weapon -> skill link
+  ItemTypeEnum.RuneMagic, // common spells need Rqid for visualisation in spell list
+  ItemTypeEnum.Rune, // Rune tab needs rqid to sort opposed rune pairs into the fixed paper-character-sheet order
+  ItemTypeEnum.Cult, // cults need rqid to match the same cult across actors for Allied Spirit's shared rune point pool
+];
+
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 export class RqidBatchEditor extends HandlebarsApplicationMixin(
@@ -243,7 +255,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
       RqidBatchEditor.logger.warn("Generate RQID clicked but no item name was found in target.");
       return;
     }
-    const rqidSuffix = toKebabCase(name);
+    const rqidSuffix = Rqid.getDefaultRqidIdentifier(name, this.batchConfig.itemType);
     const newRqid = rqidSuffix ? this.batchConfig.idPrefix + rqidSuffix : undefined;
     this.changes.itemName2Rqid.set(name, newRqid);
     this.updateRowInput(target, rqidSuffix);

--- a/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-data.types.ts
+++ b/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-data.types.ts
@@ -29,6 +29,7 @@ export type RuneMagicRollDialogContext = RollHeaderData &
     showMagicPointSource: boolean;
     runePointSourceOptions: SelectOptionData<string>[];
     showRunePointSource: boolean;
+    showRunePointSourceMismatchWarning: boolean;
   };
 
 export type RuneMagicRollDialogFormData = {

--- a/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.hbs
+++ b/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.hbs
@@ -22,6 +22,13 @@
       </select>
     {{/if}}
 
+    {{#if showRunePointSourceMismatchWarning}}
+      <label>
+        {{localize "RQG.Dialog.RuneMagicRoll.RunePointSource"}}
+      </label>
+      <div class="warning">{{localize "RQG.Dialog.RuneMagicRoll.RunePointSourceMismatchWarning"}}</div>
+    {{/if}}
+
     {{#if isOneUse}}
       <label>{{localize "RQG.Dialog.RuneMagicRoll.OneUseHeader"}}</label>
       <div class="warning">{{localize "RQG.Dialog.RuneMagicRoll.OneUseDescription"}}</div>

--- a/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.ts
+++ b/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.ts
@@ -25,6 +25,7 @@ import {
 import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
 import {
   AUTO_MAGIC_POINT_SOURCE,
+  getAlliedBondActor,
   getMagicPointSourceOptions,
 } from "../../system/magic-point-source";
 import { getRunePointSourceOptions, SELF_RUNE_POINT_SOURCE } from "../../system/rune-point-source";
@@ -170,6 +171,14 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
       this.spellItem.actor,
       this.spellItem.system.getCult(),
     );
+    // A bonded ally exists but doesn't have a Cult item matching this spell's exact cult (e.g. a
+    // different subcult of the same deity) - without this, that misconfiguration is silent: the
+    // picker just never appears, indistinguishable from having no bond at all.
+    const alliedBondActor = this.spellItem.actor
+      ? getAlliedBondActor(this.spellItem.actor)
+      : undefined;
+    const showRunePointSourceMismatchWarning =
+      runePointSourceOptions.length === 0 && !!alliedBondActor;
 
     return {
       formData: formData,
@@ -186,6 +195,7 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
       showMagicPointSource: magicPointSourceOptions.length > 0 && Number(formData.boost) > 0,
       runePointSourceOptions: runePointSourceOptions,
       showRunePointSource: runePointSourceOptions.length > 0,
+      showRunePointSourceMismatchWarning: showRunePointSourceMismatchWarning,
 
       // RollHeader
       rollType: localize("TYPES.Item.runeMagic"),

--- a/src/rqg.ts
+++ b/src/rqg.ts
@@ -19,7 +19,10 @@ import { TextEditorHooks } from "./foundry-ui/text-editor-hooks";
 import { RqgJournalEntry } from "./journals/rqg-journal-entry";
 import { getTokenStatusEffects } from "./system/token-status-effects";
 import { RqgSettings } from "./foundry-ui/rqg-settings";
-import { RqidBatchEditor } from "./applications/rqid-batch-editor/rqid-batch-editor";
+import {
+  DEFAULT_RQID_BATCH_ITEM_TYPES,
+  RqidBatchEditor,
+} from "./applications/rqid-batch-editor/rqid-batch-editor";
 import { ItemTypeEnum } from "@item-model/item-types.ts";
 import { initSockets } from "./sockets/rqg-socket";
 import { AbilityRoll } from "./rolls/ability-roll/ability-roll";
@@ -132,11 +135,7 @@ Hooks.once("init", () => {
         const itemTypeEnums = (
           itemTypes.length
             ? itemTypes.map((it) => it as ItemTypeEnum)
-            : [
-                ItemTypeEnum.Skill, // weapon skills need Rqid for weapon -> skill link
-                ItemTypeEnum.RuneMagic, // common spells need Rqid for visualisation in spell list
-                ItemTypeEnum.Rune, // Future needs
-              ]
+            : DEFAULT_RQID_BATCH_ITEM_TYPES
         ) as Item.SubType[];
         await RqidBatchEditor.factory(...itemTypeEnums);
       },

--- a/src/system/api/rqid-api.test.ts
+++ b/src/system/api/rqid-api.test.ts
@@ -390,6 +390,94 @@ describe("Rqid", () => {
     });
   });
 
+  describe("getDefaultRqid", () => {
+    afterEach(() => {
+      globalThis.Item = originalItem;
+    });
+
+    const originalItem = globalThis.Item;
+
+    it("derives a cult identifier from the full item name, keeping subcults of the same deity distinct", () => {
+      // Subcults (e.g. Orlanth Adventurous, Orlanth Thunderous) share a deity but must not share
+      // an rqid - Allied Spirit rune point sharing (rune-point-source.ts) matches cults by their
+      // exact rqid, and subcults are deliberately NOT interchangeable for that purpose even though
+      // they share a deity (see cult-lifecycle.ts, which only merges same-deity cults on one actor).
+      globalThis.Item = class {} as any;
+      const doc = {
+        documentName: "Item",
+        type: "cult",
+        name: "Orlanth Adventurous (Orlanth)",
+        system: { deity: "Orlanth" },
+      };
+      Object.setPrototypeOf(doc, globalThis.Item.prototype);
+
+      expect(Rqid.getDefaultRqid(doc as any)).toBe("i.cult.orlanth-adventurous-orlanth");
+    });
+
+    it("derives the same cult identifier as the base deity when there is no subcult", () => {
+      globalThis.Item = class {} as any;
+      const doc = {
+        documentName: "Item",
+        type: "cult",
+        name: "Ernalda",
+        system: { deity: "Ernalda" },
+      };
+      Object.setPrototypeOf(doc, globalThis.Item.prototype);
+
+      expect(Rqid.getDefaultRqid(doc as any)).toBe("i.cult.ernalda");
+    });
+
+    it("derives a skill identifier from skillName and specialization", () => {
+      globalThis.Item = class {} as any;
+      const doc = {
+        documentName: "Item",
+        type: "skill",
+        name: "Sword (Broadsword)",
+        system: { skillName: "Sword", specialization: "Broadsword" },
+      };
+      Object.setPrototypeOf(doc, globalThis.Item.prototype);
+
+      expect(Rqid.getDefaultRqid(doc as any)).toBe("i.skill.sword-broadsword");
+    });
+
+    it("uses the plain document name for non-special-cased item types", () => {
+      globalThis.Item = class {} as any;
+      const doc = {
+        documentName: "Item",
+        type: "gear",
+        name: "Sturdy Rope",
+        system: {},
+      };
+      Object.setPrototypeOf(doc, globalThis.Item.prototype);
+
+      expect(Rqid.getDefaultRqid(doc as any)).toBe("i.gear.sturdy-rope");
+    });
+  });
+
+  describe("getDefaultRqidIdentifier", () => {
+    it("derives a cult identifier from the full name regardless of system data", () => {
+      expect(
+        Rqid.getDefaultRqidIdentifier("Orlanth Adventurous (Orlanth)", "cult", {
+          deity: "Orlanth",
+        }),
+      ).toBe("orlanth-adventurous-orlanth");
+    });
+
+    it("falls back to the name when no system data is available (e.g. batch editor without a matched document)", () => {
+      expect(Rqid.getDefaultRqidIdentifier("Ernalda", "cult", undefined)).toBe("ernalda");
+    });
+
+    it("derives an armor identifier from namePrefix, armorType and material", () => {
+      expect(
+        Rqid.getDefaultRqidIdentifier("Fine Bronze Cuirass", "armor", {
+          namePrefix: "Fine",
+          armorType: "Cuirass",
+          material: "Bronze",
+        }),
+      ).toBe("fine-cuirass-bronze");
+    });
+  });
+
   describe("setRqid and setDefaultRqid", () => {
     it("sets rqid flag with provided values", async () => {
       const setFlag = vi.fn().mockResolvedValue(undefined);

--- a/src/system/api/rqid-api.ts
+++ b/src/system/api/rqid-api.ts
@@ -1,14 +1,7 @@
 import { ItemTypeEnum } from "@item-model/item-types.ts";
 import { systemId } from "../config";
 import { getDefaultItemIconSettings } from "../settings/default-item-icons";
-import {
-  getAvailableRunes,
-  isDocumentSubType,
-  localize,
-  RqgError,
-  toKebabCase,
-  trimChars,
-} from "../util";
+import { getAvailableRunes, localize, RqgError, toKebabCase, trimChars } from "../util";
 import {
   documentRqidFlags,
   type DocumentRqidFlags,
@@ -377,6 +370,45 @@ export class Rqid {
   }
 
   /**
+   * Compute the default rqid identifier segment (the last `.`-separated part of an item rqid)
+   * from a name, item subtype and optional system data. This is the single source of truth for
+   * how a default rqid identifier is derived, shared by getDefaultRqid (which operates on real
+   * Documents) and the RqidBatchEditor (which mostly only has plain item data available, e.g.
+   * from compendium indexes or actor.toObject()).
+   */
+  public static getDefaultRqidIdentifier(
+    name: string | null | undefined,
+    itemType?: string,
+    system?: Record<string, unknown>,
+  ): string {
+    let rqidIdentifier = "";
+
+    if (itemType === ItemTypeEnum.Skill) {
+      rqidIdentifier = trimChars(
+        toKebabCase(
+          `${(system?.["skillName"] as string) ?? ""}-${(system?.["specialization"] as string) ?? ""}`,
+        ),
+        "-",
+      );
+    }
+    if (itemType === ItemTypeEnum.Armor) {
+      rqidIdentifier = trimChars(
+        toKebabCase(
+          `${(system?.["namePrefix"] as string) ?? ""}-${(system?.["armorType"] as string) ?? ""}-${
+            (system?.["material"] as string) ?? ""
+          }`,
+        ),
+        "-",
+      );
+    }
+    if (!rqidIdentifier) {
+      rqidIdentifier = trimChars(toKebabCase(name ?? ""), "-");
+    }
+
+    return rqidIdentifier;
+  }
+
+  /**
    * Given a Document, create a valid rqid string for the document.
    */
   public static getDefaultRqid(document: RqidEnabledDocument | Document.Any): RqidString | "" {
@@ -386,29 +418,10 @@ export class Rqid {
 
     const rqidDocumentString = Rqid.getRqidDocumentName(document);
     const documentSubType = toKebabCase("type" in document ? String(document.type) : "");
-    let rqidIdentifier = "";
-
-    if (document instanceof Item) {
-      if (isDocumentSubType<SkillItem>(document, ItemTypeEnum.Skill)) {
-        rqidIdentifier = trimChars(
-          toKebabCase(`${document.system.skillName ?? ""}-${document.system.specialization ?? ""}`),
-          "-",
-        );
-      }
-      if (isDocumentSubType<ArmorItem>(document, ItemTypeEnum.Armor)) {
-        rqidIdentifier = trimChars(
-          toKebabCase(
-            `${document.system.namePrefix ?? ""}-${document.system.armorType ?? ""}-${
-              document.system.material ?? ""
-            }`,
-          ),
-          "-",
-        );
-      }
-    }
-    if (!rqidIdentifier) {
-      rqidIdentifier = trimChars(toKebabCase(document.name), "-");
-    }
+    const itemType = document instanceof Item ? String(document.type) : undefined;
+    const system =
+      document instanceof Item ? (document.system as Record<string, unknown>) : undefined;
+    const rqidIdentifier = Rqid.getDefaultRqidIdentifier(document.name, itemType, system);
 
     return `${rqidDocumentString}.${documentSubType}.${rqidIdentifier}` as RqidString;
   }

--- a/src/system/migrations/migrate-world.ts
+++ b/src/system/migrations/migrate-world.ts
@@ -12,8 +12,10 @@ import { systemId } from "../config";
 import { tagSkillNameSkillsWithRqid } from "./migrations-item/tag-skill-name-skills-with-rqid";
 import { migrateWorldDialog } from "../../applications/migrate-world-dialog";
 import { migrateWeaponSkillLinks } from "./migrations-item/migrate-weapon-skill-links";
-import { ItemTypeEnum } from "@item-model/item-types.ts";
-import { RqidBatchEditor } from "../../applications/rqid-batch-editor/rqid-batch-editor";
+import {
+  DEFAULT_RQID_BATCH_ITEM_TYPES,
+  RqidBatchEditor,
+} from "../../applications/rqid-batch-editor/rqid-batch-editor";
 import { openDataModelRepairDialog } from "../api/data-model-repair";
 import { migrateRuneItemType } from "./migrations-item/migrate-rune-item-type";
 import { relabelRuneMagicCommandCultSpiritRqid } from "./migrations-item/relabel-rune-magic-command-cult-spirit-rqid";
@@ -59,11 +61,7 @@ export async function migrateWorld(): Promise<void> {
   await runDataModelRepairPreflight();
 
   // Open a dialog to set missing Rqids on selected items
-  await RqidBatchEditor.factory(
-    ItemTypeEnum.Skill, // weapon skills need Rqid for weapon -> skill link
-    ItemTypeEnum.RuneMagic, // common spells need Rqid for visualisation in spell list
-    ItemTypeEnum.Rune, // Future needs
-  );
+  await RqidBatchEditor.factory(...DEFAULT_RQID_BATCH_ITEM_TYPES);
 
   const confirmed = await migrateWorldDialog(systemVersion);
   if (!confirmed) {

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -593,6 +593,7 @@
         "Meditate": "meditate",
         "MagicPointSource": "Magic Point Source",
         "RunePointSource": "Rune Point Source",
+        "RunePointSourceMismatchWarning": "Your Allied Spirit isn't initiated to this same cult, so Rune Points can't be shared for this spell.",
         "OneUseHeader": "One Use",
         "OneUseDescription": "Casting this spell will reduce both your current and total Rune Points for the cult!"
       },


### PR DESCRIPTION
## Summary
- Cults are now included in the `RqidBatchEditor` coverage run during world migration (and the macro-facing `game.system.api.migration.openRqidBatchEditor` default), so pre-existing cult items get a chance to be assigned an rqid.
- `RqidBatchEditor`'s "guess" button now reuses `Rqid.getDefaultRqid`'s identifier logic (extracted into `Rqid.getDefaultRqidIdentifier`) instead of reimplementing its own `toKebabCase(name)`.
- The Rune Magic cast dialog now shows an explicit warning when a bonded Allied Spirit (#957) exists but doesn't share the exact cult with the caster, instead of the Rune Point source picker just silently not appearing.
- De-duplicated the default Rqid-coverage item-type list that had drifted between `migrate-world.ts` and `rqg.ts` into one shared `DEFAULT_RQID_BATCH_ITEM_TYPES` constant.

Closes #1004

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm i18n:audit-unused --lang en --fail-on-unused`
- [x] `pnpm vitest run` (653 passing)
- [x] Manual: open the Rune Magic cast dialog for a spell whose cult is missing on the Allied Spirit's sheet, confirm the warning renders instead of the picker