### PR TITLE
feat: add Spell Matrix Enchantments as a spell source (#959)

### DIFF
--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -23,8 +23,9 @@
       mix-blend-mode: normal;
     }
 
-/* Bound-spirit indicator matches the MP storage icon's gear-tab dimming above. */
-    & .tab.gear .bound-spirit-indicator {
+/* Bound-spirit and matrix-spell indicators match the MP storage icon's gear-tab dimming above. */
+    & .tab.gear .bound-spirit-indicator,
+    & .tab.gear .matrix-spell-indicator {
       opacity: 0.85;
       mix-blend-mode: normal;
     }
@@ -156,6 +157,26 @@
         height: 20px;
         background-color: currentcolor;
         mask-image: url("/systems/rqg/assets/images/runes/spirit.svg");
+        mask-size: contain;
+        mask-repeat: no-repeat;
+        mask-position: center;
+      }
+    }
+
+/* Gear-row indicator for an item enchanted as a Spell Matrix (#959) - clickable, casts the
+   stored spell (single click opens the roll dialog, double click quick-rolls). */
+    & .matrix-spell-indicator {
+      display: inline-flex;
+      align-items: center;
+      margin-left: 0.3rem;
+      cursor: pointer;
+
+      & .matrix-spell-indicator-icon {
+        display: inline-block;
+        width: 20px;
+        height: 20px;
+        background-color: currentcolor;
+        mask-image: url("/systems/rqg/assets/images/items/spirit-magic.svg");
         mask-size: contain;
         mask-repeat: no-repeat;
         mask-position: center;

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -66,6 +66,7 @@ import {
   updateRqidLink,
 } from "../documents/drag-drop";
 import { getWeaponEffectModifier } from "../items/weapon-item/weapon-skill-links";
+import { getMatrixSpellSources, resolveMatrixSpellItem } from "../system/spell-matrix";
 import type { SpiritMagicItem } from "@item-model/spirit-magic-data-model.ts";
 import type { RuneMagicItem } from "@item-model/rune-magic-data-model.ts";
 import type { CultItem } from "@item-model/cult-data-model.ts";
@@ -284,8 +285,13 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     const externalSpiritMagic = getExternalSpiritMagicItems(this.actor, alliedBondActor);
     // #999: Spirit Magic spells known by each bound spirit, one group per spirit.
     const boundSpiritSpiritMagic = getBoundSpiritSpiritMagicItems(this.actor, boundSpiritItems);
+    // #959: Spirit Magic spells enchanted into the actor's own Spell Matrix items, one group per
+    // item - see getMatrixSpellSources.
     const incorrectRunes: RqgItem[] = [];
-    const embeddedItems = await DataPrep.organizeEmbeddedItems(this.actor, incorrectRunes);
+    const [matrixSpellSources, embeddedItems] = await Promise.all([
+      getMatrixSpellSources(this.actor),
+      DataPrep.organizeEmbeddedItems(this.actor, incorrectRunes),
+    ]);
     const itemTree = new ItemTree(this.actor.items.contents);
     const uniqueGearItems = ((embeddedItems[ItemTypeEnum.Gear] ?? []) as GearItem[])
       .filter((item) => foundry.utils.getProperty(item, "system.physicalItemType") === "unique")
@@ -437,6 +443,12 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         sourceItemImg: sourceItem.img ?? "",
         items,
       })),
+      matrixSpellSources: matrixSpellSources.map(({ sourceItem, item }) => ({
+        sourceItemId: sourceItem.id ?? "",
+        sourceItemName: sourceItem.name ?? "",
+        sourceItemImg: sourceItem.img ?? "",
+        item,
+      })),
 
       enrichedBiography: await foundry.applications.ux.TextEditor.implementation.enrichHTML(
         system.background.biography ?? "",
@@ -503,6 +515,17 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
 
   /** True when the active drag originates from this actor's own items (reorder only, no sheet glow). */
   private _isSameActorDrag = false;
+
+  /** Shared single/double-click cast logic for Spirit Magic - a double click rolls the spell
+   *  immediately unless it's a variable spell with more than 1 point enchanted/matrix-stored, in
+   *  which case it still needs the points-to-use dialog (spiritMagicRoll) instead. Used both for
+   *  the caster's own (and #1002 external) items and for #959 Matrix Spells. */
+  private _castSpiritMagicItem(item: SpiritMagicItem, immediate: boolean): Promise<void> {
+    if (!immediate || (item.system.isVariable && item.system.points > 1)) {
+      return item.spiritMagicRoll(this.document.token, this.actor);
+    }
+    return item.spiritMagicRollImmediate(undefined, this.document.token, this.actor);
+  }
 
   private _bindSingleDoubleClick(
     el: HTMLElement,
@@ -898,14 +921,8 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         `Couldn't find item to roll Spirit Magic`,
       );
       this._bindSingleDoubleClick(el, {
-        onSingle: () => item.spiritMagicRoll(this.document.token, this.actor),
-        onDouble: () => {
-          if (item.system.isVariable && item.system.points > 1) {
-            return item.spiritMagicRoll(this.document.token, this.actor);
-          } else {
-            return item.spiritMagicRollImmediate(undefined, this.document.token, this.actor);
-          }
-        },
+        onSingle: () => this._castSpiritMagicItem(item, false),
+        onDouble: () => this._castSpiritMagicItem(item, true),
       });
     });
 
@@ -926,6 +943,25 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
             return item.runeMagicRoll(this.document.token, this.actor);
           }
         },
+      });
+    });
+
+    // Cast Matrix Spell (#959) - unlike the Spirit/Rune Magic rolls above, the spell isn't an
+    // actual embedded Item (a physical item can't embed another Item in Foundry), so it's resolved
+    // live from spellRqidLink on each click instead of eagerly at bind time - see
+    // resolveMatrixSpellItem (spell-matrix.ts).
+    this.element.querySelectorAll<HTMLElement>("[data-matrix-spell-cast]").forEach((el) => {
+      const matrixItem = resolveCastItem(el, this.actor) as PhysicalItem | undefined;
+      requireValue(matrixItem, `Couldn't find item to cast its Matrix Spell`);
+      const castMatrixSpell = async (immediate: boolean) => {
+        const spellItem = await resolveMatrixSpellItem(matrixItem);
+        if (spellItem) {
+          await this._castSpiritMagicItem(spellItem, immediate);
+        }
+      };
+      this._bindSingleDoubleClick(el, {
+        onSingle: () => castMatrixSpell(false),
+        onDouble: () => castMatrixSpell(true),
       });
     });
 

--- a/src/actors/rqg-actor-sheet-v2.types.ts
+++ b/src/actors/rqg-actor-sheet-v2.types.ts
@@ -130,6 +130,14 @@ export interface RqgActorSheetV2Context {
     sourceItemImg: string;
     items: RqgItem[];
   }[];
+  /** Spirit Magic spells enchanted into this actor's own Spell Matrix items (#959), one group per
+   *  item - see getMatrixSpellSources. */
+  matrixSpellSources: {
+    sourceItemId: string;
+    sourceItemName: string;
+    sourceItemImg: string;
+    item: RqgItem;
+  }[];
 
   /** Enriched biography HTML. */
   enrichedBiography: string;

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-gear.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-gear.hbs
@@ -49,7 +49,7 @@
                 <div class="gear-row">
                 <div data-item-id="{{id}}" class="gear contextmenu item">{{#if @root.isEditable}}<span class="item-drag-handle item draggable" data-tooltip data-item-drag-handle data-item-id="{{id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{img}}" data-item-tooltip data-tooltip-class="item-description-tooltip"></div>
                 <div data-item-id="{{id}}" class="gear contextmenu item">{{name}}
-                  {{> actorSheetV2MpStorageIcon}} {{> actorSheetV2BoundSpiritIcon}}
+                  {{> actorSheetV2MpStorageIcon}} {{> actorSheetV2BoundSpiritIcon}} {{> actorSheetV2MatrixSpellIcon}}
                 </div>
                 <div data-item-id="{{id}}" class="gear contextmenu item"></div>
                 <div data-item-id="{{id}}" class="gear contextmenu item">
@@ -89,7 +89,7 @@
                   <div class="gear-row">
                   <div data-item-id="{{id}}" class="gear contextmenu item">{{#if @root.isEditable}}<span class="item-drag-handle item draggable" data-tooltip data-item-drag-handle data-item-id="{{id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{img}}" data-item-tooltip data-tooltip-class="item-description-tooltip"></div>
                   <div data-item-id="{{id}}" class="gear contextmenu item" data-tooltip="{{system.price.conversion}}">{{name}}
-                    {{> actorSheetV2MpStorageIcon}} {{> actorSheetV2BoundSpiritIcon}}
+                    {{> actorSheetV2MpStorageIcon}} {{> actorSheetV2BoundSpiritIcon}} {{> actorSheetV2MatrixSpellIcon}}
                   </div>
                   <div data-item-id="{{id}}" class="gear contextmenu item">
                     <input type="number" min="0" max="999999" data-item-edit-value="system.quantity" value="{{system.quantity}}">
@@ -142,7 +142,7 @@
                   <div class="gear-row">
                   <div data-item-id="{{id}}" class="gear contextmenu item">{{#if @root.isEditable}}<span class="item-drag-handle item draggable" data-tooltip data-item-drag-handle data-item-id="{{id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{img}}" data-item-tooltip data-tooltip-class="item-description-tooltip"></div>
                   <div data-item-id="{{id}}" class="gear contextmenu item">{{name}}
-                    {{> actorSheetV2MpStorageIcon}} {{> actorSheetV2BoundSpiritIcon}}
+                    {{> actorSheetV2MpStorageIcon}} {{> actorSheetV2BoundSpiritIcon}} {{> actorSheetV2MatrixSpellIcon}}
                   </div>
                   <div data-item-id="{{id}}" class="gear contextmenu item">
                     <input type="number" min="0" max="999999" data-item-edit-value="system.quantity" value="{{system.quantity}}">
@@ -190,7 +190,7 @@
               <div data-item-id="{{id}}" class="gear contextmenu item">{{#if @root.isEditable}}<span class="item-drag-handle item draggable" data-tooltip data-item-drag-handle data-item-id="{{id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{img}}" data-item-tooltip data-tooltip-class="item-description-tooltip"></div>
               <div data-item-id="{{id}}" class="gear contextmenu item">{{name}}
                 {{#if (eq system.physicalItemType "consumable")}} ({{system.quantity}}){{/if}}
-                {{> actorSheetV2MpStorageIcon}} {{> actorSheetV2BoundSpiritIcon}}
+                {{> actorSheetV2MpStorageIcon}} {{> actorSheetV2BoundSpiritIcon}} {{> actorSheetV2MatrixSpellIcon}}
               </div>
               <div data-item-id="{{id}}" class="gear usagecontainer contextmenu nowrap item">
                 {{#each system.usage}}
@@ -312,7 +312,7 @@
               <div class="gear-row">
               <div data-item-id="{{id}}" class="gear contextmenu item">{{#if @root.isEditable}}<span class="item-drag-handle item draggable" data-tooltip data-item-drag-handle data-item-id="{{id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{img}}" data-item-tooltip data-tooltip-class="item-description-tooltip"></div>
               <div data-item-id="{{id}}" class="gear contextmenu item">{{name}}
-                {{> actorSheetV2MpStorageIcon}} {{> actorSheetV2BoundSpiritIcon}}
+                {{> actorSheetV2MpStorageIcon}} {{> actorSheetV2BoundSpiritIcon}} {{> actorSheetV2MatrixSpellIcon}}
               </div>
               <div data-item-id="{{id}}" class="gear contextmenu item">
                 <span class="text-right">{{system.absorbs}}</span>

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-rune-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-rune-magic.hbs
@@ -126,7 +126,7 @@
           {{/each}}
 
           {{#if externalRuneMagic.length}}
-            {{> externalSpellDivider fromLabelKey="RQG.Actor.RuneMagic.FromLabel"
+            {{> externalSpellDivider labelKey="RQG.Actor.RuneMagic.AlliedSpiritFromLabel"
                 name=externalSpellSourceActor.name img=externalSpellSourceActor.img}}
             {{#each externalRuneMagic}}
               <div class="rune-magic-row external-item" data-external-owner-uuid="{{../externalSpellSourceActor.uuid}}">

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
@@ -67,21 +67,28 @@
     {{/each}}
 
     {{#if externalSpiritMagic.length}}
-      {{> externalSpellDivider fromLabelKey="RQG.Actor.SpiritMagic.FromLabel"
+      {{> externalSpellDivider labelKey="RQG.Actor.SpiritMagic.AlliedSpiritFromLabel"
           name=externalSpellSourceActor.name img=externalSpellSourceActor.img}}
       {{#each externalSpiritMagic}}
         {{> spiritMagicExternalRow item=this ownerUuid=@root.externalSpellSourceActor.uuid}}
       {{/each}}
     {{/if}}
 
-    {{!-- Bound Spirits (#999): one "From [img] {spiritName} in [img] {itemName}:" group per spirit. --}}
+    {{!-- Bound Spirits (#999): one "Bound Spirit: [img] {spiritName} in [img] {itemName}" group per spirit. --}}
     {{#each boundSpiritSpiritMagic}}
-      {{> externalSpellDivider fromLabelKey="RQG.Actor.SpiritMagic.FromLabel"
+      {{> externalSpellDivider labelKey="RQG.Actor.SpiritMagic.BoundSpiritFromLabel"
           inLabelKey="RQG.Actor.SpiritMagic.InLabel"
           name=sourceActor.name img=sourceActor.img itemName=sourceItemName itemImg=sourceItemImg}}
       {{#each items}}
         {{> spiritMagicExternalRow item=this ownerUuid=../sourceActor.uuid}}
       {{/each}}
+    {{/each}}
+
+    {{!-- Spell Matrix Enchantments (#959): one "Matrix: [img] {itemName}" group per enchanted item. --}}
+    {{#each matrixSpellSources}}
+      {{> externalSpellDivider labelKey="RQG.Actor.SpiritMagic.MatrixFromLabel"
+          name=sourceItemName img=sourceItemImg}}
+      {{> matrixSpellSpiritMagicRow item=item sourceItemId=sourceItemId}}
     {{/each}}
   </div>
 

--- a/src/actors/sheet-parts-v2/external-spell-divider.hbs
+++ b/src/actors/sheet-parts-v2/external-spell-divider.hbs
@@ -1,16 +1,17 @@
-{{!-- Partial: "From [img] {name}:" divider, or "From [img] {name} in [img] {itemName}:" when
-     itemName is given (#999, a bound spirit's item). Shared by the Rune Magic and Spirit Magic
-     tabs' external-spell-source sections.
+{{!-- Partial: "{label}: [img] {name}" divider, or "{label}: [img] {name} {inLabel} [img] {itemName}"
+     when itemName is given (#999, a bound spirit's item). Shared by the Rune Magic and Spirit Magic
+     tabs' external-spell-source sections (Allied Spirit, Bound Spirit, and #959 Spell Matrix) - the
+     label names which kind of source it is, since "From {name}" alone doesn't distinguish them.
 
-     Params: fromLabelKey, inLabelKey (localization keys, namespaced per tab), name, img,
+     Params: labelKey, inLabelKey (localization keys, namespaced per tab), name, img,
      itemName (optional), itemImg (optional). --}}
 <div class="external-spell-divider">
-  {{localize fromLabelKey}}
+  {{localize labelKey}}:
   <img class="external-spell-divider-icon" src="{{img}}">
   {{name}}
   {{#if itemName}}
     {{localize inLabelKey}}
     <img class="external-spell-divider-icon" src="{{itemImg}}">
     {{itemName}}
-  {{/if}}:
+  {{/if}}
 </div>

--- a/src/actors/sheet-parts-v2/matrix-spell-icon.hbs
+++ b/src/actors/sheet-parts-v2/matrix-spell-icon.hbs
@@ -1,0 +1,8 @@
+{{#if system.matrixSpell.spellRqidLink.rqid}}
+  <span class="matrix-spell-indicator"
+        data-matrix-spell-cast
+        data-item-id="{{id}}"
+        data-tooltip="{{localize 'RQG.Item.Gear.MatrixSpellIndicatorTooltip' spellName=system.matrixSpell.spellRqidLink.name points=system.matrixSpell.points}}">
+    <span class="matrix-spell-indicator-icon"></span>
+  </span>
+{{/if}}

--- a/src/actors/sheet-parts-v2/matrix-spell-spirit-magic-row.hbs
+++ b/src/actors/sheet-parts-v2/matrix-spell-spirit-magic-row.hbs
@@ -1,0 +1,28 @@
+{{!-- Partial: one Spirit Magic spell row for a spell enchanted into one of this actor's own
+     Spell Matrix items (#959). Unlike spiritMagicExternalRow.hbs, `item` isn't an actual
+     embedded/owned Item - it's resolved live from the matrix item's rqid on each click, so this
+     uses data-matrix-spell-cast + the matrix item's own id (see rqg-actor-sheet-v2.ts) rather than
+     data-spirit-magic-roll/data-external-owner-uuid. It deliberately omits the "contextmenu" class
+     other Spirit Magic rows use: the shared spiritMagicMenuOptions context menu resolves its
+     target via resolveCastItem's actor.items.get(data-item-id), which here would return the
+     physical matrix item (sourceItemId), not a SpiritMagicItem - so it isn't wired up for this row.
+
+     Params: item (the resolved transient spell), sourceItemId (the matrix item's id). --}}
+<div class="spirit-magic-row external-item">
+  <div class="spirit-magic item">
+    <img class="row-icon" src="{{item.img}}">
+  </div>
+  <div class="spirit-magic item"
+       data-matrix-spell-cast
+       data-item-id="{{sourceItemId}}"
+       data-tooltip="{{localize 'RQG.Game.RollTitle'}}">
+    {{item.name}}
+  </div>
+  <div class="spirit-magic item"
+       data-tooltip="{{item.spellSummaryTooltip}}"
+       data-matrix-spell-cast
+       data-item-id="{{sourceItemId}}">
+    {{item.spellSummary}}
+  </div>
+  <div class="spirit-magic item">—</div>
+</div>

--- a/src/data-model/json-schemas/generated/item/armor.schema.json
+++ b/src/data-model/json-schemas/generated/item/armor.schema.json
@@ -106,6 +106,47 @@
         "type": "string"
       }
     },
+    "matrixSpell": {
+      "type": "object",
+      "properties": {
+        "spellRqidLink": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "rqid": {
+              "type": "string",
+              "default": ""
+            },
+            "name": {
+              "type": "string",
+              "default": ""
+            },
+            "bonus": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "rqid",
+            "name"
+          ]
+        },
+        "points": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "points"
+      ]
+    },
     "size": {
       "type": "integer",
       "minimum": 0,
@@ -174,6 +215,7 @@
     "price",
     "storedMagicPoints",
     "boundSpiritActorUuids",
+    "matrixSpell",
     "size",
     "hitLocationRqidLinks",
     "namePrefix",

--- a/src/data-model/json-schemas/generated/item/gear.schema.json
+++ b/src/data-model/json-schemas/generated/item/gear.schema.json
@@ -105,6 +105,47 @@
       "items": {
         "type": "string"
       }
+    },
+    "matrixSpell": {
+      "type": "object",
+      "properties": {
+        "spellRqidLink": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "rqid": {
+              "type": "string",
+              "default": ""
+            },
+            "name": {
+              "type": "string",
+              "default": ""
+            },
+            "bonus": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "rqid",
+            "name"
+          ]
+        },
+        "points": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "points"
+      ]
     }
   },
   "additionalProperties": false,
@@ -120,6 +161,7 @@
     "equippedStatus",
     "price",
     "storedMagicPoints",
-    "boundSpiritActorUuids"
+    "boundSpiritActorUuids",
+    "matrixSpell"
   ]
 }

--- a/src/data-model/json-schemas/generated/item/weapon.schema.json
+++ b/src/data-model/json-schemas/generated/item/weapon.schema.json
@@ -106,6 +106,47 @@
         "type": "string"
       }
     },
+    "matrixSpell": {
+      "type": "object",
+      "properties": {
+        "spellRqidLink": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "rqid": {
+              "type": "string",
+              "default": ""
+            },
+            "name": {
+              "type": "string",
+              "default": ""
+            },
+            "bonus": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "rqid",
+            "name"
+          ]
+        },
+        "points": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "points"
+      ]
+    },
     "effect": {
       "type": "object",
       "properties": {
@@ -648,6 +689,7 @@
     "price",
     "storedMagicPoints",
     "boundSpiritActorUuids",
+    "matrixSpell",
     "effect",
     "usage",
     "hitPoints",

--- a/src/data-model/shared/physical-item-schema-fields.ts
+++ b/src/data-model/shared/physical-item-schema-fields.ts
@@ -1,5 +1,6 @@
 import { equippedStatuses, physicalItemProperties } from "../item-data/i-physical-item";
 import { enumChoices } from "./enum-choices";
+import { rqidLinkSchemaField } from "./rqid-link-field";
 
 const { ArrayField, BooleanField, DocumentUUIDField, NumberField, SchemaField, StringField } =
   foundry.data.fields;
@@ -51,5 +52,17 @@ export function physicalItemSchemaFields() {
     boundSpiritActorUuids: new ArrayField(
       new DocumentUUIDField({ blank: false, nullable: false, required: true }),
     ),
+    // Spirit Magic spell stored via a Spell Matrix Enchantment (Core p.264-265, #959) - anyone in
+    // physical contact with this item can cast the spell at their own POW×5% using their own
+    // Magic Points, regardless of whether they know it themselves. Deliberately not a full spell
+    // copy: `points` is the level enchanted into the matrix (fixed once, but GM-editable to allow
+    // correcting mistakes - see item-common-physical.hbs), while the spell's other mechanics
+    // (range/duration/concentration/isVariable/...) never diverge per matrix instance, so they're
+    // resolved live from `spellRqidLink.rqid` via resolveMatrixSpellItem (spell-matrix.ts) instead
+    // of being duplicated here.
+    matrixSpell: new SchemaField({
+      spellRqidLink: rqidLinkSchemaField({ nullable: true }),
+      points: new NumberField({ integer: true, min: 0, nullable: false, initial: 0 }),
+    }),
   } as const;
 }

--- a/src/items/itemsheets-v2.css
+++ b/src/items/itemsheets-v2.css
@@ -102,13 +102,13 @@
     }
 
 /* Base chip styling (.bond-actor-link) is shared with the actor sheet's Allied Spirit link -
-       see rqg.css. */
-    & .bound-spirit-link {
-      & [data-action="unlinkBoundSpirit"] {
-        color: var(--rqg-unassigned-rm-action);
-        text-shadow: none;
-        margin-left: auto;
-      }
+       see rqg.css. Matrix Spell dropzone (#959) is a single link, unlike the Bound Spirit list,
+       but shares the same unlink-chip styling. */
+    & .bound-spirit-link [data-action="unlinkBoundSpirit"],
+    & .matrix-spell-link [data-action="unlinkMatrixSpell"] {
+      color: var(--rqg-unassigned-rm-action);
+      text-shadow: none;
+      margin-left: auto;
     }
   }
 }

--- a/src/items/rqg-item-sheet-v2.ts
+++ b/src/items/rqg-item-sheet-v2.ts
@@ -16,12 +16,15 @@ import {
   extractDropInfo,
   extractDroppedActor,
   getAllowedDropDocumentNames,
+  getDroppedDocumentRqidLink,
   hasRqid,
   isAllowedDocumentNames,
   onDragEnter,
   onDragLeave,
   updateRqidLink,
 } from "../documents/drag-drop";
+import { ItemTypeEnum } from "@item-model/item-types.ts";
+import type { SpiritMagicItem } from "@item-model/spirit-magic-data-model.ts";
 import type { RqgActiveEffect } from "../active-effect/rqg-active-effect.ts";
 import type { DeepPartial } from "fvtt-types/utils";
 
@@ -84,6 +87,7 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
     },
     actions: {
       unlinkBoundSpirit: RqgItemSheetV2._unlinkBoundSpiritAction,
+      unlinkMatrixSpell: RqgItemSheetV2._unlinkMatrixSpellAction,
     },
   };
 
@@ -92,9 +96,10 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
   // Override ItemSheetV2 drag-drop controller to use explicit dropzones and callbacks.
   protected get _dragDrop(): foundry.applications.ux.DragDrop.Implementation {
     this._rqgDragDrop ??= new foundry.applications.ux.DragDrop.implementation({
-      // [data-bound-spirit-dropzone] (#999) is checked before the generic Item/JournalEntry
-      // switch below, same two-tier pattern as RqgActorSheetV2's Allied Spirit dropzone.
-      dropSelector: "[data-dropzone], [data-bound-spirit-dropzone]",
+      // [data-bound-spirit-dropzone] (#999) and [data-matrix-spell-dropzone] (#959) are checked
+      // before the generic Item/JournalEntry switch below, same two-tier pattern as
+      // RqgActorSheetV2's Allied Spirit dropzone.
+      dropSelector: "[data-dropzone], [data-bound-spirit-dropzone], [data-matrix-spell-dropzone]",
       permissions: {
         drop: () => this.isEditable,
       },
@@ -332,6 +337,10 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
       await this._onDropBoundSpirit(event);
       return;
     }
+    if (target instanceof Element && target.closest("[data-matrix-spell-dropzone]")) {
+      await this._onDropMatrixSpell(event);
+      return;
+    }
 
     this.render();
 
@@ -444,6 +453,46 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
           (uuid) => uuid !== spiritUuid,
         ),
       },
+    });
+  }
+
+  /** Set the dropped Spirit Magic spell as this item's Spell Matrix Enchantment (Core p.264-265,
+   *  #959) - a single link, replacing whatever was there before. Only `spellRqidLink` and the
+   *  initial `points` (seeded from the dropped spell's own level) are stored; the spell's other
+   *  mechanics are resolved live at cast time (resolveMatrixSpellItem, spell-matrix.ts). */
+  protected async _onDropMatrixSpell(event: DragEvent): Promise<void> {
+    if (!this.isEditable) {
+      return;
+    }
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(
+      event,
+    ) as Item.DropData;
+    const droppedItem = (await Item.implementation.fromDropData(data)) as RqgItem | undefined;
+    const spellRqidLink =
+      droppedItem?.type === ItemTypeEnum.SpiritMagic
+        ? getDroppedDocumentRqidLink(droppedItem)
+        : undefined;
+    if (!spellRqidLink) {
+      ui.notifications?.warn(localize("RQG.Item.Gear.MatrixSpellDropRequiresSpiritMagicWarn"));
+      return;
+    }
+    await this.document.update({
+      system: {
+        matrixSpell: {
+          spellRqidLink: spellRqidLink,
+          points: (droppedItem as unknown as SpiritMagicItem).system.points,
+        },
+      },
+    });
+  }
+
+  /** Unlink action for the Matrix Spell link - see _onDropMatrixSpell. */
+  private static async _unlinkMatrixSpellAction(this: RqgItemSheetV2): Promise<void> {
+    if (!this.isEditable) {
+      return;
+    }
+    await this.document.update({
+      system: { matrixSpell: { spellRqidLink: { rqid: "", name: "" }, points: 0 } },
     });
   }
 

--- a/src/items/sheet-parts/item-common-physical.hbs
+++ b/src/items/sheet-parts/item-common-physical.hbs
@@ -110,3 +110,40 @@
     </div>
   {{/unless}}
 </div>
+
+{{!-- Matrix Spell (Core p.264-265, #959) - a single Spirit Magic spell link, unlike Bound
+     Spirit(s) above. The spell's own mechanics are resolved live from spellRqidLink at cast time
+     (resolveMatrixSpellItem, spell-matrix.ts); only the enchanted level is stored here. --}}
+<label for="matrix-spell-{{id}}">{{localize "RQG.Item.Gear.MatrixSpell"}}</label>
+<div id="matrix-spell-{{id}}"
+     class="matrix-spell-dropzone"
+     data-matrix-spell-dropzone
+     data-tooltip="{{localize "RQG.Item.Gear.MatrixSpellDropHint"}}">
+  {{#if system.matrixSpell.spellRqidLink.rqid}}
+    <div class="bond-actor-link matrix-spell-link">
+      <span data-rqid-link="{{system.matrixSpell.spellRqidLink.rqid}}">
+        {{system.matrixSpell.spellRqidLink.name}}
+      </span>
+      {{#if isEditable}}
+        <a data-action="unlinkMatrixSpell"
+           data-tooltip="{{localize "RQG.Item.Gear.UnlinkMatrixSpellTitle" spellName=system.matrixSpell.spellRqidLink.name}}">
+          <i class="fas fa-unlink"></i>
+        </a>
+      {{/if}}
+    </div>
+  {{else}}
+    <div class="bond-actor-link matrix-spell-link empty">
+      <span class="matrix-spell-hint">{{localize "RQG.Item.Gear.MatrixSpellDropHint"}}</span>
+    </div>
+  {{/if}}
+</div>
+
+{{#if isGM}}
+  <label for="matrix-spell-points-{{id}}">{{localize "RQG.Item.Gear.MatrixSpellPoints"}}</label>
+  <input id="matrix-spell-points-{{id}}"
+         type="number"
+         name="system.matrixSpell.points"
+         value="{{system.matrixSpell.points}}"
+         min="0"
+         max="99">
+{{/if}}

--- a/src/system/load-handlebars-templates.ts
+++ b/src/system/load-handlebars-templates.ts
@@ -188,8 +188,11 @@ export const loadHandlebarsTemplates = async function () {
     actorSheetV2Background: "systems/rqg/actors/sheet-parts-v2/actor-sheet-v2-background.hbs",
     actorSheetV2MpStorageIcon: "systems/rqg/actors/sheet-parts-v2/mp-storage-icon.hbs",
     actorSheetV2BoundSpiritIcon: "systems/rqg/actors/sheet-parts-v2/bound-spirit-icon.hbs",
+    actorSheetV2MatrixSpellIcon: "systems/rqg/actors/sheet-parts-v2/matrix-spell-icon.hbs",
     externalSpellDivider: "systems/rqg/actors/sheet-parts-v2/external-spell-divider.hbs",
     spiritMagicExternalRow: "systems/rqg/actors/sheet-parts-v2/spirit-magic-external-row.hbs",
+    matrixSpellSpiritMagicRow:
+      "systems/rqg/actors/sheet-parts-v2/matrix-spell-spirit-magic-row.hbs",
 
     actorRuneTab: "systems/rqg/actors/sheet-parts/runes-tab/runes-tab.hbs",
     actorRuneElements: "systems/rqg/actors/sheet-parts/runes-tab/runes-elemental.hbs",

--- a/src/system/spell-matrix.ts
+++ b/src/system/spell-matrix.ts
@@ -1,0 +1,78 @@
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import type { PhysicalItem } from "@item-model/item-types.ts";
+import type { SpiritMagicItem } from "@item-model/spirit-magic-data-model.ts";
+import type { RqgItem } from "../items/rqg-item";
+import { physicalItemTypes } from "@item-model/i-physical-item.ts";
+import { ItemTypeEnum } from "@item-model/item-types.ts";
+import { Rqid } from "./api/rqid-api";
+import { isDocumentSubType, localize } from "./util";
+
+/**
+ * Resolve the Spirit Magic spell stored in a Spell Matrix Enchantment (Core p.264-265, #959) into
+ * a real, but transient and unembedded, SpiritMagicItem - built fresh from the canonical rqid
+ * document (world override or compendium, via Rqid.fromRqid) each time it's needed, with `points`
+ * overridden to the level actually enchanted into the matrix. Never persisted: Foundry Items can't
+ * be embedded on other Items, so the matrix only stores `{spellRqidLink, points}`
+ * (physical-item-schema-fields.ts) and this rebuilds the rest (range/duration/concentration/
+ * isVariable/...) on demand instead of duplicating it there.
+ *
+ * Returns undefined (and warns) if the item has no matrix spell set, or the rqid can't be resolved
+ * - e.g. the wiki-rqg compendium isn't installed, or the spell's rqid was renamed upstream.
+ */
+export async function resolveMatrixSpellItem(
+  item: PhysicalItem,
+): Promise<SpiritMagicItem | undefined> {
+  const matrixSpell = item.system.matrixSpell;
+  const rqid = matrixSpell?.spellRqidLink?.rqid;
+  if (!rqid) {
+    return undefined;
+  }
+
+  const canonical = (await Rqid.fromRqid<any>(rqid)) as RqgItem | undefined;
+  if (!isDocumentSubType<SpiritMagicItem>(canonical, ItemTypeEnum.SpiritMagic)) {
+    ui.notifications?.warn(
+      localize("RQG.Item.Gear.MatrixSpellNotFoundWarn", {
+        rqid: rqid,
+        name: matrixSpell?.spellRqidLink?.name ?? rqid,
+      }),
+    );
+    return undefined;
+  }
+
+  const data = foundry.utils.mergeObject(canonical.toObject(false), {
+    system: { points: matrixSpell.points },
+  });
+  return new CONFIG.Item.documentClass(data) as unknown as SpiritMagicItem;
+}
+
+/** One Spell Matrix Enchantment (#959) the actor is carrying, resolved for display in the Spirit
+ *  Magic tab's "From {itemName}:" group - see actor-sheet-v2-spirit-magic.hbs. Grouped by
+ *  `sourceItem` the same way getBoundSpiritSpiritMagicItems groups by bound spirit (spell-source.ts),
+ *  even though a matrix only ever holds a single spell. */
+export type MatrixSpellSource = {
+  sourceItem: PhysicalItem;
+  item: SpiritMagicItem;
+};
+
+/**
+ * Every enchanted Spell Matrix among the actor's own physical items, resolved to its live
+ * SpiritMagicItem (see resolveMatrixSpellItem). Anyone in physical contact with the item could
+ * cast it, but for sheet display purposes this only looks at the viewing actor's own items -
+ * items on other actors are out of scope here. Entries whose spell can't be resolved (already
+ * warned about by resolveMatrixSpellItem) are omitted.
+ */
+export async function getMatrixSpellSources(actor: RqgActor): Promise<MatrixSpellSource[]> {
+  const matrixItems = actor.items.filter(
+    (i) =>
+      isDocumentSubType<PhysicalItem>(i, physicalItemTypes) &&
+      !!i.system.matrixSpell?.spellRqidLink?.rqid,
+  ) as PhysicalItem[];
+
+  const resolved = await Promise.all(
+    matrixItems.map(async (sourceItem) => {
+      const item = await resolveMatrixSpellItem(sourceItem);
+      return item ? { sourceItem, item } : undefined;
+    }),
+  );
+  return resolved.filter((source): source is MatrixSpellSource => source != null);
+}

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -395,7 +395,7 @@
         "BoundSpiritCapExceeded": "Bound spirits exceed the CHA÷3 limit by {exceededBy}! ({count} bound, CHA÷3 limit is {cap}).",
         "BoundSpiritCapReached": "Bound spirit limit reached — {count} bound (CHA÷3 limit).",
         "BoundSpiritCapFormula": "{count} of {cap} bound spirits (CHA÷3 limit).",
-        "FromLabel": "From",
+        "AlliedSpiritFromLabel": "Allied Spirit",
         "CultRank": {
           "layMember": "Lay Member",
           "initiate": "Initiate",
@@ -450,7 +450,9 @@
         "Range": "Range",
         "Duration": "Duration",
         "Concentration": "Concentration",
-        "FromLabel": "From",
+        "AlliedSpiritFromLabel": "Allied Spirit",
+        "BoundSpiritFromLabel": "Bound Spirit",
+        "MatrixFromLabel": "Matrix",
         "InLabel": "in"
       }
     },
@@ -832,6 +834,13 @@
         "BoundSpiritDrainConfirmContent": "Casting this would drain {spiritNames} to 0 Magic Points, releasing it from its binding. Keep it bound by leaving 1 Magic Point (drawing the rest from elsewhere if possible), release it fully, or cancel the cast.",
         "BoundSpiritDrainKeepBoundBtn": "Keep Bound (leave 1 MP)",
         "BoundSpiritDrainReleaseBtn": "Release",
+        "MatrixSpell": "Matrix Spell",
+        "MatrixSpellDropHint": "Drag a Spirit Magic spell here to enchant this item as its Spell Matrix",
+        "MatrixSpellPoints": "Matrix Points",
+        "MatrixSpellDropRequiresSpiritMagicWarn": "Drop a Spirit Magic spell to make this item its Spell Matrix",
+        "MatrixSpellIndicatorTooltip": "Spell Matrix: {spellName} ({points})",
+        "MatrixSpellNotFoundWarn": "Couldn't find the Spirit Magic spell \"{name}\" ({rqid}) - is the compendium it came from still installed?",
+        "UnlinkMatrixSpellTitle": "Remove {spellName} from this item's Spell Matrix",
         "HitPointsAbbr": "HP",
         "CurrentHitPoints": "Current Hit Points",
         "HitPointLocation": "Hit Point Location",


### PR DESCRIPTION
## Summary
- Physical items can now carry a Spell Matrix Enchantment (Core p.264-265): a single Spirit Magic spell, dropped onto the item's sheet and resolved live from its rqid, rather than duplicating the spell's mechanics onto the matrix item.
- Adds a gear-row indicator and Spirit Magic tab entry to cast the stored spell directly (single click for the roll dialog, double click for a quick roll), matching the existing Bound Spirit / Allied Spirit interaction pattern.
- Clarifies the "From ..." dividers on the Spirit Magic and Rune Magic tabs so Allied Spirit, Bound Spirit, and Spell Matrix sources are labeled distinctly ("Allied Spirit:", "Bound Spirit:", "Matrix:") instead of sharing generic, ambiguous "From ..." wording.

## Test plan
- [x] `pnpm typecheck`, `pnpm i18n:audit:en`, and `pnpm test` all pass (ran automatically via pre-push hook)
- [x] `pnpm lint` (stylelint/eslint) clean on touched files
- [x] Manually verify in a running world: drop a Spirit Magic spell onto a Gear/Weapon/Armor item's Matrix dropzone, confirm it casts correctly from both the gear-row icon and the Spirit Magic tab, and that the tab dividers read clearly for Allied Spirit / Bound Spirit / Matrix sources