### PR TITLE
fix: allow null max for a natural weapon's hitPoints

### DIFF
--- a/src/data-model/item-data/weapon-data-model.ts
+++ b/src/data-model/item-data/weapon-data-model.ts
@@ -105,7 +105,9 @@ function defineWeaponSchema() {
       initial: undefined,
       choices: weaponUsageChoices(),
     }),
-    hitPoints: resourceSchemaField(),
+    // nullableMax: a natural/body-part weapon (hitPointLocation set) has no independent max HP of
+    // its own - see the sheet's blanking logic below and #1012.
+    hitPoints: resourceSchemaField({ nullableMax: true }),
     hitPointLocation: new StringField({ blank: true, nullable: false, initial: "" }),
     isNatural: new BooleanField({ nullable: false, initial: false }),
     rate: new NumberField({ integer: true, min: 0, max: 5, nullable: false, initial: 0 }),

--- a/src/data-model/json-schemas/generated/item/weapon.schema.json
+++ b/src/data-model/json-schemas/generated/item/weapon.schema.json
@@ -626,14 +626,14 @@
           "default": 0
         },
         "max": {
-          "type": "integer",
+          "type": [
+            "integer",
+            "null"
+          ],
           "default": 0
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "max"
-      ]
+      "additionalProperties": false
     },
     "hitPointLocation": {
       "type": "string",

--- a/src/data-model/shared/resource-schema-field.ts
+++ b/src/data-model/shared/resource-schema-field.ts
@@ -4,11 +4,17 @@ const { NumberField, SchemaField } = foundry.data.fields;
  * Returns a SchemaField representing a Resource (value + max).
  * Use this for fields like `hitPoints`, `runePoints`, etc., where max is
  * user-configurable and persisted (weapons, cult rune points, hit locations).
+ *
+ * `nullableMax` allows `max` to be `null`, for the rare case where the resource genuinely doesn't
+ * apply rather than just being "not yet set" - e.g. a natural/body-part weapon's hitPoints, which
+ * has no independent max once `hitPointLocation` is set (see weapon-data-model.ts and #1012).
+ * Leave it `false` (the default) for resources that always have a real max, like hit locations and
+ * cult rune points.
  */
-export function resourceSchemaField() {
+export function resourceSchemaField({ nullableMax = false }: { nullableMax?: boolean } = {}) {
   return new SchemaField({
     value: new NumberField({ integer: true, nullable: true, initial: 0 }),
-    max: new NumberField({ integer: true, nullable: false, initial: 0 }),
+    max: new NumberField({ integer: true, nullable: nullableMax, initial: 0 }),
   });
 }
 


### PR DESCRIPTION
## Summary

- A natural/body-part weapon (`hitPointLocation` set) has no independent max HP of its own - it
  uses the owning creature's hit location instead. `weapon-sheet-v2.ts`/`weapon-sheet.ts` already
  try to express that by blanking `hitPoints.value`/`max` on save, but `max` was `nullable: false`,
  so Foundry's `NumberField` silently coerced that blank back to `0` instead of leaving it unset -
  the sheet's own intent was a no-op.
- `resourceSchemaField()` now takes an optional `{ nullableMax }` (default `false`, so existing
  callers - hit-location `hitPoints`, cult `runePoints`, both of which always have a real max - are
  unaffected). Weapon `hitPoints` opts in.
- Regenerated `weapon.schema.json` accordingly (`max` is now `["integer", "null"]`, no longer
  `required`).

Every place that reads a weapon's hit points already coalesces a missing value away
(`combat-calculations.ts` reads `?? undefined` then `?? 0`), so this costs nothing downstream.

Fixes #1012

## Test plan

- [x] `pnpm typecheck` / lint clean
- [x] `pnpm test` - 700/700 passing
- [x] Confirmed only `weapon.schema.json` changed after `pnpm generate:schemas` - hit-location and
      cult schemas unaffected
- [x] `/code-review` - no findings