### PR TITLE
feat: add Allied Spirit spell-knowledge sharing (#1002)

### DIFF
--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -2276,6 +2276,32 @@
       }
     }
 
+/* --- External spell source rows (#1002): Spirit/Rune Magic spells known via the linked Allied
+   Spirit bond partner, not this actor. Rendered as extra rows in the *same* grid as the actor's
+   own spells (not a second nested grid) so columns line up - the divider spans the full row via
+   grid-column, and each subsequent row/cell is just another grid item in source order. Marked
+   with a left accent border on the leading (icon) cell only, rather than recoloring the row - text
+   stays the theme's normal color/contrast (row background/hover/active are untouched, unlike an
+   earlier version of this that overrode them and became unreadable). */
+    & .external-spell-divider {
+      grid-column: 1 / -1;
+      display: flex;
+      align-items: center;
+      color: var(--rqg-unassigned-rm-text);
+      background: var(--rqg-unassigned-rm-bg);
+      border: 1px solid var(--rqg-unassigned-rm-border);
+      border-radius: var(--rqg-radius-sm);
+      padding: 4px 8px;
+      margin: 4px 0 2px;
+      font-weight: 600;
+    }
+
+    & .spirit-magic-row.external-item > *:first-child,
+    & .rune-magic-row.external-item > *:first-child {
+      border-left: 3px solid var(--rqg-unassigned-rm-border);
+      padding-left: 3px;
+    }
+
 /* --- Wounded / injured overall sheet background --- */
     &.dead {
       filter: grayscale(0.8);

--- a/src/actors/context-menus/rune-magic-context-menu.ts
+++ b/src/actors/context-menus/rune-magic-context-menu.ts
@@ -2,10 +2,11 @@ import type { RqgContextMenuEntry } from "../../foundry-ui/rqg-context-menu";
 import { confirmActorItemDelete } from "../confirm-item-delete-dialog";
 import { RqgActor } from "../rqg-actor";
 import {
-  assertDocumentSubType,
+  getDomDataset,
   getRequiredDomDataset,
   localize,
   localizeItemType,
+  resolveCastItem,
   RqgError,
 } from "../../system/util";
 import { ItemTypeEnum } from "@item-model/item-types.ts";
@@ -21,39 +22,37 @@ export const runeMagicMenuOptions = (actor: RqgActor): RqgContextMenuEntry[] => 
     icon: contextMenuRunes.RollViaChat,
     visible: () => true,
     onClick: async (_event: Event, el: HTMLElement) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      const item = actor.items.get(itemId) as RqgItem | undefined;
-      assertDocumentSubType<RuneMagicItem>(item, ItemTypeEnum.RuneMagic);
-      await item.runeMagicRoll();
+      const item = resolveCastItem(el, actor) as RuneMagicItem | undefined;
+      if (!item) {
+        return;
+      }
+      await item.runeMagicRoll(undefined, actor);
     },
   },
   {
     label: "RQG.Game.RollQuick",
     icon: contextMenuRunes.RollQuick,
     visible: (el: HTMLElement) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      const item = actor.items.get(itemId) as RqgItem | undefined;
-      assertDocumentSubType<RuneMagicItem>(item, ItemTypeEnum.RuneMagic);
-      return item.system.points === 1;
+      const item = resolveCastItem(el, actor) as RuneMagicItem | undefined;
+      return item?.system.points === 1;
     },
     onClick: async (_event: Event, el: HTMLElement) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      const item = actor.items.get(itemId) as RqgItem | undefined;
-      assertDocumentSubType<RuneMagicItem>(item, ItemTypeEnum.RuneMagic);
-      await item.runeMagicRollImmediate();
+      const item = resolveCastItem(el, actor) as RuneMagicItem | undefined;
+      if (!item) {
+        return;
+      }
+      await item.runeMagicRollImmediate(undefined, undefined, actor);
     },
   },
   {
     label: "RQG.ContextMenu.ViewDescription",
     icon: contextMenuRunes.ViewDescription,
     visible: (el: HTMLElement) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      const item = actor.items.get(itemId) as RuneMagicItem | undefined;
+      const item = resolveCastItem(el, actor) as RuneMagicItem | undefined;
       return isValidRqidString(item?.system.descriptionRqidLink?.rqid);
     },
     onClick: async (_event: Event, el: HTMLElement) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      const item = actor.items.get(itemId) as RuneMagicItem | undefined;
+      const item = resolveCastItem(el, actor) as RuneMagicItem | undefined;
       const rqid = item?.system.descriptionRqidLink?.rqid;
       if (isValidRqidString(rqid)) {
         await Rqid.renderRqidDocument(rqid);
@@ -65,11 +64,16 @@ export const runeMagicMenuOptions = (actor: RqgActor): RqgContextMenuEntry[] => 
       itemType: localizeItemType(ItemTypeEnum.RuneMagic),
     }),
     icon: contextMenuRunes.Edit,
-    visible: () => !!game.user?.isGM,
+    // Only the caster's own Rune Magic items are editable - a spell surfaced from an external
+    // spell source (#1002, e.g. an Allied Spirit bond partner's known spells) isn't this actor's
+    // Item to edit.
+    visible: (el: HTMLElement) => !!game.user?.isGM && !getDomDataset(el, "external-owner-uuid"),
     onClick: (_event: Event, el: HTMLElement) => {
       const itemId = getRequiredDomDataset(el, "item-id");
       const item = actor.items.get(itemId) as RqgItem | undefined;
-      assertDocumentSubType<RuneMagicItem>(item, ItemTypeEnum.RuneMagic);
+      if (!item) {
+        return;
+      }
       if (!item.sheet) {
         const msg = `Couldn't find itemId [${itemId}] on actor ${actor.name} to edit the runemagic item from the runemagic context menu.`;
         ui.notifications?.error(msg);
@@ -83,7 +87,7 @@ export const runeMagicMenuOptions = (actor: RqgActor): RqgContextMenuEntry[] => 
       itemType: localizeItemType(ItemTypeEnum.RuneMagic),
     }),
     icon: contextMenuRunes.Delete,
-    visible: () => !!game.user?.isGM,
+    visible: (el: HTMLElement) => !!game.user?.isGM && !getDomDataset(el, "external-owner-uuid"),
     onClick: (_event: Event, el: HTMLElement) => {
       const itemId = getRequiredDomDataset(el, "item-id");
       void confirmActorItemDelete(actor, itemId);

--- a/src/actors/context-menus/spirit-magic-context-menu.ts
+++ b/src/actors/context-menus/spirit-magic-context-menu.ts
@@ -1,11 +1,11 @@
 import type { RqgContextMenuEntry } from "../../foundry-ui/rqg-context-menu";
 import { confirmActorItemDelete } from "../confirm-item-delete-dialog";
 import {
-  assertDocumentSubType,
   getDomDataset,
   getRequiredDomDataset,
   localize,
   localizeItemType,
+  resolveCastItem,
   RqgError,
 } from "../../system/util";
 import { ItemTypeEnum } from "@item-model/item-types.ts";
@@ -21,29 +21,29 @@ export const spiritMagicMenuOptions = (actor: CharacterActor): RqgContextMenuEnt
     icon: contextMenuRunes.RollViaChat,
     visible: () => true,
     onClick: async (_event: Event, el: HTMLElement) => {
-      const itemId = getDomDataset(el, "item-id");
-      const item = actor.items.get(itemId ?? "") as SpiritMagicItem | undefined;
-      assertDocumentSubType<SpiritMagicItem>(item, ItemTypeEnum.SpiritMagic);
-      await item.spiritMagicRoll();
+      const item = resolveCastItem(el, actor) as SpiritMagicItem | undefined;
+      if (!item) {
+        return;
+      }
+      await item.spiritMagicRoll(undefined, actor);
     },
   },
   {
     label: "RQG.Game.RollQuick",
     icon: contextMenuRunes.RollQuick,
     visible: (el: HTMLElement) => {
-      const itemId = getDomDataset(el, "item-id");
-      const item = actor.items.get(itemId ?? "") as SpiritMagicItem | undefined;
-      assertDocumentSubType<SpiritMagicItem>(item, ItemTypeEnum.SpiritMagic);
-      return !item.system.isVariable || item.system.points === 1;
+      const item = resolveCastItem(el, actor) as SpiritMagicItem | undefined;
+      return !item || !item.system.isVariable || item.system.points === 1;
     },
     onClick: async (_event: Event, el: HTMLElement) => {
-      const itemId = getDomDataset(el, "item-id");
-      const item = actor.items.get(itemId ?? "") as SpiritMagicItem | undefined;
-      assertDocumentSubType<SpiritMagicItem>(item, ItemTypeEnum.SpiritMagic);
+      const item = resolveCastItem(el, actor) as SpiritMagicItem | undefined;
+      if (!item) {
+        return;
+      }
       if (item.system.isVariable && item.system.points > 1) {
-        await item.spiritMagicRoll();
+        await item.spiritMagicRoll(undefined, actor);
       } else {
-        await item.spiritMagicRollImmediate();
+        await item.spiritMagicRollImmediate(undefined, undefined, actor);
       }
     },
   },
@@ -51,13 +51,11 @@ export const spiritMagicMenuOptions = (actor: CharacterActor): RqgContextMenuEnt
     label: "RQG.ContextMenu.ViewDescription",
     icon: contextMenuRunes.ViewDescription,
     visible: (el: HTMLElement) => {
-      const itemId = getDomDataset(el, "item-id");
-      const item = actor.items.get(itemId ?? "") as SpiritMagicItem | undefined;
+      const item = resolveCastItem(el, actor) as SpiritMagicItem | undefined;
       return isValidRqidString(item?.system.descriptionRqidLink?.rqid);
     },
     onClick: async (_event: Event, el: HTMLElement) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      const item = actor.items.get(itemId) as SpiritMagicItem | undefined;
+      const item = resolveCastItem(el, actor) as SpiritMagicItem | undefined;
       const rqid = item?.system.descriptionRqidLink?.rqid;
       if (isValidRqidString(rqid)) {
         await Rqid.renderRqidDocument(rqid);
@@ -69,11 +67,16 @@ export const spiritMagicMenuOptions = (actor: CharacterActor): RqgContextMenuEnt
       itemType: localizeItemType(ItemTypeEnum.SpiritMagic),
     }),
     icon: contextMenuRunes.Edit,
-    visible: () => !!game.user?.isGM,
+    // Only the caster's own Spirit Magic items are editable - a spell surfaced from an external
+    // spell source (#1002, e.g. an Allied Spirit bond partner's known spells) isn't this actor's
+    // Item to edit.
+    visible: (el: HTMLElement) => !!game.user?.isGM && !getDomDataset(el, "external-owner-uuid"),
     onClick: (_event: Event, el: HTMLElement) => {
       const itemId = getDomDataset(el, "item-id");
       const item = actor.items.get(itemId ?? "") as SpiritMagicItem | undefined;
-      assertDocumentSubType<SpiritMagicItem>(item, ItemTypeEnum.SpiritMagic);
+      if (!item) {
+        return;
+      }
       if (!item.sheet) {
         const msg = localize("RQG.ContextMenu.Notification.CantEditSpiritMagicError", {
           itemId: itemId!,
@@ -90,7 +93,7 @@ export const spiritMagicMenuOptions = (actor: CharacterActor): RqgContextMenuEnt
       itemType: localizeItemType(ItemTypeEnum.SpiritMagic),
     }),
     icon: contextMenuRunes.Delete,
-    visible: () => !!game.user?.isGM,
+    visible: (el: HTMLElement) => !!game.user?.isGM && !getDomDataset(el, "external-owner-uuid"),
     onClick: (_event: Event, el: HTMLElement) => {
       const itemId = getRequiredDomDataset(el, "item-id");
       void confirmActorItemDelete(actor, itemId);

--- a/src/actors/rqg-actor-sheet-data-prep.ts
+++ b/src/actors/rqg-actor-sheet-data-prep.ts
@@ -758,6 +758,11 @@ export async function organizeEmbeddedItems(
     (cultItem as any).hasAccessToRuneMagic = hasAccessToRuneMagic(cultItem);
   });
 
+  // externalRuneMagic/externalSpellSourceActor (#1002, spells known via the linked Allied Spirit
+  // bond) are decorated onto cult items in rqg-actor-sheet-v2.ts instead of here, since this
+  // function is also used by the legacy V1 sheet (rqg-actor-sheet.ts), which never renders them -
+  // no reason to make it pay for computing them too.
+
   // Enrich item description and GM notes texts for tooltip display
   const enrichItem = async (item: RqgItem) => {
     (item.system as any).enrichedDescription =

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -18,6 +18,7 @@ import {
   localizeDocumentName,
   range,
   requireValue,
+  resolveCastItem,
   RqgError,
 } from "../system/util";
 
@@ -66,6 +67,7 @@ import {
 import { getWeaponEffectModifier } from "../items/weapon-item/weapon-skill-links";
 import type { SpiritMagicItem } from "@item-model/spirit-magic-data-model.ts";
 import type { RuneMagicItem } from "@item-model/rune-magic-data-model.ts";
+import type { CultItem } from "@item-model/cult-data-model.ts";
 import type { GearItem } from "@item-model/gear-data-model.ts";
 import type { RqgActiveEffect } from "../active-effect/rqg-active-effect.ts";
 import { ActorWizard } from "../applications/actor-wizard-application";
@@ -92,6 +94,7 @@ import {
   getMagicPointSourcesAppId,
   MagicPointSourcesApp,
 } from "../applications/magic-point-sources-app/magic-point-sources-app";
+import { getExternalRuneMagicItems, getExternalSpiritMagicItems } from "../system/spell-source";
 
 const { HandlebarsApplicationMixin } = foundry.applications.api;
 const ActorSheetV2 = foundry.applications.sheets.ActorSheetV2;
@@ -265,6 +268,9 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     // the allied bond (and, on the ally side, re-walk game.actors.contents) themselves.
     const alliedBondActor = alliedSpirit ?? boundPriest;
     const magicPointStorageItems = getStorageItems(this.actor, alliedBondActor);
+    // #1002: Spirit Magic spells known via the linked Allied Spirit bond, not this actor - a live
+    // computed view (never merged into this actor's own Items), see getExternalSpiritMagicItems.
+    const externalSpiritMagic = getExternalSpiritMagicItems(this.actor, alliedBondActor);
     const incorrectRunes: RqgItem[] = [];
     const embeddedItems = await DataPrep.organizeEmbeddedItems(this.actor, incorrectRunes);
     const itemTree = new ItemTree(this.actor.items.contents);
@@ -293,6 +299,24 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     );
     const showUiSection = DataPrep.getUiSectionVisibility(this.actor);
     const cultItems = (embeddedItems[ItemTypeEnum.Cult] ?? []) as RqgItem[];
+    // #1002: Rune Magic spells known via the linked Allied Spirit bond, not this actor, attached
+    // per-cult (same "decorate the cult item" pattern as hasAccessToRuneMagic in
+    // organizeEmbeddedItems) - kept in the V2-only sheet rather than shared data-prep since the
+    // legacy V1 sheet never renders this and shouldn't pay for computing it.
+    cultItems.forEach((cult) => {
+      const cultItem = cult as CultItem;
+      const externalRuneMagic = getExternalRuneMagicItems(this.actor, cultItem, alliedBondActor);
+      externalRuneMagic.forEach((runeMagicItem) => {
+        (runeMagicItem as any).externalChance = (
+          runeMagicItem as RuneMagicItem
+        ).system.getDefaultChance(this.actor);
+      });
+      (cultItem as any).externalRuneMagic = externalRuneMagic;
+      (cultItem as any).externalSpellSourceActor =
+        externalRuneMagic.length > 0
+          ? { uuid: alliedBondActor!.uuid ?? "", name: alliedBondActor!.name ?? "" }
+          : undefined;
+    });
     const availableCultTabs = cultItems.map((cult) => `cult-${cult.id}`);
     const requestedCultTab = this.tabGroups["cult-view"] ?? undefined;
     const activeCultTab =
@@ -368,6 +392,12 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       ),
       alliedSpirit: alliedSpirit ? { uuid: alliedSpirit.uuid ?? "" } : undefined,
       boundPriest: boundPriest ? { uuid: boundPriest.uuid ?? "" } : undefined,
+      // Gates any "From {name}:" divider (#1002) - individual sections (e.g. externalSpiritMagic
+      // below, or a cult's externalRuneMagic) separately check their own item list is non-empty.
+      externalSpellSourceActor: alliedBondActor
+        ? { uuid: alliedBondActor.uuid ?? "", name: alliedBondActor.name ?? "" }
+        : undefined,
+      externalSpiritMagic: externalSpiritMagic,
 
       enrichedBiography: await foundry.applications.ux.TextEditor.implementation.enrichHTML(
         system.background.biography ?? "",
@@ -820,22 +850,21 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       });
     });
 
-    // Roll Spirit Magic
+    // Roll Spirit Magic (own or, via #1002, an external spell source - see resolveCastItem)
     this.element.querySelectorAll<HTMLElement>("[data-spirit-magic-roll]").forEach((el) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      const item = this.actor.items.get(itemId) as SpiritMagicItem | undefined;
+      const item = resolveCastItem(el, this.actor) as SpiritMagicItem | undefined;
       assertDocumentSubType<SpiritMagicItem>(
         item,
         ItemTypeEnum.SpiritMagic,
-        `Couldn't find item [${itemId}] to roll Spirit Magic`,
+        `Couldn't find item to roll Spirit Magic`,
       );
       this._bindSingleDoubleClick(el, {
-        onSingle: () => item.spiritMagicRoll(this.document.token),
+        onSingle: () => item.spiritMagicRoll(this.document.token, this.actor),
         onDouble: () => {
           if (item.system.isVariable && item.system.points > 1) {
-            return item.spiritMagicRoll(this.document.token);
+            return item.spiritMagicRoll(this.document.token, this.actor);
           } else {
-            return item.spiritMagicRollImmediate(undefined, this.document.token);
+            return item.spiritMagicRollImmediate(undefined, this.document.token, this.actor);
           }
         },
       });
@@ -843,20 +872,19 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
 
     // Roll Rune Magic
     this.element.querySelectorAll<HTMLElement>("[data-rune-magic-roll]").forEach((el) => {
-      const itemId = getRequiredDomDataset(el, "item-id");
-      const item = this.actor.items.get(itemId) as RuneMagicItem | undefined;
+      const item = resolveCastItem(el, this.actor) as RuneMagicItem | undefined;
       assertDocumentSubType<RuneMagicItem>(
         item,
         ItemTypeEnum.RuneMagic,
-        `Couldn't find item [${itemId}] to roll Rune Magic`,
+        `Couldn't find item to roll Rune Magic`,
       );
       this._bindSingleDoubleClick(el, {
-        onSingle: () => item.runeMagicRoll(this.document.token),
+        onSingle: () => item.runeMagicRoll(this.document.token, this.actor),
         onDouble: () => {
           if (item.system.points === 1) {
-            return item.runeMagicRollImmediate({}, this.document.token);
+            return item.runeMagicRollImmediate({}, this.document.token, this.actor);
           } else {
-            return item.runeMagicRoll(this.document.token);
+            return item.runeMagicRoll(this.document.token, this.actor);
           }
         },
       });

--- a/src/actors/rqg-actor-sheet-v2.types.ts
+++ b/src/actors/rqg-actor-sheet-v2.types.ts
@@ -106,6 +106,15 @@ export interface RqgActorSheetV2Context {
   /** The Character actor that has *this* actor linked as its Allied Spirit (#957) - the
    *  reciprocal, read-only side of the bond - see getBondedPriest. Undefined otherwise. */
   boundPriest: { uuid: string } | undefined;
+  /** The linked Allied Spirit bond partner (#957, either direction), only when it's the source of
+   *  at least one external spell (#1002) shown somewhere on this sheet - undefined otherwise, even
+   *  if a bond exists, so templates can gate a "From {name}:" divider on this alone. Distinct from
+   *  alliedSpirit/boundPriest above (those gate the link-management UI, not spell sharing). */
+  externalSpellSourceActor: { uuid: string; name: string } | undefined;
+  /** Spirit Magic spells known by the linked Allied Spirit bond partner, not this actor (#1002) -
+   *  never merged into embeddedItems.spiritMagic, so they disappear immediately if the bond is
+   *  unlinked. Empty when there's no bond partner or it knows no Spirit Magic. */
+  externalSpiritMagic: RqgItem[];
 
   /** Enriched biography HTML. */
   enrichedBiography: string;

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-rune-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-rune-magic.hbs
@@ -124,6 +124,39 @@
               </div>
             {{/if}}
           {{/each}}
+
+          {{#if externalRuneMagic.length}}
+            <div class="external-spell-divider">{{localize "RQG.Actor.RuneMagic.FromSourceLabel" name=externalSpellSourceActor.name}}</div>
+            {{#each externalRuneMagic}}
+              <div class="rune-magic-row external-item" data-external-owner-uuid="{{../externalSpellSourceActor.uuid}}">
+                <div class="rune-magic contextmenu item"
+                     data-item-id="{{id}}"
+                     {{#if system.descriptionRqidLink.rqid}}data-rqid-link="{{system.descriptionRqidLink.rqid}}"{{/if}}>
+                  <img class="row-icon" src="{{img}}">
+                </div>
+                <div class="rune-magic contextmenu item"
+                     data-item-id="{{id}}"
+                     data-rune-magic-roll
+                     data-tooltip="{{localize 'RQG.Game.RollTitle'}}">
+                  {{name}}&nbsp;
+                  {{#if system.isCommon}}
+                    <img class="common" src="systems/rqg/assets/images/items/cult.svg"
+                         data-tooltip="{{localize "RQG.Actor.RuneMagic.CommonRuneMagicTooltip"}}">
+                  {{/if}}
+                  {{#each system.runeRqidLinks}}
+                    <img class="rune" src="{{rqidImgSrc rqid}}" data-tooltip="{{name}}">
+                  {{/each}}
+                </div>
+                   <div class="rune-magic contextmenu item"
+                     data-item-id="{{id}}"
+                     data-tooltip="{{spellSummaryTooltip}}"
+                     data-rune-magic-roll>{{spellSummary}}</div>
+                <div class="rune-magic contextmenu item text-right"
+                     data-item-id="{{id}}"
+                     data-rune-magic-roll>{{externalChance}}%</div>
+              </div>
+            {{/each}}
+          {{/if}}
         </div>
       {{else}}
         <div class="warning p-5 flex-row">

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
@@ -65,6 +65,32 @@
       </div>
     </div>
     {{/each}}
+
+    {{#if externalSpiritMagic.length}}
+      <div class="external-spell-divider">{{localize "RQG.Actor.SpiritMagic.FromSourceLabel" name=externalSpellSourceActor.name}}</div>
+      {{#each externalSpiritMagic}}
+      <div class="spirit-magic-row external-item" data-external-owner-uuid="{{@root.externalSpellSourceActor.uuid}}">
+         <div class="spirit-magic contextmenu item"
+           data-item-id="{{id}}"
+           {{#if system.descriptionRqidLink.rqid}}data-rqid-link="{{system.descriptionRqidLink.rqid}}"{{/if}}>
+           <img class="row-icon" src="{{img}}">
+        </div>
+        <div class="spirit-magic contextmenu item"
+             data-item-id="{{id}}"
+             data-spirit-magic-roll
+             data-tooltip="{{localize 'RQG.Game.RollTitle'}}">
+          {{name}}{{#if system.isMatrix}} {{localize "RQG.Item.SpiritMagic.MatrixIndicator"}}{{/if}}
+        </div>
+        <div class="spirit-magic contextmenu item"
+             data-item-id="{{id}}"
+             data-tooltip="{{spellSummaryTooltip}}"
+             data-spirit-magic-roll>
+          {{spellSummary}}
+        </div>
+        <div class="spirit-magic contextmenu item" data-item-id="{{id}}">—</div>
+      </div>
+      {{/each}}
+    {{/if}}
   </div>
 
 </section>

--- a/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-data.types.ts
+++ b/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-data.types.ts
@@ -45,4 +45,5 @@ export type RuneMagicRollDialogFormData = {
 
   spellItemUuid?: string; // hidden field
   tokenUuid?: string; // hidden field
+  casterActorUuid?: string; // hidden field
 };

--- a/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.hbs
+++ b/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.hbs
@@ -89,4 +89,5 @@
 
   <input type="hidden" value="{{formData.spellItemUuid}}" name="spellItemUuid">
   <input type="hidden" value="{{formData.tokenUuid}}" name="tokenUuid">
+  <input type="hidden" value="{{formData.casterActorUuid}}" name="casterActorUuid">
 </div>

--- a/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.ts
+++ b/src/applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2.ts
@@ -1,3 +1,5 @@
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data.ts";
 import { systemId } from "../../system/config";
 import { templatePaths } from "../../system/load-handlebars-templates";
 import {
@@ -41,7 +43,7 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
   }
 
   private computeTotalChance(formData: RuneMagicRollDialogFormData): number {
-    const eligibleRunes = this.spellItem.system.getEligibleRunes();
+    const eligibleRunes = this.spellItem.system.getEligibleRunes(this.casterActor);
     const usedRune = eligibleRunes.find((r) => r.id === formData.usedRuneId);
     return this.spellItem.system.getCastChance(usedRune, [
       { value: formData.augmentModifier },
@@ -87,15 +89,25 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
   ];
 
   private spellItem: RuneMagicItem;
+  private casterActor: CharacterActor;
   private token: TokenDocument | null | undefined;
 
+  /**
+   * `casterActor` defaults to the spell's own owner - pass it explicitly when the spell is being
+   * cast via an external spell source (#1002, e.g. an Allied Spirit bond partner's known spells)
+   * so eligible Runes, chances, and the MP/RP source pickers all reflect the actual caster.
+   */
   constructor(
     spellItem: RuneMagicItem,
     token?: TokenDocument | null,
+    casterActor?: RqgActor,
     options?: Partial<foundry.applications.types.ApplicationConfiguration>,
   ) {
     super(options);
+    const caster = casterActor ?? spellItem.parent;
+    assertDocumentSubType<CharacterActor>(caster, ActorTypeEnum.Character);
     this.spellItem = spellItem;
+    this.casterActor = caster;
     this.token = token;
   }
 
@@ -134,18 +146,19 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
       {}) as RuneMagicRollDialogFormData;
 
     const speaker = getSpeakerCompat({
-      actor: this.spellItem.actor ?? undefined,
+      actor: this.casterActor,
       token: this.token,
     });
 
-    const eligibleRunes = this.spellItem.system.getEligibleRunes();
+    const eligibleRunes = this.spellItem.system.getEligibleRunes(this.casterActor);
 
     const eligibleRuneOptions = eligibleRunes.map((rune) => ({
       value: rune.id ?? "",
       label: rune.name ?? "",
     }));
     formData.levelUsed ??= this.spellItem.system.points;
-    formData.usedRuneId ??= this.spellItem.system.getStrongestEligibleRune()?.id ?? "";
+    formData.usedRuneId ??=
+      this.spellItem.system.getStrongestEligibleRune(this.casterActor)?.id ?? "";
     formData.boost ??= 0;
     // Rune Magic only spends Magic Points when boosting, so the source picker only matters (and
     // is only shown) once the caster has actually entered a boost - see showMagicPointSource
@@ -164,19 +177,18 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
     formData.otherModifierDescription ??= localize("RQG.Dialog.Common.OtherModifier");
     formData.spellItemUuid ??= this.spellItem.uuid ?? undefined;
     formData.tokenUuid ??= this.token?.uuid ?? undefined;
+    formData.casterActorUuid ??= this.casterActor.uuid ?? undefined;
 
     const usedRune = eligibleRunes.find((r) => r.id === formData.usedRuneId);
-    const magicPointSourceOptions = getMagicPointSourceOptions(this.spellItem.actor);
+    const magicPointSourceOptions = getMagicPointSourceOptions(this.casterActor);
     const runePointSourceOptions = getRunePointSourceOptions(
-      this.spellItem.actor,
-      this.spellItem.system.getCult(),
+      this.casterActor,
+      this.spellItem.system.getCastingCult(this.casterActor),
     );
     // A bonded ally exists but doesn't have a Cult item matching this spell's exact cult (e.g. a
     // different subcult of the same deity) - without this, that misconfiguration is silent: the
     // picker just never appears, indistinguishable from having no bond at all.
-    const alliedBondActor = this.spellItem.actor
-      ? getAlliedBondActor(this.spellItem.actor)
-      : undefined;
+    const alliedBondActor = getAlliedBondActor(this.casterActor);
     const showRunePointSourceMismatchWarning =
       runePointSourceOptions.length === 0 && !!alliedBondActor;
 
@@ -254,7 +266,12 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
     }
     assertDocumentSubType<RuneMagicItem>(spellItem, ItemTypeEnum.RuneMagic);
 
-    const eligibleRunes = spellItem.system.getEligibleRunes();
+    const casterActor = formDataObject.casterActorUuid
+      ? ((await fromUuid(formDataObject.casterActorUuid)) as RqgActor | undefined)
+      : (spellItem.actor ?? undefined);
+    assertDocumentSubType<CharacterActor>(casterActor, ActorTypeEnum.Character);
+
+    const eligibleRunes = spellItem.system.getEligibleRunes(casterActor);
 
     const usedRune = eligibleRunes.find((r) => r.id === formDataObject.usedRuneId);
     if (!usedRune) {
@@ -262,10 +279,10 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
       return logger.throw(msg, formDataObject);
     }
 
-    if (!spellItem.system.getCult()) {
+    if (!spellItem.system.getCastingCult(casterActor)) {
       const msg = "No cult to cast the rune magic spell";
       return logger.throw(msg, {
-        actorId: spellItem.actor?.id,
+        actorId: casterActor.id,
         spellItemId: spellItem.id,
         cultId: spellItem.system.cultId,
       });
@@ -302,12 +319,13 @@ export class RuneMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
       formDataObject.boost,
       formDataObject.magicPointSource,
       formDataObject.runePointSource,
+      casterActor,
     );
     if (validationError) {
       ui.notifications?.warn(validationError);
       return;
     }
 
-    await spellItem.runeMagicRollImmediate(options, token);
+    await spellItem.runeMagicRollImmediate(options, token, casterActor);
   }
 }

--- a/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-data.types.ts
+++ b/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-data.types.ts
@@ -24,5 +24,6 @@ export type SpiritMagicRollDialogFormData = {
 
   spellItemUuid?: string; // hidden field
   tokenUuid?: string; // hidden field
+  casterActorUuid?: string; // hidden field
   powX5: number; // hidden field
 };

--- a/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-v2.hbs
+++ b/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-v2.hbs
@@ -52,5 +52,6 @@
 
   <input type="hidden" value="{{formData.spellItemUuid}}" name="spellItemUuid">
   <input type="hidden" value="{{formData.tokenUuid}}" name="tokenUuid">
+  <input type="hidden" value="{{formData.casterActorUuid}}" name="casterActorUuid">
   <input type="hidden" data-dtype="Number" value="{{formData.powX5}}" name="powX5">
 </div>

--- a/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-v2.ts
+++ b/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-v2.ts
@@ -12,6 +12,7 @@ import {
 } from "../../system/util";
 import { getSpeakerCompat } from "../../system/fvtt-type-compat";
 import type { SpiritMagicRollOptions } from "../../rolls/spirit-magic-roll/spirit-magic-roll.types";
+import type { RqgActor } from "@actors/rqg-actor.ts";
 import { RqgItem } from "@items/rqg-item.ts";
 import type { PartialAbilityItem } from "../ability-roll-dialog/ability-roll-dialog-data.types.ts";
 import { ItemTypeEnum } from "@item-model/item-types.ts";
@@ -57,6 +58,7 @@ export class SpiritMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
   ];
 
   private spellItem: SpiritMagicItem;
+  private casterActor: CharacterActor;
   private powX5: number;
   private token: TokenDocument | null | undefined;
 
@@ -67,18 +69,25 @@ export class SpiritMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
     };
   }
 
+  /**
+   * `casterActor` defaults to the spell's own owner - pass it explicitly when the spell is being
+   * cast via an external spell source (#1002, e.g. an Allied Spirit bond partner's known spells)
+   * so POWx5% and the Magic Point source options both reflect the actual caster.
+   */
   constructor(
     spellItem: SpiritMagicItem,
     token?: TokenDocument | null,
+    casterActor?: RqgActor,
     options?: Partial<foundry.applications.types.ApplicationConfiguration>,
   ) {
     super(options);
 
-    const actor = spellItem.parent;
-    assertDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character);
+    const caster = casterActor ?? spellItem.parent;
+    assertDocumentSubType<CharacterActor>(caster, ActorTypeEnum.Character);
 
     this.spellItem = spellItem;
-    this.powX5 = (actor.system?.characteristics?.power?.value ?? 0) * 5;
+    this.casterActor = caster;
+    this.powX5 = (caster.system?.characteristics?.power?.value ?? 0) * 5;
     this.token = token;
   }
 
@@ -130,6 +139,7 @@ export class SpiritMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
     formData.powX5 ??= this.powX5;
     formData.spellItemUuid ??= this.spellItem.uuid ?? undefined;
     formData.tokenUuid ??= this.token?.uuid ?? undefined;
+    formData.casterActorUuid ??= this.casterActor.uuid ?? undefined;
 
     return {
       formData: formData,
@@ -138,7 +148,7 @@ export class SpiritMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
       isVariable: this.spellItem.system.isVariable && this.spellItem.system.points > 1,
       augmentOptions: SpiritMagicRollDialogV2.augmentOptions,
       meditateOptions: SpiritMagicRollDialogV2.meditateOptions,
-      magicPointSourceOptions: getMagicPointSourceOptions(this.spellItem.actor),
+      magicPointSourceOptions: getMagicPointSourceOptions(this.casterActor),
 
       // RollHeader
       rollType: localize("TYPES.Item.spiritMagic"),
@@ -193,6 +203,11 @@ export class SpiritMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
     }
     assertDocumentSubType<SpiritMagicItem>(spellItem, ItemTypeEnum.SpiritMagic);
 
+    const casterActor = formDataObject.casterActorUuid
+      ? ((await fromUuid(formDataObject.casterActorUuid)) as RqgActor | undefined)
+      : (spellItem.actor ?? undefined);
+    assertDocumentSubType<CharacterActor>(casterActor, ActorTypeEnum.Character);
+
     const options: SpiritMagicRollOptions = {
       powX5: formDataObject.powX5,
       levelUsed: formDataObject.levelUsed,
@@ -217,18 +232,19 @@ export class SpiritMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
       spellName: spellItem?.name ?? undefined,
       spellImg: spellItem?.img ?? undefined,
       rollMode: rollMode,
-      speaker: getSpeakerCompat({ actor: spellItem.actor ?? undefined, token }),
+      speaker: getSpeakerCompat({ actor: casterActor, token }),
     };
     const validationError = spellItem.system.getCastValidationError(
       formDataObject.levelUsed,
       Number(formDataObject.boost ?? 0),
       formDataObject.magicPointSource,
+      casterActor,
     );
     if (validationError) {
       ui.notifications?.warn(validationError);
       return;
     }
 
-    await spellItem.spiritMagicRollImmediate(options, token);
+    await spellItem.spiritMagicRollImmediate(options, token, casterActor);
   }
 }

--- a/src/data-model/item-data/rune-magic-data-model.test.ts
+++ b/src/data-model/item-data/rune-magic-data-model.test.ts
@@ -44,6 +44,7 @@ describe("RuneMagicDataModel chance helpers", () => {
   it("validates available rune and magic points for casting", () => {
     const fakeModel = {
       getCult: () => ({ system: { runePoints: { value: 4 } } }),
+      getCastingCult: () => ({ system: { runePoints: { value: 4 } } }),
       parent: { actor: { system: { attributes: { magicPoints: { value: 7 } } } } },
     } as unknown as RuneMagicDataModel;
 
@@ -61,6 +62,7 @@ describe("RuneMagicDataModel chance helpers", () => {
   it("counts a chosen magic point source's stored points for the boost, leaving Rune Points cult-sourced (#956)", () => {
     const fakeModel = {
       getCult: () => ({ system: { runePoints: { value: 4 } } }),
+      getCastingCult: () => ({ system: { runePoints: { value: 4 } } }),
       parent: {
         actor: {
           items: [
@@ -115,6 +117,104 @@ describe("RuneMagicDataModel chance helpers", () => {
       mp: 0,
       exp: false,
     });
+  });
+});
+
+describe("RuneMagicDataModel.getCastingCult (#1002)", () => {
+  it("returns the spell's own cult unchanged when casterActor is the spell's own owner", () => {
+    const ownActor = {};
+    const ownCult = { id: "cult1", system: { runePoints: { value: 4 } } };
+    const fakeModel = {
+      getCult: () => ownCult,
+      parent: { actor: ownActor },
+    } as unknown as RuneMagicDataModel;
+
+    expect(RuneMagicDataModel.prototype.getCastingCult.call(fakeModel, ownActor as any)).toBe(
+      ownCult,
+    );
+  });
+
+  it("matches the caster's own Cult item by rqid when casterActor is a different actor", () => {
+    const casterCult = { id: "cult-on-caster", system: { runePoints: { value: 2 } } };
+    const casterActor = {
+      uuid: "Actor.caster",
+      getBestEmbeddedDocumentByRqid: (rqid: string) =>
+        rqid === "je.orlanth" ? casterCult : undefined,
+    } as any;
+    const fakeModel = {
+      getCult: () => ({
+        id: "cult-on-owner",
+        getFlag: (_scope: string, key: string) =>
+          key === "documentRqidFlags" ? { id: "je.orlanth" } : undefined,
+      }),
+      parent: {
+        actor: { uuid: "Actor.owner" /* the spell's own owner, distinct from casterActor */ },
+      },
+    } as unknown as RuneMagicDataModel;
+
+    expect(RuneMagicDataModel.prototype.getCastingCult.call(fakeModel, casterActor)).toBe(
+      casterCult,
+    );
+  });
+
+  it("returns undefined when the caster has no matching cult", () => {
+    const casterActor = {
+      uuid: "Actor.caster",
+      getBestEmbeddedDocumentByRqid: () => undefined,
+    } as any;
+    const fakeModel = {
+      getCult: () => ({
+        id: "cult-on-owner",
+        getFlag: (_scope: string, key: string) =>
+          key === "documentRqidFlags" ? { id: "je.orlanth" } : undefined,
+      }),
+      parent: { actor: { uuid: "Actor.owner" } },
+    } as unknown as RuneMagicDataModel;
+
+    expect(
+      RuneMagicDataModel.prototype.getCastingCult.call(fakeModel, casterActor),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the spell has no cult at all", () => {
+    const fakeModel = {
+      getCult: () => undefined,
+      parent: { actor: {} },
+    } as unknown as RuneMagicDataModel;
+
+    expect(RuneMagicDataModel.prototype.getCastingCult.call(fakeModel, {} as any)).toBeUndefined();
+  });
+});
+
+describe("RuneMagicDataModel.getEligibleRunes with an external caster (#1002)", () => {
+  it("searches the caster's own Runes and cult, not the spell owner's", () => {
+    const casterWaterRune = { id: "caster-water", system: { chance: 60 } };
+    const casterActor = {
+      getBestEmbeddedDocumentByRqid: (rqid: string) =>
+        rqid === "i.rune.water" ? casterWaterRune : undefined,
+    } as any;
+    const fakeModel = {
+      runeRqidLinks: [{ rqid: "i.rune.water" }],
+      getCastingCult: () => ({
+        system: { runeRqidLinks: [{ rqid: "i.rune.magic" }] },
+      }),
+      parent: { actor: {/* the spell's own owner */} },
+    } as unknown as RuneMagicDataModel;
+
+    expect(RuneMagicDataModel.prototype.getEligibleRunes.call(fakeModel, casterActor)).toEqual([
+      casterWaterRune,
+    ]);
+  });
+
+  it("is empty when the caster has no matching cult to cast under", () => {
+    const casterActor = { getBestEmbeddedDocumentByRqid: () => undefined } as any;
+    const fakeModel = {
+      runeRqidLinks: [{ rqid: "i.rune.water" }],
+      getCastingCult: () => undefined,
+      parent: { actor: {} },
+    } as unknown as RuneMagicDataModel;
+
+    expect(RuneMagicDataModel.prototype.getEligibleRunes.call(fakeModel, casterActor)).toEqual([]);
   });
 });
 

--- a/src/data-model/item-data/rune-magic-data-model.ts
+++ b/src/data-model/item-data/rune-magic-data-model.ts
@@ -1,3 +1,4 @@
+import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
@@ -16,6 +17,7 @@ import {
   type MagicPointSourceSelection,
 } from "../../system/magic-point-source";
 import {
+  findMatchingCultByRqid,
   getAvailableRunePoints,
   type RunePointSourceSelection,
   SELF_RUNE_POINT_SOURCE,
@@ -68,10 +70,40 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
     return isDocumentSubType<CultItem>(cult, "cult" as Item.SubType) ? cult : undefined;
   }
 
-  getEligibleRunes(): RuneItem[] {
-    const actor = this.parent?.actor;
-    const cult = this.getCult();
-    if (!actor || !cult) {
+  /**
+   * The cult this spell is cast under, from `casterActor`'s point of view - the spell's own cult
+   * (`getCult()`, a local-id lookup) when `casterActor` is this Item's own owner, or that same
+   * cult matched by rqid onto `casterActor`'s own Cult items when the spell is being cast via an
+   * external spell source (#1002, e.g. an Allied Spirit bond partner's known spells). `cultId` is a
+   * local Foundry document id, only meaningful on the actor the spell Item actually lives on - it
+   * can't be resolved directly against a different actor, hence the rqid fallback via
+   * findMatchingCultByRqid (rune-point-source.ts, shared with getAlliedCultItem's reverse
+   * direction of this same match).
+   */
+  getCastingCult(casterActor: RqgActor): CultItem | undefined {
+    const ownCult = this.getCult();
+    if (!ownCult) {
+      return undefined;
+    }
+    // Compare by uuid, not object identity - casterActor may have round-tripped through
+    // fromUuid/fromUuidSync (e.g. resolved from a roll dialog's hidden form field) rather than
+    // being the exact same in-memory reference as this.parent?.actor.
+    if (casterActor.uuid === this.parent?.actor?.uuid) {
+      return ownCult;
+    }
+    return findMatchingCultByRqid(casterActor, ownCult);
+  }
+
+  /**
+   * `casterActor` defaults to this Item's own owner (unchanged pre-#1002 behavior) - pass it
+   * explicitly to find the Runes the actual caster would roll against when casting via an external
+   * spell source, so the caster's own Rune chance is used, never the spell owner's.
+   */
+  getEligibleRunes(
+    casterActor: RqgActor | undefined = this.parent?.actor ?? undefined,
+  ): RuneItem[] {
+    const cult = casterActor ? this.getCastingCult(casterActor) : undefined;
+    if (!casterActor || !cult) {
       return [];
     }
 
@@ -84,7 +116,9 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
       : runeMagicRuneRqids;
 
     return usableRuneRqids
-      .map((runeRqid) => actor.getBestEmbeddedDocumentByRqid(toRqidString(runeRqid)) as RuneItem)
+      .map(
+        (runeRqid) => casterActor.getBestEmbeddedDocumentByRqid(toRqidString(runeRqid)) as RuneItem,
+      )
       .filter(isTruthy);
   }
 
@@ -99,16 +133,16 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
     });
   }
 
-  getStrongestEligibleRune(): RuneItem | undefined {
-    return RuneMagicDataModel.getStrongestRune(this.getEligibleRunes());
+  getStrongestEligibleRune(casterActor?: RqgActor): RuneItem | undefined {
+    return RuneMagicDataModel.getStrongestRune(this.getEligibleRunes(casterActor));
   }
 
   getBaseChance(usedRune: RuneItem | null | undefined): number {
     return Number(usedRune?.system.chance ?? 0);
   }
 
-  getDefaultChance(): number {
-    return this.getBaseChance(this.getStrongestEligibleRune());
+  getDefaultChance(casterActor?: RqgActor): number {
+    return this.getBaseChance(this.getStrongestEligibleRune(casterActor));
   }
 
   static calculateCastChanceFromBaseChance(
@@ -142,11 +176,13 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
     magicPointsBoost: number = 0,
     magicPointSource?: MagicPointSourceSelection,
     runePointSource: RunePointSourceSelection = SELF_RUNE_POINT_SOURCE,
+    casterActor: RqgActor | undefined = this.parent?.actor ?? undefined,
   ): string | undefined {
-    const cult = this.getCult();
-    const actor = this.parent?.actor;
-    const availableRunePoints = getAvailableRunePoints(actor, cult, runePointSource);
-    const availableMagicPoints = actor ? getAvailableMagicPoints(actor, magicPointSource) : 0;
+    const cult = casterActor ? this.getCastingCult(casterActor) : undefined;
+    const availableRunePoints = getAvailableRunePoints(casterActor, cult, runePointSource);
+    const availableMagicPoints = casterActor
+      ? getAvailableMagicPoints(casterActor, magicPointSource)
+      : 0;
     if (runePointCost == null || runePointCost > availableRunePoints) {
       return game.i18n?.format("RQG.Item.RuneMagic.validationNotEnoughRunePoints");
     }
@@ -201,39 +237,50 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
   }
 
   /**
-   * Open a dialog for a RuneMagicRoll.
+   * Open a dialog for a RuneMagicRoll. `casterActor` defaults to the spell's own owner - pass it
+   * explicitly when the spell is being cast via an external spell source (#1002, e.g. an Allied
+   * Spirit bond partner's known spells) so the roll uses the caster's own Rune chance, not the
+   * spell owner's.
    */
-  async runeMagicRoll(token?: TokenDocument | null): Promise<void> {
+  async runeMagicRoll(token?: TokenDocument | null, casterActor?: RqgActor): Promise<void> {
     // Dynamic import to avoid circular dependency through RuneMagicRollDialogV2 → rqgItem.ts
     const { RuneMagicRollDialogV2 } =
       await import("../../applications/rune-magic-roll-dialog/rune-magic-roll-dialog-v2");
-    await new RuneMagicRollDialogV2(this.parent as unknown as RuneMagicItem, token).render({
+    await new RuneMagicRollDialogV2(
+      this.parent as unknown as RuneMagicItem,
+      token,
+      casterActor,
+    ).render({
       force: true,
     });
   }
 
   /**
    * Do a runeMagicRoll and possibly draw rune and magic points afterward.
-   * Also adds experience to the used rune.
+   * Also adds experience to the used rune. `casterActor` defaults to this Item's own owner (same
+   * as before #1002); pass it explicitly to roll and pay for the cast as the actual caster, when
+   * casting a spell known via an external spell source rather than the actor that owns this Item.
    */
   async runeMagicRollImmediate(
     options: RuneMagicRollImmediateOptions = {},
     token?: TokenDocument | null,
+    casterActor: RqgActor = this.parent?.actor as RqgActor,
   ): Promise<void> {
     const item = this.parent;
-    const actor = item?.parent;
-    assertDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character, "Item is not embedded");
+    assertDocumentSubType<CharacterActor>(
+      casterActor,
+      ActorTypeEnum.Character,
+      "Item is not embedded",
+    );
 
     // Dynamic imports to avoid circular dependencies through rqgItem.ts
     const { handleRollResult } = await import("../../items/rune-magic-item/rune-magic-casting");
     const { RuneMagicRoll } = await import("../../rolls/rune-magic-roll/rune-magic-roll");
 
-    const cult = actor.items.find((i) => i.id === this.cultId) as RqgItem | undefined;
+    const cult = this.getCastingCult(casterActor);
     if (!cult) {
       return logger.throw("Rune Magic item isn't connected to a cult", item);
     }
-    // Use string literal "cult" to avoid circular dep through ItemTypeEnum → itemTypes.ts → runeMagic.ts → rqgItem.ts
-    assertDocumentSubType<CultItem>(cult, "cult" as Item.SubType);
 
     const levelUsedOrDefault = options.levelUsed ?? this.points;
     // Quick Roll (no dialog) never sets this, so fall back to Auto (drain stored sources first)
@@ -246,6 +293,7 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
       options.magicPointBoost,
       magicPointSource,
       runePointSource,
+      casterActor,
     );
     if (validationError) {
       ui.notifications?.warn(validationError);
@@ -254,15 +302,15 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
 
     const runeMagicItemTyped = item as unknown as RuneMagicItem;
     const usedRune = options.usedRuneId
-      ? this.getEligibleRunes().find((r) => r.id === options.usedRuneId)
-      : this.getStrongestEligibleRune();
+      ? this.getEligibleRunes(casterActor).find((r) => r.id === options.usedRuneId)
+      : this.getStrongestEligibleRune(casterActor);
     if (!usedRune) {
       const msg = "Could not find a rune to use for rune magic";
       ui.notifications?.warn(msg);
       return;
     }
 
-    const speaker = getSpeakerCompat({ actor, token });
+    const speaker = getSpeakerCompat({ actor: casterActor, token });
 
     const runeMagicRoll = await RuneMagicRoll.rollAndShow({
       usedRuneName: usedRune.name ?? "",
@@ -289,6 +337,7 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
       runeMagicItemTyped,
       magicPointSource,
       runePointSource,
+      casterActor,
     );
   }
 

--- a/src/data-model/item-data/spirit-magic-data-model.test.ts
+++ b/src/data-model/item-data/spirit-magic-data-model.test.ts
@@ -60,6 +60,32 @@ describe("SpiritMagicDataModel cast validation", () => {
   });
 });
 
+describe("SpiritMagicDataModel cast validation with an external caster (#1002)", () => {
+  it("checks the caster's own available Magic Points, not the spell owner's", () => {
+    const fakeModel = {
+      points: 3,
+      parent: { actor: { system: { attributes: { magicPoints: { value: 0 } } } } },
+    } as unknown as SpiritMagicDataModel;
+    const casterActor = { system: { attributes: { magicPoints: { value: 6 } } } } as any;
+
+    // The item's own owner has 0 MP and would fail...
+    expect(SpiritMagicDataModel.prototype.getCastValidationError.call(fakeModel, 2, 1)).toContain(
+      "RQG.Item.SpiritMagic.NotEnoughMagicPoints",
+    );
+
+    // ...but an explicit external caster with enough MP succeeds.
+    expect(
+      SpiritMagicDataModel.prototype.getCastValidationError.call(
+        fakeModel,
+        2,
+        1,
+        undefined,
+        casterActor,
+      ),
+    ).toBeUndefined();
+  });
+});
+
 describe("SpiritMagicDataModel.migrateData", () => {
   it("rewrites a legacy string-typed isRitual value to a real boolean", () => {
     const migrated = SpiritMagicDataModel.migrateData({ isRitual: "true," });

--- a/src/data-model/item-data/spirit-magic-data-model.ts
+++ b/src/data-model/item-data/spirit-magic-data-model.ts
@@ -1,3 +1,4 @@
+import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
@@ -54,11 +55,13 @@ export class SpiritMagicDataModel extends RqgItemDataModel<SpiritMagicSchema> {
     levelUsed: number | undefined,
     boost: number = 0,
     magicPointSource?: MagicPointSourceSelection,
+    casterActor: RqgActor | undefined = this.parent?.actor ?? undefined,
   ): string | undefined {
     const normalizedLevelUsed = levelUsed == null ? undefined : Number(levelUsed);
     const normalizedBoost = Number(boost) || 0;
-    const actor = this.parent?.actor;
-    const availableMagicPoints = actor ? getAvailableMagicPoints(actor, magicPointSource) : 0;
+    const availableMagicPoints = casterActor
+      ? getAvailableMagicPoints(casterActor, magicPointSource)
+      : 0;
 
     if (
       normalizedLevelUsed == null ||
@@ -76,42 +79,61 @@ export class SpiritMagicDataModel extends RqgItemDataModel<SpiritMagicSchema> {
   }
 
   /**
-   * Open a dialog for a SpiritMagicRoll.
+   * Open a dialog for a SpiritMagicRoll. `casterActor` defaults to the spell's own owner - pass it
+   * explicitly when the spell is being cast via an external spell source (#1002, e.g. an Allied
+   * Spirit bond partner's known spells) so the roll uses the caster's own stats, not the spell
+   * owner's.
    */
-  async spiritMagicRoll(token?: TokenDocument | null): Promise<void> {
+  async spiritMagicRoll(token?: TokenDocument | null, casterActor?: RqgActor): Promise<void> {
     // Dynamic import to avoid circular dependency through SpiritMagicRollDialogV2 → rqgItem.ts
     const { SpiritMagicRollDialogV2 } =
       await import("../../applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-v2");
-    await new SpiritMagicRollDialogV2(this.parent as unknown as SpiritMagicItem, token).render({
+    await new SpiritMagicRollDialogV2(
+      this.parent as unknown as SpiritMagicItem,
+      token,
+      casterActor,
+    ).render({
       force: true,
     });
   }
 
   /**
-   * Do a SpiritMagicRoll and possibly draw magic points afterward.
+   * Do a SpiritMagicRoll and possibly draw magic points afterward. `casterActor` defaults to the
+   * spell's own owner (same as before #1002); pass it explicitly when casting a spell known via an
+   * external spell source so POWx5% and the Magic Point draw both use the actual caster, not
+   * whoever's Item this is.
    */
   async spiritMagicRollImmediate(
     options: Omit<SpiritMagicRollOptions, "powX5"> = { levelUsed: this.points },
     token?: TokenDocument | null,
+    casterActor: RqgActor = this.parent?.actor as RqgActor,
   ): Promise<void> {
     const item = this.parent;
-    const actor = item?.actor;
-    assertDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character, "Item is not embedded");
+    assertDocumentSubType<CharacterActor>(
+      casterActor,
+      ActorTypeEnum.Character,
+      "Item is not embedded",
+    );
 
-    const powX5: number = (Number(actor.system.characteristics.power.value) || 0) * 5; // Handle NaN
+    const powX5: number = (Number(casterActor.system.characteristics.power.value) || 0) * 5; // Handle NaN
 
     const levelUsed = Number(options.levelUsed ?? this.points);
     const boost = Number(options.magicPointBoost ?? 0) || 0;
     // Quick Roll (no dialog) never sets this, so fall back to Auto (drain stored sources first)
     // instead of always using the caster's own pool - matches the cast dialogs' default.
     const magicPointSource = options.magicPointSource ?? AUTO_MAGIC_POINT_SOURCE;
-    const validationError = this.getCastValidationError(levelUsed, boost, magicPointSource);
+    const validationError = this.getCastValidationError(
+      levelUsed,
+      boost,
+      magicPointSource,
+      casterActor,
+    );
     if (validationError) {
       ui.notifications?.warn(validationError);
       return;
     }
 
-    const speaker = getSpeakerCompat({ actor, token });
+    const speaker = getSpeakerCompat({ actor: casterActor, token });
 
     // Dynamic import to avoid circular dependency through SpiritMagicRoll → itemTypes.ts → rqgItem.ts
     const { SpiritMagicRoll } = await import("../../rolls/spirit-magic-roll/spirit-magic-roll");
@@ -129,7 +151,7 @@ export class SpiritMagicDataModel extends RqgItemDataModel<SpiritMagicSchema> {
       throw new RqgError("Evaluated AbilityRoll didn't give successLevel");
     }
     const mpCost = levelUsed + boost;
-    await actor.drawMagicPoints(mpCost, spiritMagicRoll.successLevel, magicPointSource);
+    await casterActor.drawMagicPoints(mpCost, spiritMagicRoll.successLevel, magicPointSource);
   }
 
   /**

--- a/src/items/rqg-item.ts
+++ b/src/items/rqg-item.ts
@@ -1,3 +1,4 @@
+import type { RqgActor } from "@actors/rqg-actor.ts";
 import { PassionSheet } from "./passion-item/passion-sheet";
 import { PassionSheetV2 } from "./passion-item/passion-sheet-v2";
 import {
@@ -271,43 +272,53 @@ export class RqgItem extends Item {
   }
 
   /**
-   * Open a dialog for a SpiritMagicRoll
+   * Open a dialog for a SpiritMagicRoll. `casterActor` defaults to this item's own owner - pass it
+   * explicitly when casting via an external spell source (#1002).
    */
-  public async spiritMagicRoll(token?: TokenDocument | null): Promise<void> {
+  public async spiritMagicRoll(
+    token?: TokenDocument | null,
+    casterActor?: RqgActor,
+  ): Promise<void> {
     assertDocumentSubType<SpiritMagicItem>(this, ItemTypeEnum.SpiritMagic);
-    await this.system.spiritMagicRoll(token);
+    await this.system.spiritMagicRoll(token, casterActor);
   }
 
   /**
-   * Do a SpiritMagicRoll and possibly draw magic points afterward
+   * Do a SpiritMagicRoll and possibly draw magic points afterward. `casterActor` defaults to this
+   * item's own owner - pass it explicitly when casting via an external spell source (#1002).
    */
   public async spiritMagicRollImmediate(
     options: Omit<SpiritMagicRollOptions, "powX5"> = {
       levelUsed: (this as SpiritMagicItem).system.points,
     },
     token?: TokenDocument | null,
+    casterActor?: RqgActor,
   ): Promise<void> {
     assertDocumentSubType<SpiritMagicItem>(this, ItemTypeEnum.SpiritMagic);
-    await this.system.spiritMagicRollImmediate(options, token);
+    await this.system.spiritMagicRollImmediate(options, token, casterActor);
   }
 
   /**
-   * Open a dialog for a RuneMagicRoll
+   * Open a dialog for a RuneMagicRoll. `casterActor` defaults to this item's own owner - pass it
+   * explicitly when casting via an external spell source (#1002).
    */
-  public async runeMagicRoll(token?: TokenDocument | null): Promise<void> {
+  public async runeMagicRoll(token?: TokenDocument | null, casterActor?: RqgActor): Promise<void> {
     assertDocumentSubType<RuneMagicItem>(this, ItemTypeEnum.RuneMagic);
-    await this.system.runeMagicRoll(token);
+    await this.system.runeMagicRoll(token, casterActor);
   }
 
   /**
-   * Do a runeMagicRoll and possibly draw rune and magic points afterward. Also add experience to used rune.
+   * Do a runeMagicRoll and possibly draw rune and magic points afterward. Also add experience to
+   * used rune. `casterActor` defaults to this item's own owner - pass it explicitly when casting
+   * via an external spell source (#1002).
    */
   public async runeMagicRollImmediate(
     options: RuneMagicRollImmediateOptions = {},
     token?: TokenDocument | null,
+    casterActor?: RqgActor,
   ): Promise<void> {
     assertDocumentSubType<RuneMagicItem>(this, ItemTypeEnum.RuneMagic);
-    await this.system.runeMagicRollImmediate(options, token);
+    await this.system.runeMagicRollImmediate(options, token, casterActor);
   }
 
   /**

--- a/src/items/rune-magic-item/rune-magic-casting.ts
+++ b/src/items/rune-magic-item/rune-magic-casting.ts
@@ -17,6 +17,15 @@ import {
   spendRunePoints,
 } from "../../system/rune-point-source";
 
+/**
+ * `casterActor` defaults to `runeMagicItem`'s own owner (unchanged pre-#1002 behavior) - pass it
+ * explicitly when the spell was cast via an external spell source (#1002, e.g. an Allied Spirit
+ * bond partner's known spells), so Rune/Magic Points are drawn relative to the actual caster (not
+ * the spell owner) and the cult used for Rune Point spending is the caster's own matching cult
+ * (see RuneMagicDataModel.getCastingCult). `runeItem` is expected to already be the caster's own
+ * Rune (see getEligibleRunes) - awardExperience() below flags whichever actor owns `runeItem`,
+ * which falls out correctly for free as long as that's true.
+ */
 export async function handleRollResult(
   result: AbilitySuccessLevelEnum,
   runePointCost: number,
@@ -25,11 +34,12 @@ export async function handleRollResult(
   runeMagicItem: RuneMagicItem,
   magicPointSource: MagicPointSourceSelection = SELF_MAGIC_POINT_SOURCE,
   runePointSource: RunePointSourceSelection = SELF_RUNE_POINT_SOURCE,
+  casterActor: RqgActor | undefined = runeMagicItem.actor ?? undefined,
 ): Promise<void> {
   assertDocumentSubType<RuneItem>(runeItem, ItemTypeEnum.Rune);
   assertDocumentSubType<RuneMagicItem>(runeMagicItem, ItemTypeEnum.RuneMagic);
-  const cult = runeMagicItem.actor?.items.get(runeMagicItem.system.cultId ?? "") as
-    CultItem | undefined;
+  assertDocumentSubType<CharacterActor>(casterActor, ActorTypeEnum.Character);
+  const cult = runeMagicItem.system.getCastingCult(casterActor);
   assertDocumentSubType<CultItem>(cult, ItemTypeEnum.Cult);
   const isOneUse = runeMagicItem.system?.isOneUse;
 
@@ -38,7 +48,7 @@ export async function handleRollResult(
   await spendRuneAndMagicPoints(
     costs.rp,
     costs.mp,
-    runeMagicItem.actor ?? undefined,
+    casterActor,
     cult,
     isOneUse,
     magicPointSource,
@@ -51,7 +61,7 @@ export async function handleRollResult(
   if (costs.mp > 0 || costs.rp > 0) {
     ui.notifications?.info(
       localize("RQG.Item.RuneMagic.CastingCostInfo", {
-        actorName: runeMagicItem.parent?.name ?? "",
+        actorName: casterActor.name ?? "",
         runePointAmount: costs.rp.toString(),
         magicPointAmount: costs.mp.toString(),
       }),

--- a/src/system/rune-point-source.ts
+++ b/src/system/rune-point-source.ts
@@ -30,8 +30,22 @@ export const ALLY_RUNE_POINT_SOURCE = "ally";
  * cult copied onto two different actors' sheets shares this id, unlike `deity` which is just
  * display text and can vary (e.g. subcults).
  */
-function getCultRqid(cult: CultItem): RqidString | undefined {
+export function getCultRqid(cult: CultItem): RqidString | undefined {
   return cult.getFlag(systemId, documentRqidFlags)?.id;
+}
+
+/**
+ * `cult`'s matching Cult item on `actor`, matched by rqid (e.g. the same compendium cult copied
+ * onto two different actors' sheets) - the shared primitive behind both getAlliedCultItem (below)
+ * and RuneMagicDataModel.getCastingCult (#1002, rune-magic-data-model.ts), which resolve this in
+ * opposite directions (bond-partner's cult given mine vs. an arbitrary caster's cult given the
+ * spell's own).
+ */
+export function findMatchingCultByRqid(actor: RqgActor, cult: CultItem): CultItem | undefined {
+  const cultRqid = getCultRqid(cult);
+  return cultRqid
+    ? (actor.getBestEmbeddedDocumentByRqid(cultRqid) as CultItem | undefined)
+    : undefined;
 }
 
 /**
@@ -40,17 +54,20 @@ function getCultRqid(cult: CultItem): RqidString | undefined {
  * spirit is an initiate of the cult and can sacrifice for Rune points, just as a normal
  * initiate" - the ally only shares Rune Points for the cult it's actually initiated to, not any
  * cult either side happens to belong to.
+ *
+ * Accepts an already-resolved `ally` (e.g. from a caller that also needs it for something else)
+ * to avoid re-resolving the allied bond a second time - getBondedPriest's reverse-lookup side in
+ * particular walks game.actors.contents.
  */
 export function getAlliedCultItem(
   actor: RqgActor,
   cult: CultItem,
+  ally: RqgActor | undefined = getAlliedBondActor(actor),
 ): { actor: RqgActor; cult: CultItem } | undefined {
-  const ally = getAlliedBondActor(actor);
-  const cultRqid = getCultRqid(cult);
-  if (!ally || !cultRqid) {
+  if (!ally) {
     return undefined;
   }
-  const allyCult = ally.getBestEmbeddedDocumentByRqid(cultRqid) as CultItem | undefined;
+  const allyCult = findMatchingCultByRqid(ally, cult);
   return allyCult ? { actor: ally, cult: allyCult } : undefined;
 }
 

--- a/src/system/spell-source.test.ts
+++ b/src/system/spell-source.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { getExternalRuneMagicItems, getExternalSpiritMagicItems } from "./spell-source";
+
+function fakeActor(
+  items: any[] = [],
+  options: { alliedSpiritActorUuid?: string; uuid?: string; isOwner?: boolean } = {},
+) {
+  return {
+    type: "character",
+    uuid: options.uuid,
+    isOwner: options.isOwner ?? true,
+    items,
+    system: { alliedSpiritActorUuid: options.alliedSpiritActorUuid },
+  } as any;
+}
+
+/** A fake Cult item identified by rqid via the documentRqidFlags flag (see getCultRqid). */
+function fakeCult(id: string, rqid: string) {
+  return {
+    id,
+    type: "cult",
+    system: { runePoints: { value: 0, max: 0 } },
+    getFlag: (_scope: string, key: string) =>
+      key === "documentRqidFlags" ? { id: rqid } : undefined,
+  } as any;
+}
+
+function fakeSpiritMagicItem(id: string, sort: number) {
+  return { id, type: "spiritMagic", sort } as any;
+}
+
+function fakeRuneMagicItem(id: string, sort: number, cultId: string) {
+  return { id, type: "runeMagic", sort, system: { cultId } } as any;
+}
+
+/** A fake Allied Spirit bond partner actor - `instanceof Actor` per the global stub, so it
+ *  passes getAlliedSpirit's type-guard checks. */
+function fakeAlly(items: any[] = [], isOwner: boolean = true, name = "Whiskers") {
+  const ally = Object.create((globalThis as any).Actor.prototype);
+  return Object.assign(ally, {
+    name,
+    uuid: "Actor.ally1",
+    isOwner,
+    items,
+    getBestEmbeddedDocumentByRqid: (rqid: string) =>
+      items.find((i) => i.type === "cult" && i.getFlag("rqg", "documentRqidFlags")?.id === rqid),
+  });
+}
+
+describe("getExternalSpiritMagicItems", () => {
+  it("is empty when there's no bond partner", () => {
+    expect(getExternalSpiritMagicItems(fakeActor())).toEqual([]);
+  });
+
+  it("returns the ally's Spirit Magic items sorted by sort order", () => {
+    const spellB = fakeSpiritMagicItem("b", 2);
+    const spellA = fakeSpiritMagicItem("a", 1);
+    const otherItem = { id: "x", type: "skill", sort: 0 };
+    const ally = fakeAlly([spellB, otherItem, spellA]);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+    const actor = fakeActor([], { alliedSpiritActorUuid: "Actor.ally1" });
+
+    expect(getExternalSpiritMagicItems(actor)).toEqual([spellA, spellB]);
+  });
+});
+
+describe("getExternalRuneMagicItems", () => {
+  it("is empty when there's no bond partner", () => {
+    const cult = fakeCult("cult1", "je.orlanth");
+    expect(getExternalRuneMagicItems(fakeActor(), cult)).toEqual([]);
+  });
+
+  it("is empty when the bond partner isn't initiated to a matching cult", () => {
+    const allyCult = fakeCult("cult2", "je.ernalda");
+    const ally = fakeAlly([allyCult]);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+    const actor = fakeActor([], { alliedSpiritActorUuid: "Actor.ally1" });
+    const cult = fakeCult("cult1", "je.orlanth");
+
+    expect(getExternalRuneMagicItems(actor, cult)).toEqual([]);
+  });
+
+  it("returns the ally's Rune Magic items for the matching cult, sorted", () => {
+    const allyCult = fakeCult("cult2", "je.orlanth");
+    const spellB = fakeRuneMagicItem("b", 2, "cult2");
+    const spellA = fakeRuneMagicItem("a", 1, "cult2");
+    const otherCultSpell = fakeRuneMagicItem("c", 0, "some-other-cult");
+    const ally = fakeAlly([allyCult, spellB, otherCultSpell, spellA]);
+    (globalThis as any).fromUuidSync.mockReturnValue(ally);
+    const actor = fakeActor([], { alliedSpiritActorUuid: "Actor.ally1" });
+    const cult = fakeCult("cult1", "je.orlanth");
+
+    expect(getExternalRuneMagicItems(actor, cult)).toEqual([spellA, spellB]);
+  });
+});

--- a/src/system/spell-source.ts
+++ b/src/system/spell-source.ts
@@ -1,0 +1,64 @@
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import type { CultItem } from "@item-model/cult-data-model.ts";
+import { ItemTypeEnum } from "@item-model/item-types.ts";
+import type { RuneMagicItem } from "@item-model/rune-magic-data-model.ts";
+import type { SpiritMagicItem } from "@item-model/spirit-magic-data-model.ts";
+import { getAlliedBondActor } from "./magic-point-source";
+import { getAlliedCultItem } from "./rune-point-source";
+
+/**
+ * Spirit/Rune Magic spells the actor doesn't know itself, but can cast anyway because Core p.277's
+ * Allied Spirit bond shares spell knowledge (not just Magic/Rune Points, #957) with a linked bond
+ * partner (#1002, either direction - see getAlliedBondActor). Named generically ("external", not
+ * "allied") since a future spell source (e.g. a Matrix item) could plausibly grant spells the same
+ * way without being a bonded actor at all - callers shouldn't need to know or care which kind of
+ * external source it is.
+ */
+
+/**
+ * The linked Allied Spirit bond partner's known Spirit Magic spells (#1002), in the same sort
+ * order as the caster's own `embeddedItems.spiritMagic`. Empty when there's no usable bond partner
+ * (see getAlliedBondActor) - never merged into the actor's own Item collection, so it disappears
+ * immediately if the bond is unlinked.
+ *
+ * Accepts an already-resolved `ally` (e.g. from a caller that also needs it for something else,
+ * like the sheet's header display) to avoid re-resolving the allied bond a second time -
+ * getBondedPriest's reverse-lookup side in particular walks game.actors.contents.
+ */
+export function getExternalSpiritMagicItems(
+  actor: RqgActor,
+  ally: RqgActor | undefined = getAlliedBondActor(actor),
+): SpiritMagicItem[] {
+  if (!ally) {
+    return [];
+  }
+  return (ally.items.filter((i) => i.type === ItemTypeEnum.SpiritMagic) as SpiritMagicItem[]).sort(
+    (a, b) => a.sort - b.sort,
+  );
+}
+
+/**
+ * The linked Allied Spirit bond partner's known Rune Magic spells (#1002) for the *same* cult as
+ * `cult` (matched by rqid, via getAlliedCultItem - the same match already used for Rune Point
+ * sharing, #957). Empty when there's no bond partner or the bond partner isn't initiated to a
+ * matching cult - a priest's cult tab with no Allied Spirit counterpart just shows nothing extra,
+ * per #1002's design (a rare edge case, not the common path to design around).
+ *
+ * Accepts an already-resolved `ally` - see getExternalSpiritMagicItems above.
+ */
+export function getExternalRuneMagicItems(
+  actor: RqgActor,
+  cult: CultItem,
+  ally: RqgActor | undefined = getAlliedBondActor(actor),
+): RuneMagicItem[] {
+  const allied = getAlliedCultItem(actor, cult, ally);
+  if (!allied) {
+    return [];
+  }
+  return (
+    allied.actor.items.filter(
+      (i) =>
+        i.type === ItemTypeEnum.RuneMagic && (i as RuneMagicItem).system.cultId === allied.cult.id,
+    ) as RuneMagicItem[]
+  ).sort((a, b) => a.sort - b.sort);
+}

--- a/src/system/util.ts
+++ b/src/system/util.ts
@@ -133,6 +133,29 @@ export function getDomDatasetAmongSiblings(
   return firstItemEl?.dataset[toCamelCase(dataset)];
 }
 
+/**
+ * Resolve the RqgItem targeted by a sheet row's `data-item-id`. Most rows belong to the caster's
+ * own actor - but a row surfaced from an external spell source (e.g. an Allied Spirit bond
+ * partner's known spells, #1002) carries a `data-external-owner-uuid` pointing at the actor that
+ * really embeds the item, since `itemId` alone isn't unique across actors. `casterActor` is always
+ * who the roll/cast itself should be attributed to (the sheet's own actor), independent of which
+ * actor's `items` collection the item is actually resolved from.
+ */
+export function resolveCastItem(
+  el: HTMLElement | Element | Event | JQuery,
+  casterActor: RqgActor,
+): RqgItem | undefined {
+  const itemId = getDomDataset(el, "item-id");
+  if (!itemId) {
+    return undefined;
+  }
+  const ownerUuid = getDomDataset(el, "external-owner-uuid");
+  const owner = ownerUuid
+    ? ((fromUuidSync(ownerUuid) as RqgActor | null) ?? undefined)
+    : casterActor;
+  return owner?.items.get(itemId) as RqgItem | undefined;
+}
+
 export function getHTMLElement(
   el: HTMLElement | Element | Event | JQuery,
 ): HTMLElement | undefined {

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -388,6 +388,7 @@
         "AlliedSpiritDropRequiresActorWarn": "Drop an Actor to link it as an Allied Spirit",
         "AlliedSpiritDropRequiresCharacterWarn": "Only a Character actor can be linked as an Allied Spirit",
         "AlliedSpiritCannotLinkSelfWarn": "A character cannot be its own Allied Spirit",
+        "FromSourceLabel": "From {name}:",
         "CultRank": {
           "layMember": "Lay Member",
           "initiate": "Initiate",
@@ -441,7 +442,8 @@
         "Variable": "Variable",
         "Range": "Range",
         "Duration": "Duration",
-        "Concentration": "Concentration"
+        "Concentration": "Concentration",
+        "FromSourceLabel": "From {name}:"
       }
     },
     "ContextMenu": {

--- a/test/setup/foundryMockFunctions.js
+++ b/test/setup/foundryMockFunctions.js
@@ -217,6 +217,9 @@ globalThis.CONFIG = {
   ],
   RQG: {
     fallbackLanguage: "en",
+    runeRqid: {
+      magic: "i.rune.magic-condition",
+    },
   },
 };
 


### PR DESCRIPTION
## Summary

Core p.277: "An allied spirit is in continual mind-to-mind communication with the priest. They can use each other's magical abilities, including spell knowledge, magic points, and Rune points." #957 covered the MP/RP pool-sharing half; this covers **spell knowledge** — a priest and their linked Allied Spirit can now cast Spirit/Rune Magic spells from each other's known-spell lists, rolling against the caster's own POWx5%/Rune chance (never the spell owner's).

- Threads an optional `casterActor` parameter (defaulting to the item's own owner, so non-external casts are unchanged) through the whole casting chain — `getCastValidationError`, `spiritMagicRollImmediate`/`runeMagicRollImmediate`, both roll dialogs (a new hidden `casterActorUuid` form field carries it through the dialog's submit round-trip), `RqgItem`'s wrapper methods, and `rune-magic-casting.ts`'s `handleRollResult`.
- Adds `RuneMagicDataModel.getCastingCult(casterActor)` — same-actor path is byte-identical to the existing `getCult()`, cross-actor path matches the caster's own cult by rqid via a new shared `findMatchingCultByRqid` primitive (`rune-point-source.ts`), also reused by `getAlliedCultItem`.
- Adds `src/system/spell-source.ts` (`getExternalSpiritMagicItems`/`getExternalRuneMagicItems`) as a live, computed view of the bond partner's known spells — never merged into the actor's own Item collection, so it disappears immediately if the bond is unlinked.
- Item resolution for context-menu/click actions on these rows goes through a new `resolveCastItem` helper (`util.ts`) that reads an optional `data-external-owner-uuid` row attribute.
- Named "external" (not "allied") throughout, since a future non-actor spell source (e.g. a Matrix item) could plausibly grant spells the same way without being a bonded actor.
- Rune Magic experience-flagging needed no changes — `awardExperience()` already flags whichever actor owns the used Rune item, and since `getEligibleRunes` now sources that Rune from `casterActor`, correct attribution falls out for free.

## Test plan

- [x] `vitest run` — 665 tests pass (17 new/updated for this feature)
- [x] `tsc --noEmit` clean
- [x] `eslint` / `stylelint` clean
- [x] `vite build` succeeds
- [x] Manual smoke test in a live world: link two Character actors as Allied Spirit bond partners, give each a distinct Spirit Magic spell and a Rune Magic spell under a shared cult, and confirm:
  - Each sheet shows a "From X:" section under the other's known spells, in the same grid/columns as their own spells
  - Casting an external Spirit Magic spell rolls against the caster's own POW, not the ally's
  - Casting an external Rune Magic spell rolls against the caster's own Rune chance (or is unavailable if the caster lacks that Rune), and Rune experience flags the caster's own Rune item
  - MP/RP source pickers on both dialogs still offer "ally" and correctly move points off the right actor
  - Unlinking the bond makes both external-source sections disappear immediately