### PR TITLE
refactor: rename rqid parts to kind/type/slug for a single shared vocabulary

### DIFF
--- a/src/applications/rqid-batch-editor/rqid-batch-editor.hbs
+++ b/src/applications/rqid-batch-editor/rqid-batch-editor.hbs
@@ -20,8 +20,8 @@
             </select>
           </div>
           <div class="value flexrow">
-            <span class="rqid-prefix">{{../idPrefix}}</span>
-            <input class="rqid-input {{#unless selectedRqidSuffix}}missing{{/unless}}" type="text" value="{{selectedRqidSuffix}}" data-name="{{name}}">
+            <span class="rqid-prefix">{{../prefix}}</span>
+            <input class="rqid-input {{#unless selectedSlug}}missing{{/unless}}" type="text" value="{{selectedSlug}}" data-name="{{name}}">
             <button type="button" class="generate-rqid" data-action="generateRqid" data-name="{{name}}" data-tooltip="{{localize "RQG.RQGSystem.Rqid.GenerateDefault"}}" data-tooltip-class="rqid-batch-editor-tooltip" data-tooltip-direction="RIGHT">
               <i class="fas fa-wand-magic-sparkles"></i>
             </button>

--- a/src/applications/rqid-batch-editor/rqid-batch-editor.ts
+++ b/src/applications/rqid-batch-editor/rqid-batch-editor.ts
@@ -141,7 +141,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
           name: itemName,
           rqid: this.batchConfig.existingRqids.get(itemName) ?? "",
           selectedRqid: this.changes.itemName2Rqid.get(itemName),
-          selectedRqidSuffix: this.changes.itemName2Rqid
+          selectedSlug: this.changes.itemName2Rqid
             .get(itemName)
             ?.replace(this.batchConfig.prefixRegex ?? "", ""),
         });
@@ -168,7 +168,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
     return {
       summary: summary,
       itemType: this.batchConfig.itemType,
-      idPrefix: this.batchConfig.idPrefix,
+      prefix: this.batchConfig.prefix,
       existingRqidOptions: existingRqidOptions,
       itemNamesWithoutRqid: itemNamesWithoutRqid,
       buttons: [
@@ -243,10 +243,8 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
     const newRqid = selectedRqid || undefined;
     this.changes.itemName2Rqid.set(name, newRqid);
 
-    const rqidSuffix = selectedRqid
-      ? selectedRqid.replace(this.batchConfig.prefixRegex ?? "", "")
-      : "";
-    this.updateRowInput(target, rqidSuffix);
+    const slug = selectedRqid ? selectedRqid.replace(this.batchConfig.prefixRegex ?? "", "") : "";
+    this.updateRowInput(target, slug);
   }
 
   onClickGuess(target: HTMLElement): void {
@@ -255,10 +253,10 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
       RqidBatchEditor.logger.warn("Generate RQID clicked but no item name was found in target.");
       return;
     }
-    const rqidSuffix = Rqid.getDefaultRqidIdentifier(name, this.batchConfig.itemType);
-    const newRqid = rqidSuffix ? this.batchConfig.idPrefix + rqidSuffix : undefined;
+    const slug = Rqid.getDefaultRqidSlug(name, this.batchConfig.itemType);
+    const newRqid = slug ? this.batchConfig.prefix + slug : undefined;
     this.changes.itemName2Rqid.set(name, newRqid);
-    this.updateRowInput(target, rqidSuffix);
+    this.updateRowInput(target, slug);
   }
 
   onTypeRqid(target: HTMLInputElement): void {
@@ -267,8 +265,8 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
 
   private applyTypedRqid(target: HTMLInputElement): void {
     const name = getDomDataset(target, "name") ?? "";
-    const rqidSuffix = toKebabCase(convertFormValueToString(target.value));
-    const newRqid = rqidSuffix ? this.batchConfig.idPrefix + rqidSuffix : undefined;
+    const slug = toKebabCase(convertFormValueToString(target.value));
+    const newRqid = slug ? this.batchConfig.prefix + slug : undefined;
     this.changes.itemName2Rqid.set(name, newRqid);
 
     const rowElement = target.closest(".document-row");
@@ -276,18 +274,18 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
       return;
     }
 
-    this.updateRowInput(target, rqidSuffix);
+    this.updateRowInput(target, slug);
   }
 
-  private updateRowInput(target: HTMLElement, rqidSuffix: string): void {
+  private updateRowInput(target: HTMLElement, slug: string): void {
     const rowElement = target.closest(".document-row");
     const rowInput = rowElement?.querySelector(".rqid-input") as HTMLInputElement | null;
     if (!rowInput) {
       return;
     }
 
-    rowInput.value = rqidSuffix;
-    rowInput.classList.toggle("missing", !rqidSuffix);
+    rowInput.value = slug;
+    rowInput.classList.toggle("missing", !slug);
   }
 
   private async onFormSubmit(event: SubmitEvent): Promise<void> {
@@ -535,7 +533,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
   // ---
 
   static async findItemsWithMissingRqids(
-    documentType: Item.SubType,
+    type: Item.SubType,
     prefixRegex: RegExp,
   ): Promise<{
     sceneChangesMap: Map<string, Map<string, ItemChange[]>>;
@@ -575,7 +573,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
 
       actorData.items.forEach((item) => {
         const itemData = item instanceof CONFIG.Item.documentClass ? item.toObject() : item;
-        if (itemData.type !== documentType) {
+        if (itemData.type !== type) {
           return;
         }
         if (
@@ -609,7 +607,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
     RqidBatchEditor.updateProgress(progress, scanningCount, "Find Rqids from World Items");
     worldItems.forEach((item) => {
       const itemData = item.toObject();
-      if (itemData.type !== documentType) {
+      if (itemData.type !== type) {
         RqidBatchEditor.updateProgress(++progress, scanningCount, "Find Rqids from World Items");
         return;
       }
@@ -647,7 +645,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
       for (const packIndexData of packIndex) {
         if ("type" in packIndexData) {
           switch (packIndexData.type) {
-            case documentType:
+            case type:
               RqidBatchEditor.collectItemPackRqids(
                 pack,
                 prefixRegex,
@@ -668,7 +666,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
                 await RqidBatchEditor.collectActorPackEmbeddedItemRqids(
                   pack,
                   actors,
-                  documentType,
+                  type,
                   itemNamesWithoutRqid,
                   packActorChangesMap,
                 );
@@ -719,7 +717,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
 
         // Loop over actor items
         tokenActorItems.forEach((item) => {
-          if (item.type !== documentType) {
+          if (item.type !== type) {
             return;
           }
 
@@ -763,11 +761,11 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
       items.forEach((item) => {
         const itemName = item.name ?? "";
         const rqgFlags = (item.flags as { rqg?: { documentRqidFlags?: DocumentRqidFlags } })?.rqg;
-        const previousRqidSuffix = existingRqids.get(itemName)?.replace(prefixRegex, "");
-        const previousExpandedName = `${itemName} ➤ ${previousRqidSuffix}`;
+        const previousSlug = existingRqids.get(itemName)?.replace(prefixRegex, "");
+        const previousExpandedName = `${itemName} ➤ ${previousSlug}`;
 
-        const newRqidSuffix = rqgFlags?.documentRqidFlags?.id?.replace(prefixRegex, "");
-        const newExpandedName = `${itemName} ➤ ${newRqidSuffix}`;
+        const newSlug = rqgFlags?.documentRqidFlags?.id?.replace(prefixRegex, "");
+        const newExpandedName = `${itemName} ➤ ${newSlug}`;
 
         if (
           // If existingRqids already has this item name but with another Rqid, then add the new one as well under a different name
@@ -854,7 +852,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
   private static async collectActorPackEmbeddedItemRqids(
     pack: CompendiumCollection.Any,
     actors: RqgActor[],
-    documentType: ItemTypeEnum,
+    type: ItemTypeEnum,
     itemNamesWithoutRqid: Map<string, string | undefined>,
     packActorChangesMap: Map<string, Map<string, ItemChange[]>>,
   ): Promise<void> {
@@ -867,7 +865,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
     for (const actor of actors) {
       const embeddedItemChanges: ItemChange[] = [];
       for (const itemData of actor.items) {
-        if (itemData.type !== documentType) {
+        if (itemData.type !== type) {
           continue;
         }
         if (!itemData?.flags?.rqg?.documentRqidFlags?.id) {
@@ -904,12 +902,10 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
       return;
     }
     for (const itemType of itemTypes) {
-      const rqidDocumentName = "i"; // Hardcoded for now until more documents than Item are supported
+      const kind = "i"; // Hardcoded for now until more documents than Item are supported
 
-      const idPrefix = `${rqidDocumentName}.${toKebabCase(itemType)}.`;
-      const prefixRegex = new RegExp(
-        "^" + rqidDocumentName + "\\." + toKebabCase(itemType) + "\\.",
-      );
+      const prefix = `${kind}.${toKebabCase(itemType)}.`;
+      const prefixRegex = new RegExp("^" + kind + "\\." + toKebabCase(itemType) + "\\.");
 
       const {
         sceneChangesMap,
@@ -935,7 +931,7 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
         },
         {
           itemType,
-          idPrefix,
+          prefix,
           prefixRegex,
           existingRqids: existingRqids,
         },

--- a/src/applications/rqid-batch-editor/rqid-batch-editor.types.ts
+++ b/src/applications/rqid-batch-editor/rqid-batch-editor.types.ts
@@ -23,13 +23,13 @@ export interface ItemNameWithoutRqid {
   name: string;
   rqid: string;
   selectedRqid?: string;
-  selectedRqidSuffix?: string;
+  selectedSlug?: string;
 }
 
 export interface RqidBatchEditorData {
   summary: string;
   itemType: string;
-  idPrefix: string;
+  prefix: string;
   existingRqidOptions: SelectOptionData<string>[];
   itemNamesWithoutRqid: ItemNameWithoutRqid[];
   buttons: {
@@ -41,7 +41,7 @@ export interface RqidBatchEditorData {
 
 export interface RqidBatchEditorOptions {
   itemType: ItemTypeEnum;
-  idPrefix: string;
+  prefix: string;
   prefixRegex: RegExp;
   existingRqids: Map<string, string>;
 }

--- a/src/applications/rqid-editor/rqid-editor-info.hbs
+++ b/src/applications/rqid-editor/rqid-editor-info.hbs
@@ -1,5 +1,5 @@
 <div class="rqid-editor-reference scrollable">
-  <fieldset class="rqid-editor-reference-matches" data-rqid-duplicates {{#unless rqidNamePart}}hidden{{/unless}}>
+  <fieldset class="rqid-editor-reference-matches" data-rqid-duplicates {{#unless slug}}hidden{{/unless}}>
     <legend>{{localize "RQG.RQGSystem.MatchingRqidDocuments"}}</legend>
     <div class="fullwidth">
       <details open>
@@ -149,14 +149,14 @@
       </button>
     </div>
 
-    <label data-rqid-dependent {{#unless rqidNamePart}}hidden{{/unless}}>
+    <label data-rqid-dependent {{#unless slug}}hidden{{/unless}}>
       {{localize "RQG.RQGSystem.GetDocumentLikeThis"}}
     </label>
-    <div class="input-button" data-rqid-dependent {{#unless rqidNamePart}}hidden{{/unless}}>
+    <div class="input-button" data-rqid-dependent {{#unless slug}}hidden{{/unless}}>
       <input
         type="text"
         id="rqid-editor-get-document-like-this"
-        value='{{#if fullRqid}}await game.system.api.rqid.fromRqid("{{fullRqid}}","{{flags.rqg.documentRqidFlags.lang}}"){{/if}}'
+        value='{{#if rqid}}await game.system.api.rqid.fromRqid("{{rqid}}","{{flags.rqg.documentRqidFlags.lang}}"){{/if}}'
         readonly
       >
       <button
@@ -171,10 +171,10 @@
       </button>
     </div>
 
-    <label data-rqid-dependent {{#unless rqidNamePart}}hidden{{/unless}}>
+    <label data-rqid-dependent {{#unless slug}}hidden{{/unless}}>
       {{localize "RQG.RQGSystem.JournalLinkToDocumentLikeThis"}}
     </label>
-    <div class="input-button" data-rqid-dependent {{#unless rqidNamePart}}hidden{{/unless}}>
+    <div class="input-button" data-rqid-dependent {{#unless slug}}hidden{{/unless}}>
       <input
         type="text"
         id="rqid-editor-journal-link-to-document-like-this"

--- a/src/applications/rqid-editor/rqid-editor.css
+++ b/src/applications/rqid-editor/rqid-editor.css
@@ -15,7 +15,7 @@ body.theme-light .rqid-editor {
       display: flex;
       align-items: center;
 
-      & input[name="rqidNamePart"] {
+      & input[name="slug"] {
         width: 15rem;
         padding-left: 0;
       }
@@ -25,7 +25,7 @@ body.theme-light .rqid-editor {
       color: var(--rqid-editor-input-text-color);
     }
 
-    &:has(input[name="rqidNamePart"]:focus) .rqid-prefix {
+    &:has(input[name="slug"]:focus) .rqid-prefix {
       color: var(--rqid-editor-input-focus-text-color);
     }
   }

--- a/src/applications/rqid-editor/rqid-editor.hbs
+++ b/src/applications/rqid-editor/rqid-editor.hbs
@@ -3,8 +3,8 @@
     <div class="input-button">
       <label class="rqid-input-group" for="rqid-editor">
         {{#if parentRqid}}<span class="parent-rqid rqid-prefix">{{parentRqid}}.</span>{{/if}}
-        <span class="rqid-prefix">{{rqidDocumentNamePart}}</span>
-        <input type="text" id="rqid-editor" name="rqidNamePart" value="{{rqidNamePart}}" />
+        <span class="rqid-prefix">{{prefix}}</span>
+        <input type="text" id="rqid-editor" name="slug" value="{{slug}}" />
       </label>
       <button type="button" class="generate-rqid" data-tooltip="{{localize "RQG.RQGSystem.Rqid.GenerateDefault"}}" data-generate-default-rqid><i
         class="fas fa-wand-magic-sparkles"></i></button>

--- a/src/applications/rqid-editor/rqid-editor.ts
+++ b/src/applications/rqid-editor/rqid-editor.ts
@@ -6,7 +6,7 @@ import {
   toKebabCase,
   trimChars,
 } from "../../system/util";
-import { Rqid, isRqidDocumentName } from "../../system/api/rqid-api";
+import { Rqid, isRqidKind } from "../../system/api/rqid-api";
 import { templatePaths } from "../../system/load-handlebars-templates";
 
 import Document = foundry.abstract.Document;
@@ -28,7 +28,7 @@ interface RqidEditorData {
   worldDocumentInfo?: (DocumentInfo & { folder: string })[];
   compendiumDocumentInfo?: (DocumentInfo & { compendium: string })[];
   rqidLink?: string;
-  fullRqid?: string;
+  rqid?: string;
   supportedLanguagesOptions: typeof CONFIG.supportedLanguages;
   id: string | null;
   parentId: string;
@@ -36,8 +36,8 @@ interface RqidEditorData {
   uuid: string | null;
   folder: string;
   flags: { rqg: { documentRqidFlags: { lang: string; priority: number } } };
-  rqidDocumentNamePart: string;
-  rqidNamePart: string | undefined;
+  prefix: string;
+  slug: string | undefined;
   parentRqid: string;
   parentMissingRqid: boolean;
   buttons: {
@@ -194,25 +194,21 @@ export class RqidEditor extends HandlebarsApplicationMixin(ApplicationV2<RqidEdi
       compendiumDocumentInfo: [],
     };
 
-    let rqidLinkData: Pick<RqidEditorData, "rqidLink" | "fullRqid"> = {};
+    let rqidLinkData: Pick<RqidEditorData, "rqidLink" | "rqid"> = {};
 
     if (documentRqid && documentLang) {
-      const rqidDocumentName = documentRqid.split(".")[0];
+      const kind = documentRqid.split(".")[0];
       const rqidSearchRegex = new RegExp("^" + escapeRegex(documentRqid) + "$");
 
-      if (!this.document.isEmbedded && isRqidDocumentName(rqidDocumentName)) {
-        const worldDocuments = await Rqid.fromRqidRegex(
-          rqidSearchRegex,
-          rqidDocumentName,
-          documentLang,
-          { source: "world", mode: "all" },
-        );
-        const compendiumDocuments = await Rqid.fromRqidRegex(
-          rqidSearchRegex,
-          rqidDocumentName,
-          documentLang,
-          { source: "packs", mode: "all" },
-        );
+      if (!this.document.isEmbedded && isRqidKind(kind)) {
+        const worldDocuments = await Rqid.fromRqidRegex(rqidSearchRegex, kind, documentLang, {
+          source: "world",
+          mode: "all",
+        });
+        const compendiumDocuments = await Rqid.fromRqidRegex(rqidSearchRegex, kind, documentLang, {
+          source: "packs",
+          mode: "all",
+        });
 
         const duplicateWorldPriorities = this.getDuplicatePriorities(worldDocuments);
         const duplicateCompendiumPriorities = this.getDuplicatePriorities(compendiumDocuments);
@@ -265,14 +261,14 @@ export class RqidEditor extends HandlebarsApplicationMixin(ApplicationV2<RqidEdi
         };
       }
 
-      const fullRqid = parentRqid ? `${parentRqid}.${documentRqid}` : documentRqid;
+      const rqid = parentRqid ? `${parentRqid}.${documentRqid}` : documentRqid;
       rqidLinkData = {
-        rqidLink: `@RQID[${fullRqid}]{${this.document.name}}`,
-        fullRqid: fullRqid,
+        rqidLink: `@RQID[${rqid}]{${this.document.name}}`,
+        rqid: rqid,
       };
     }
 
-    const [documentIdPart, documentType] = Rqid.getDefaultRqid(this.document).split(".");
+    const [kind, type] = Rqid.getDefaultRqid(this.document).split(".");
 
     return {
       ...duplicateData,
@@ -291,8 +287,8 @@ export class RqidEditor extends HandlebarsApplicationMixin(ApplicationV2<RqidEdi
           },
         },
       },
-      rqidDocumentNamePart: `${documentIdPart}.${documentType}.`,
-      rqidNamePart: Rqid.getDocumentFlag(this.document)?.id?.split(".").pop(),
+      prefix: `${kind}.${type}.`,
+      slug: Rqid.getDocumentFlag(this.document)?.id?.split(".").pop(),
       parentRqid: parentRqid,
       parentMissingRqid: this.document.isEmbedded && !parentRqid,
       buttons: [
@@ -350,7 +346,7 @@ export class RqidEditor extends HandlebarsApplicationMixin(ApplicationV2<RqidEdi
     });
 
     this.element
-      .querySelector<HTMLInputElement>('input[name="rqidNamePart"]')
+      .querySelector<HTMLInputElement>('input[name="slug"]')
       ?.addEventListener("input", () => this.syncRetrievalPreview());
     this.element
       .querySelector<HTMLSelectElement>('select[name="flags.rqg.documentRqidFlags.lang"]')
@@ -376,12 +372,10 @@ export class RqidEditor extends HandlebarsApplicationMixin(ApplicationV2<RqidEdi
     formData: FormDataExtended,
   ): Promise<void> {
     const data = formData.object as Record<string, unknown>;
-    const [documentIdPart, documentType] = Rqid.getDefaultRqid(this.document).split(".");
-    const rqidNamePart = toKebabCase(String(data["rqidNamePart"] ?? "").trim());
-    data["flags.rqg.documentRqidFlags.id"] = rqidNamePart
-      ? `${documentIdPart}.${documentType}.${rqidNamePart}`
-      : null;
-    delete data["rqidNamePart"];
+    const [kind, type] = Rqid.getDefaultRqid(this.document).split(".");
+    const slug = toKebabCase(String(data["slug"] ?? "").trim());
+    data["flags.rqg.documentRqidFlags.id"] = slug ? `${kind}.${type}.${slug}` : null;
+    delete data["slug"];
 
     data["flags.rqg.documentRqidFlags.priority"] =
       Number(data["flags.rqg.documentRqidFlags.priority"]) || 0;
@@ -397,11 +391,11 @@ export class RqidEditor extends HandlebarsApplicationMixin(ApplicationV2<RqidEdi
 
   private applyDefaultRqidToForm(): void {
     const defaultRqid = Rqid.getDefaultRqid(this.document);
-    const rqidNamePart = defaultRqid.split(".").pop() ?? "";
+    const slug = defaultRqid.split(".").pop() ?? "";
 
-    const rqidInput = this.element.querySelector<HTMLInputElement>('input[name="rqidNamePart"]');
+    const rqidInput = this.element.querySelector<HTMLInputElement>('input[name="slug"]');
     if (rqidInput) {
-      rqidInput.value = rqidNamePart;
+      rqidInput.value = slug;
     }
 
     const langSelect = this.element.querySelector<HTMLSelectElement>(
@@ -422,7 +416,7 @@ export class RqidEditor extends HandlebarsApplicationMixin(ApplicationV2<RqidEdi
   }
 
   private syncRetrievalPreview(): void {
-    const rqidInput = this.element.querySelector<HTMLInputElement>('input[name="rqidNamePart"]');
+    const rqidInput = this.element.querySelector<HTMLInputElement>('input[name="slug"]');
     const langSelect = this.element.querySelector<HTMLSelectElement>(
       'select[name="flags.rqg.documentRqidFlags.lang"]',
     );
@@ -440,10 +434,10 @@ export class RqidEditor extends HandlebarsApplicationMixin(ApplicationV2<RqidEdi
       return;
     }
 
-    const rqidNamePart = toKebabCase(rqidInput.value.trim());
+    const slug = toKebabCase(rqidInput.value.trim());
     const dependentElements = this.element.querySelectorAll<HTMLElement>("[data-rqid-dependent]");
 
-    if (!rqidNamePart) {
+    if (!slug) {
       getLikeThisInput.value = "";
       journalLinkInput.value = "";
       dependentElements.forEach((el) => {
@@ -457,16 +451,16 @@ export class RqidEditor extends HandlebarsApplicationMixin(ApplicationV2<RqidEdi
       return;
     }
 
-    const [documentIdPart, documentType] = Rqid.getDefaultRqid(this.document).split(".");
+    const [kind, type] = Rqid.getDefaultRqid(this.document).split(".");
     const parentRqid: string = this.document.isEmbedded
       ? (Rqid.getDocumentFlag(this.document.parent)?.id ?? "")
       : "";
-    const documentRqid = `${documentIdPart}.${documentType}.${rqidNamePart}`;
-    const fullRqid = parentRqid ? `${parentRqid}.${documentRqid}` : documentRqid;
+    const documentRqid = `${kind}.${type}.${slug}`;
+    const rqid = parentRqid ? `${parentRqid}.${documentRqid}` : documentRqid;
     const lang = langSelect?.value ?? CONFIG.RQG.fallbackLanguage;
 
-    getLikeThisInput.value = `await game.system.api.rqid.fromRqid("${fullRqid}","${lang}")`;
-    journalLinkInput.value = `@RQID[${fullRqid}]{${this.document.name}}`;
+    getLikeThisInput.value = `await game.system.api.rqid.fromRqid("${rqid}","${lang}")`;
+    journalLinkInput.value = `@RQID[${rqid}]{${this.document.name}}`;
 
     dependentElements.forEach((el) => {
       el.hidden = false;
@@ -516,14 +510,14 @@ export class RqidEditor extends HandlebarsApplicationMixin(ApplicationV2<RqidEdi
       return;
     }
 
-    const rqidDocumentName = documentRqid?.split(".")[0];
-    const canLookup = !!documentRqid && !!rqidDocumentName && !this.document.isEmbedded;
+    const kind = documentRqid?.split(".")[0];
+    const canLookup = !!documentRqid && !!kind && !this.document.isEmbedded;
 
     duplicateElements.forEach((el) => {
       el.hidden = !canLookup;
     });
 
-    if (!canLookup || !isRqidDocumentName(rqidDocumentName)) {
+    if (!canLookup || !isRqidKind(kind)) {
       worldRows.innerHTML = "";
       compRows.innerHTML = "";
       worldWarning.hidden = true;
@@ -534,19 +528,14 @@ export class RqidEditor extends HandlebarsApplicationMixin(ApplicationV2<RqidEdi
     const lookupLang = lang ?? CONFIG.RQG.fallbackLanguage;
     const rqidSearchRegex = new RegExp("^" + escapeRegex(documentRqid) + "$");
 
-    const worldDocuments = await Rqid.fromRqidRegex(rqidSearchRegex, rqidDocumentName, lookupLang, {
+    const worldDocuments = await Rqid.fromRqidRegex(rqidSearchRegex, kind, lookupLang, {
       source: "world",
       mode: "all",
     });
-    const compendiumDocuments = await Rqid.fromRqidRegex(
-      rqidSearchRegex,
-      rqidDocumentName,
-      lookupLang,
-      {
-        source: "packs",
-        mode: "all",
-      },
-    );
+    const compendiumDocuments = await Rqid.fromRqidRegex(rqidSearchRegex, kind, lookupLang, {
+      source: "packs",
+      mode: "all",
+    });
 
     if (requestId !== this.duplicateLookupRequestId) {
       return;

--- a/src/items/cult-item/cult-lifecycle.ts
+++ b/src/items/cult-item/cult-lifecycle.ts
@@ -9,17 +9,17 @@ import type { CultItem } from "@item-model/cult-data-model.ts";
 import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data.ts";
 import type { RuneMagicItem } from "@item-model/rune-magic-data-model.ts";
 
-function toCanonicalItemRqid(rqid: string, itemType: "rune" | "rune-magic"): string {
-  const match = rqid.match(new RegExp(`(?:^|\\.)(i\\.${itemType}\\.[^.]+)$`));
+function toCanonicalItemRqid(rqid: string, type: "rune" | "rune-magic"): string {
+  const match = rqid.match(new RegExp(`(?:^|\\.)(i\\.${type}\\.[^.]+)$`));
   return match?.[1] ?? rqid;
 }
 
 function normalizeRqidLinks(
   links: RqidLink[] | undefined,
-  itemType: "rune" | "rune-magic",
+  type: "rune" | "rune-magic",
 ): RqidLink[] {
   return (links ?? []).map((link) => {
-    const rqid = toCanonicalItemRqid(link.rqid, itemType);
+    const rqid = toCanonicalItemRqid(link.rqid, type);
     const normalized: RqidLink = {
       rqid,
       name: link.name,

--- a/src/rqg.css
+++ b/src/rqg.css
@@ -1600,7 +1600,7 @@
         width: 100%;
       }
 
-      &[name="rqidNamePart"] {
+      &[name="slug"] {
         width: 12rem;
       }
 

--- a/src/system/api/rqid-api.test.ts
+++ b/src/system/api/rqid-api.test.ts
@@ -454,22 +454,22 @@ describe("Rqid", () => {
     });
   });
 
-  describe("getDefaultRqidIdentifier", () => {
-    it("derives a cult identifier from the full name regardless of system data", () => {
+  describe("getDefaultRqidSlug", () => {
+    it("derives a cult slug from the full name regardless of system data", () => {
       expect(
-        Rqid.getDefaultRqidIdentifier("Orlanth Adventurous (Orlanth)", "cult", {
+        Rqid.getDefaultRqidSlug("Orlanth Adventurous (Orlanth)", "cult", {
           deity: "Orlanth",
         }),
       ).toBe("orlanth-adventurous-orlanth");
     });
 
     it("falls back to the name when no system data is available (e.g. batch editor without a matched document)", () => {
-      expect(Rqid.getDefaultRqidIdentifier("Ernalda", "cult", undefined)).toBe("ernalda");
+      expect(Rqid.getDefaultRqidSlug("Ernalda", "cult", undefined)).toBe("ernalda");
     });
 
-    it("derives an armor identifier from namePrefix, armorType and material", () => {
+    it("derives an armor slug from namePrefix, armorType and material", () => {
       expect(
-        Rqid.getDefaultRqidIdentifier("Fine Bronze Cuirass", "armor", {
+        Rqid.getDefaultRqidSlug("Fine Bronze Cuirass", "armor", {
           namePrefix: "Fine",
           armorType: "Cuirass",
           material: "Bronze",

--- a/src/system/api/rqid-api.ts
+++ b/src/system/api/rqid-api.ts
@@ -61,10 +61,10 @@ const RQID_DOCUMENT_DEFINITIONS = {
   s: { documentName: "Scene", gameProperty: "scenes", iconConfig: "Scene" },
 } as const;
 
-type RqidDocumentName = keyof typeof RQID_DOCUMENT_DEFINITIONS;
-type NonItemRqidDocumentName = Exclude<RqidDocumentName, "i">;
+type RqidKind = keyof typeof RQID_DOCUMENT_DEFINITIONS;
+type NonItemRqidKind = Exclude<RqidKind, "i">;
 type ItemRqidString = `i.${keyof ItemSubtypeMap}.${string}`;
-type DocumentRqidString = ItemRqidString | `${NonItemRqidDocumentName}.${string}.${string}`;
+type DocumentRqidString = ItemRqidString | `${NonItemRqidKind}.${string}.${string}`;
 
 /**
  * A typed rqid string.
@@ -75,8 +75,8 @@ type DocumentRqidString = ItemRqidString | `${NonItemRqidDocumentName}.${string}
  */
 export type RqidString = DocumentRqidString | `${DocumentRqidString}.${DocumentRqidString}`;
 
-/** Runtime validator for rqid document name (first segment), including item document `i`. */
-export function isRqidDocumentName(value: unknown): value is RqidDocumentName {
+/** Runtime validator for rqid kind (first segment), including item document `i`. */
+export function isRqidKind(value: unknown): value is RqidKind {
   return typeof value === "string" && Object.hasOwn(RQID_DOCUMENT_DEFINITIONS, value);
 }
 
@@ -121,9 +121,9 @@ type IndexCandidate = { pack: CompendiumCollection.Any; indexData: RqidIndexEntr
 
 /**
  * Handles rqid ids. These IDs are a string that is constructed like `i.skill.act`.
- * The first part (rqidDocumentName) is a shorthand to the foundry Document names (like Item, Actor) for the supported documents. See Rqid.documentNameLookup
- * The second part (document type) is the same as the document type in Foundry (like weapon, skill, etc). Can be empty.
- * The third part ()
+ * The first part (kind) is a shorthand to the foundry Document names (like Item, Actor) for the supported documents. See Rqid.documentNameLookup
+ * The second part (type) is the same as the document type in Foundry (like weapon, skill, etc). Can be empty.
+ * The third part (slug) is a unique, kebab-case identifier within that kind+type.
  *
  */
 export class Rqid {
@@ -202,25 +202,25 @@ export class Rqid {
    * `source` chooses where to search: world, packs, or both.
    * `mode` chooses whether to return all matches or only the best (highest priority) per rqid.
    * @param rqidRegex regex used on the rqid
-   * @param rqidDocumentName the first part of the wanted rqid, for example "i", "a", "je"
+   * @param kind the first part of the wanted rqid, for example "i", "a", "je"
    * @param lang the language to match against ("en", "es", ...)
    * @param options search source and result mode
    */
   public static async fromRqidRegex(
     rqidRegex: RegExp | undefined,
-    rqidDocumentName: RqidDocumentName | undefined, // like "i", "a", "je"
+    kind: RqidKind | undefined, // like "i", "a", "je"
     lang: string = CONFIG.RQG.fallbackLanguage,
     options: RqidRegexSearchOptions = {},
   ): Promise<RqidEnabledDocument[]> {
-    if (!rqidRegex || !rqidDocumentName) {
+    if (!rqidRegex || !kind) {
       return [];
     }
     const source = options.source ?? "all";
     const mode = options.mode ?? "best";
 
     const [worldDocuments, packDocuments] = await Promise.all([
-      source !== "packs" ? Rqid.documentsFromWorld(rqidRegex, rqidDocumentName, lang) : [],
-      source !== "world" ? Rqid.documentsFromPacks(rqidRegex, rqidDocumentName, lang) : [],
+      source !== "packs" ? Rqid.documentsFromWorld(rqidRegex, kind, lang) : [],
+      source !== "world" ? Rqid.documentsFromPacks(rqidRegex, kind, lang) : [],
     ]);
 
     const result: TaggedRqidDocument[] = [
@@ -241,15 +241,15 @@ export class Rqid {
    * from the World or a Compendium pack. When priorities are equal, the World document
    * takes precedence.
    * @param rqidRegex regex used on the rqid
-   * @param rqidDocumentName the first part of the wanted rqid, for example "i", "a", "je"
+   * @param kind the first part of the wanted rqid, for example "i", "a", "je"
    * @param lang the language to match against ("en", "es", ...)
    */
   public static async fromRqidRegexBest(
     rqidRegex: RegExp | undefined,
-    rqidDocumentName: RqidDocumentName, // like "i", "a", "je"
+    kind: RqidKind, // like "i", "a", "je"
     lang: string = CONFIG.RQG.fallbackLanguage,
   ): Promise<RqidEnabledDocument[]> {
-    return this.fromRqidRegex(rqidRegex, rqidDocumentName, lang, {
+    return this.fromRqidRegex(rqidRegex, kind, lang, {
       source: "all",
       mode: "best",
     });
@@ -370,29 +370,29 @@ export class Rqid {
   }
 
   /**
-   * Compute the default rqid identifier segment (the last `.`-separated part of an item rqid)
-   * from a name, item subtype and optional system data. This is the single source of truth for
-   * how a default rqid identifier is derived, shared by getDefaultRqid (which operates on real
-   * Documents) and the RqidBatchEditor (which mostly only has plain item data available, e.g.
-   * from compendium indexes or actor.toObject()).
+   * Compute the default rqid slug (the last `.`-separated part of an item rqid) from a name,
+   * item type and optional system data. This is the single source of truth for how a default
+   * slug is derived, shared by getDefaultRqid (which operates on real Documents) and the
+   * RqidBatchEditor (which mostly only has plain item data available, e.g. from compendium
+   * indexes or actor.toObject()).
    */
-  public static getDefaultRqidIdentifier(
+  public static getDefaultRqidSlug(
     name: string | null | undefined,
-    itemType?: string,
+    type?: string,
     system?: Record<string, unknown>,
   ): string {
-    let rqidIdentifier = "";
+    let slug = "";
 
-    if (itemType === ItemTypeEnum.Skill) {
-      rqidIdentifier = trimChars(
+    if (type === ItemTypeEnum.Skill) {
+      slug = trimChars(
         toKebabCase(
           `${(system?.["skillName"] as string) ?? ""}-${(system?.["specialization"] as string) ?? ""}`,
         ),
         "-",
       );
     }
-    if (itemType === ItemTypeEnum.Armor) {
-      rqidIdentifier = trimChars(
+    if (type === ItemTypeEnum.Armor) {
+      slug = trimChars(
         toKebabCase(
           `${(system?.["namePrefix"] as string) ?? ""}-${(system?.["armorType"] as string) ?? ""}-${
             (system?.["material"] as string) ?? ""
@@ -401,11 +401,11 @@ export class Rqid {
         "-",
       );
     }
-    if (!rqidIdentifier) {
-      rqidIdentifier = trimChars(toKebabCase(name ?? ""), "-");
+    if (!slug) {
+      slug = trimChars(toKebabCase(name ?? ""), "-");
     }
 
-    return rqidIdentifier;
+    return slug;
   }
 
   /**
@@ -416,14 +416,14 @@ export class Rqid {
       return "";
     }
 
-    const rqidDocumentString = Rqid.getRqidDocumentName(document);
-    const documentSubType = toKebabCase("type" in document ? String(document.type) : "");
+    const kind = Rqid.getKind(document);
+    const type = toKebabCase("type" in document ? String(document.type) : "");
     const itemType = document instanceof Item ? String(document.type) : undefined;
     const system =
       document instanceof Item ? (document.system as Record<string, unknown>) : undefined;
-    const rqidIdentifier = Rqid.getDefaultRqidIdentifier(document.name, itemType, system);
+    const slug = Rqid.getDefaultRqidSlug(document.name, itemType, system);
 
-    return `${rqidDocumentString}.${documentSubType}.${rqidIdentifier}` as RqidString;
+    return `${kind}.${type}.${slug}` as RqidString;
   }
 
   /**
@@ -507,7 +507,7 @@ export class Rqid {
       return undefined;
     }
     const documentRqid = Rqid.documentRqid(rqid);
-    const embeddedDocumentsRqid = Rqid.embeddedDocumentRqid(rqid);
+    const embeddedRqid = Rqid.embeddedRqid(rqid);
 
     const candidateDocuments = (
       Rqid.getGameCollection(documentRqid)?.contents as RqidEnabledDocument[] | undefined
@@ -539,19 +539,19 @@ export class Rqid {
       // TODO Or should this be handled in the compendium browser eventually?
       console.warn(msg + "  Duplicate items: ", candidateDocuments);
     }
-    return this.getEmbeddedOrProvidedDocument(highestPrioDocuments[0]!, embeddedDocumentsRqid);
+    return this.getEmbeddedOrProvidedDocument(highestPrioDocuments[0]!, embeddedRqid);
   }
 
   private static getEmbeddedOrProvidedDocument(
     document: RqidEnabledDocument,
-    embeddedDocumentsRqid: string,
+    embeddedRqid: string,
   ) {
     if (
-      embeddedDocumentsRqid &&
+      embeddedRqid &&
       "getBestEmbeddedDocumentByRqid" in document &&
       typeof document.getBestEmbeddedDocumentByRqid === "function" // Not all documents support embedded rqid documents
     ) {
-      return document.getBestEmbeddedDocumentByRqid(embeddedDocumentsRqid);
+      return document.getBestEmbeddedDocumentByRqid(embeddedRqid);
     } else {
       return document;
     }
@@ -563,14 +563,14 @@ export class Rqid {
    */
   private static async documentsFromWorld(
     rqidRegex: RegExp | undefined,
-    rqidDocumentName: RqidDocumentName,
+    kind: RqidKind,
     lang: string,
   ): Promise<RqidEnabledDocument[]> {
     if (!rqidRegex) {
       return [];
     }
 
-    const collection = Rqid.getGameCollection(`${rqidDocumentName}..`);
+    const collection = Rqid.getGameCollection(`${kind}..`);
     const candidateDocuments = (collection?.contents as RqidEnabledDocument[] | undefined)?.filter(
       (d) =>
         rqidRegex.test(Rqid.getDocumentFlag(d)?.id ?? "") && Rqid.getDocumentFlag(d)?.lang === lang,
@@ -635,7 +635,7 @@ export class Rqid {
       return undefined;
     }
     const documentRqid = Rqid.documentRqid(rqid);
-    const embeddedDocumentsRqid = Rqid.embeddedDocumentRqid(rqid);
+    const embeddedRqid = Rqid.embeddedRqid(rqid);
     const documentName = Rqid.getDocumentName(documentRqid);
     const indexCandidates: IndexCandidate[] = [];
 
@@ -678,7 +678,7 @@ export class Rqid {
     if (!highestPrioDocument) {
       return undefined;
     }
-    return this.getEmbeddedOrProvidedDocument(highestPrioDocument, embeddedDocumentsRqid);
+    return this.getEmbeddedOrProvidedDocument(highestPrioDocument, embeddedRqid);
   }
 
   /**
@@ -687,13 +687,13 @@ export class Rqid {
    */
   private static async documentsFromPacks(
     rqidRegex: RegExp,
-    rqidDocumentName: RqidDocumentName,
+    kind: RqidKind,
     lang: string,
   ): Promise<RqidEnabledDocument[]> {
     if (!rqidRegex) {
       return [];
     }
-    const documentName = Rqid.getDocumentName(`${rqidDocumentName}..fake-rqid`);
+    const documentName = Rqid.getDocumentName(`${kind}..fake-rqid`);
     const candidateDocuments: RqidEnabledDocument[] = [];
 
     for (const pack of game.packs ?? []) {
@@ -737,14 +737,14 @@ export class Rqid {
   }
 
   public static getRqidIcon(rqid: string | undefined): string | undefined {
-    const rqidDocumentString = rqid?.split(".")[0];
+    const kind = rqid?.split(".")[0];
 
     // Use RQG default item type images for item documents
-    if (rqidDocumentString === "i") {
-      const itemType = Rqid.getDocumentType(rqid);
+    if (kind === "i") {
+      const type = Rqid.getDocumentType(rqid);
 
       // Special handling for rune items to display the actual rune instead of the default item image
-      if (itemType === ItemTypeEnum.Rune) {
+      if (type === ItemTypeEnum.Rune) {
         const availableRunes = getAvailableRunes();
         const rune = availableRunes.find((r) => r.rqid === rqid);
         if (!rune && availableRunes.length) {
@@ -757,7 +757,7 @@ export class Rqid {
       }
 
       const iconSettings = getDefaultItemIconSettings();
-      const defaultItemIcon = itemType && iconSettings[itemType as keyof typeof iconSettings];
+      const defaultItemIcon = type && iconSettings[type as keyof typeof iconSettings];
       if (defaultItemIcon) {
         // TODO If undefined then the rqid is invalid since all items need a type
         return `<img src="${defaultItemIcon}"/>`;
@@ -765,9 +765,8 @@ export class Rqid {
     }
 
     // Use Foundry default document images
-    const configPart =
-      rqidDocumentString && Rqid.documentLinkIconsConfigName.get(rqidDocumentString);
-    if (!rqidDocumentString || !configPart) {
+    const configPart = kind && Rqid.documentLinkIconsConfigName.get(kind);
+    if (!kind || !configPart) {
       return undefined;
     }
     const linkIcon =
@@ -777,8 +776,8 @@ export class Rqid {
   }
 
   private static readonly documentLinkIconsConfigName = new Map(
-    Object.entries(RQID_DOCUMENT_DEFINITIONS).map(([rqidDocumentName, definition]) => [
-      rqidDocumentName,
+    Object.entries(RQID_DOCUMENT_DEFINITIONS).map(([kind, definition]) => [
+      kind,
       definition.iconConfig,
     ]),
   );
@@ -794,11 +793,11 @@ export class Rqid {
   }
 
   /**
-   *   Translates the first part of a rqid (rqidDocumentName) to what those documents are called in the `game` object.
+   *   Translates the first part of a rqid (kind) to what those documents are called in the `game` object.
    */
   private static getGameProperty(rqid: string | undefined): string {
-    const rqidDocumentName = rqid?.split(".")[0];
-    const gameProperty = rqidDocumentName && Rqid.gamePropertyLookup[rqidDocumentName];
+    const kind = rqid?.split(".")[0];
+    const gameProperty = kind && Rqid.gamePropertyLookup[kind];
     if (!gameProperty) {
       const msg = "Tried to convert rqid with non existing document type";
       throw new RqgError(msg, rqid);
@@ -816,23 +815,21 @@ export class Rqid {
     return game[prop as keyof typeof game] as WorldCollection<Document.WorldType> | undefined;
   }
 
-  private static readonly gamePropertyLookup: { [rqidDocumentName: string]: string } =
-    Object.entries(RQID_DOCUMENT_DEFINITIONS).reduce(
-      (acc: { [rqidDocumentName: string]: string }, [rqidDocumentName, definition]) => {
-        if ("gameProperty" in definition) {
-          acc[rqidDocumentName] = definition.gameProperty;
-        }
-        return acc;
-      },
-      {},
-    );
+  private static readonly gamePropertyLookup: { [kind: string]: string } = Object.entries(
+    RQID_DOCUMENT_DEFINITIONS,
+  ).reduce((acc: { [kind: string]: string }, [kind, definition]) => {
+    if ("gameProperty" in definition) {
+      acc[kind] = definition.gameProperty;
+    }
+    return acc;
+  }, {});
 
   /**
    *   Translates the first part of a rqid to a Foundry document name (like "Item").
    */
   public static getDocumentName(rqid: string | undefined): string {
-    const rqidDocumentName = rqid?.split(".")[0];
-    const documentName = rqidDocumentName && Rqid.documentNameLookup[rqidDocumentName];
+    const kind = rqid?.split(".")[0];
+    const documentName = kind && Rqid.documentNameLookup[kind];
     if (!documentName) {
       const msg = "Tried to convert rqid with non existing document type";
       throw new RqgError(msg, rqid);
@@ -840,44 +837,40 @@ export class Rqid {
     return documentName;
   }
 
-  private static readonly documentNameLookup: { [rqidDocumentName: string]: string } =
-    Object.entries(RQID_DOCUMENT_DEFINITIONS).reduce(
-      (acc: { [rqidDocumentName: string]: string }, [rqidDocumentName, definition]) => {
-        acc[rqidDocumentName] = definition.documentName;
-        return acc;
-      },
-      {},
-    );
+  private static readonly documentNameLookup: { [kind: string]: string } = Object.entries(
+    RQID_DOCUMENT_DEFINITIONS,
+  ).reduce((acc: { [kind: string]: string }, [kind, definition]) => {
+    acc[kind] = definition.documentName;
+    return acc;
+  }, {});
 
   /**
    * Get the document type from the rqid if it exists. For example i.skill.act returns "skill".
    * Does not check if the type is valid in the system.
    */
   public static getDocumentType(rqid: string | undefined): string | undefined {
-    const documentType = rqid?.split(".")[1];
-    return documentType ? documentType : undefined;
+    const type = rqid?.split(".")[1];
+    return type ? type : undefined;
   }
 
   /**
    * Get the first part of a rqid (like "i") from a Document.
    */
-  private static getRqidDocumentName(document: RqidEnabledDocument | Document.Any): string {
-    const documentString = Rqid.rqidDocumentNameLookup[document.documentName];
-    if (!documentString) {
+  private static getKind(document: RqidEnabledDocument | Document.Any): string {
+    const kind = Rqid.kindLookup[document.documentName];
+    if (!kind) {
       const msg = "Tried to convert a unsupported document to rqid";
       throw new RqgError(msg, document);
     }
-    return documentString;
+    return kind;
   }
 
   /**
-   *  Reverse lookup from DocumentType to rqidDocument ("Item" -> "i").
+   *  Reverse lookup from Foundry document name to rqid kind ("Item" -> "i").
    */
-  private static readonly rqidDocumentNameLookup: { [documentName: string]: string } =
-    Object.entries(Rqid.documentNameLookup).reduce(
-      (acc: { [k: string]: string }, [key, value]) => ({ ...acc, [value]: key }),
-      {},
-    );
+  private static readonly kindLookup: { [documentName: string]: string } = Object.entries(
+    Rqid.documentNameLookup,
+  ).reduce((acc: { [k: string]: string }, [key, value]) => ({ ...acc, [value]: key }), {});
 
   /**
    * Get the main level document rqid from a rqid that could contain a reference
@@ -892,7 +885,7 @@ export class Rqid {
    * such as `a.character.nisse.i.skill.act` -> `i.skill.act`. Will return an empty string
    * if no embedded rqid exists
    */
-  private static embeddedDocumentRqid(rqid: string): string {
+  private static embeddedRqid(rqid: string): string {
     return rqid.split(".").slice(3, 6).join(".");
   }
 


### PR DESCRIPTION
## Summary
- Renames the three rqid segments to one consistent vocabulary everywhere: `kind` (segment 1, e.g. `i`), `type` (segment 2, e.g. `skill`), `slug` (segment 3, e.g. `jump`), `prefix` (segments 1+2), `documentRqid` (segments 1-3, unchanged), `embeddedRqid` (an embedded child's own rqid), and `rqid`/`RqidString` for the whole thing.
- Renames `Rqid.getDefaultRqidIdentifier` (added in #1005, same cycle) to `Rqid.getDefaultRqidSlug`.
- Touches `rqid-api.ts`, `rqid-editor.ts` (+ its `.hbs`/`.css`, including the literal form-field `name` attribute and the CSS selector targeting it), `rqid-batch-editor.ts` (+ its `.types.ts`/`.hbs`), and `cult-lifecycle.ts`'s rune/rune-magic rqid helpers.
- Naming-only, no behavior change. The public `game.system.api.rqid` surface (the `Rqid` class's public method *names*) is untouched to avoid breaking macros - only `getDefaultRqidIdentifier` changes name, since it's brand new this cycle.

Closes #1006

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm i18n:audit-unused --lang en --fail-on-unused`
- [x] `pnpm vitest run` (653 passing)
- [x] Manual: open the Rqid Editor on a document, confirm the "generate default" button and the retrieval-preview snippets still populate the slug input correctly