### PR TITLE
feat: add system macro to help migrate isMatrix Spirit Magic spells

### DIFF
--- a/src/assets/macros/migrate-is-matrix-spells.js
+++ b/src/assets/macros/migrate-is-matrix-spells.js
@@ -1,0 +1,103 @@
+/* Migrate old "Matrix" (isMatrix) Spirit Magic spells to real Spell Matrix Enchantment items (#959).
+ *
+ * Before #959, the only way to represent a spell matrix was checking "Matrix" on a personal Spirit
+ * Magic spell - that only ever excluded the spell from the caster's own CHA spell-point limit, with
+ * no physical item, no sharing with anyone else, and no data connecting it to this feature.
+ *
+ * There's no fully automatic migration: nothing in the old data says which physical item (if any)
+ * an isMatrix spell was meant to represent, or who besides the caster was ever meant to hold it -
+ * that's a GM judgment call. This macro does the mechanical part instead: for each isMatrix spell
+ * you pick, it creates a new Gear item on the same actor with the Spell Matrix Enchantment already
+ * linked and set to the same points, named after the spell. It never touches or deletes the
+ * original spell - move/rename/reassign the new item to wherever it should really live, and remove
+ * the old spell's "Matrix" checkbox by hand once you're happy with the result.
+ */
+async function migrateIsMatrixSpells() {
+  const candidates = [];
+  for (const actor of game.actors ?? []) {
+    for (const item of actor.items) {
+      if (item.type === "spiritMagic" && item.system.isMatrix) {
+        const rqid = game.system.api.rqid.getDocumentFlag(item)?.id;
+        candidates.push({ actor, item, rqid });
+      }
+    }
+  }
+
+  if (!candidates.length) {
+    ui.notifications.info(
+      "No Spirit Magic spells with the old 'Matrix' checkbox were found - nothing to migrate.",
+    );
+    return;
+  }
+
+  const rows = candidates
+    .map((c, i) => {
+      const warning = c.rqid
+        ? ""
+        : ` <span style="color:#a33">— no rqid, can't be resolved live; assign one via the Rqid Editor first, then re-run this macro</span>`;
+      return `
+      <div style="margin-bottom:4px;">
+        <label>
+          <input type="checkbox" name="pick" value="${i}" ${c.rqid ? "checked" : "disabled"}>
+          <strong>${c.actor.name}</strong> — ${c.item.name}
+          (${c.item.system.points} point${c.item.system.points === 1 ? "" : "s"})${warning}
+        </label>
+      </div>`;
+    })
+    .join("");
+
+  const content = `
+    <p>Found ${candidates.length} Spirit Magic spell${candidates.length === 1 ? "" : "s"} still using
+    the old "Matrix" checkbox, superseded by real Spell Matrix Enchantment items.</p>
+    <p>For each one checked below, this creates a new Gear item <strong>on the same actor</strong>,
+    named "&lt;Spell&gt; Matrix", with the Spell Matrix Enchantment already linked and set to the
+    same points. It does <em>not</em> touch or delete the original spell, and does <em>not</em>
+    decide which actual physical item - or which character - the matrix should really belong to:
+    move, rename, and reassign the new item as needed, then remove the old spell's "Matrix" checkbox
+    by hand once you're happy with it.</p>
+    <form>${rows}</form>
+  `;
+
+  new Dialog({
+    title: "Migrate isMatrix Spells to Spell Matrix Items",
+    content,
+    buttons: {
+      migrate: {
+        icon: '<i class="fas fa-right-left"></i>',
+        label: "Create Matrix Items",
+        callback: async (html) => {
+          const picked = Array.from(html[0].querySelectorAll('input[name="pick"]:checked')).map(
+            (el) => candidates[Number(el.value)],
+          );
+          let created = 0;
+          for (const { actor, item, rqid } of picked) {
+            await actor.createEmbeddedDocuments("Item", [
+              {
+                name: `${item.name} Matrix`,
+                type: "gear",
+                img: item.img,
+                system: {
+                  matrixSpell: {
+                    spellRqidLink: { rqid, name: item.name },
+                    points: item.system.points,
+                  },
+                },
+              },
+            ]);
+            created++;
+          }
+          ui.notifications.info(
+            `Created ${created} Matrix item${created === 1 ? "" : "s"}. Review, rename, and ` +
+              `reassign as needed, then remove the old spell's Matrix checkbox by hand.`,
+          );
+        },
+      },
+      cancel: {
+        label: "Cancel",
+      },
+    },
+    default: "migrate",
+  }).render(true);
+}
+
+migrateIsMatrixSpells();

--- a/src/assets/macros/migrate-is-matrix-spells.js
+++ b/src/assets/macros/migrate-is-matrix-spells.js
@@ -1,16 +1,23 @@
-/* Migrate old "Matrix" (isMatrix) Spirit Magic spells to real Spell Matrix Enchantment items (#959).
+/* Clean up old "Held in Matrix" (isMatrix) Spirit Magic spells, superseded by Spell Matrix
+ * Enchantment items (#959) and by proper allied/bound spirit spell-sharing (#1002).
  *
- * Before #959, the only way to represent a spell matrix was checking "Matrix" on a personal Spirit
- * Magic spell - that only ever excluded the spell from the caster's own CHA spell-point limit, with
- * no physical item, no sharing with anyone else, and no data connecting it to this feature.
+ * Before those features, "Held in Matrix" was the only way to exclude a personal Spirit Magic spell
+ * from the caster's own CHA spell-point limit - no physical item, no data connecting it to a real
+ * matrix. GMs overloaded that one checkbox for two unrelated situations:
+ *   - a spell actually stored in a physical matrix
+ *   - a spell that really belonged to a bound or allied spirit, copied onto the character just to
+ *     make it accessible without eating into the character's own points
+ * Nothing in the old data says which situation a given spell is, or which physical item / which
+ * spirit it should point to now - that's a GM judgment call this macro can't make. It only does the
+ * mechanical part, one spell at a time, once you've decided: "Create Gear" (matrix case only) adds a
+ * Gear item on the same actor with the Spell Matrix Enchantment linked and set to the spell's points,
+ * then opens it for you to rename or edit; "Delete Spirit Magic" removes the now-obsolete
+ * original spell once its real new home is sorted - matrix gear, spirit spell-sharing, or otherwise -
+ * with a confirmation prompt since it can't be undone. Deleting a spell drops its row for good, so
+ * it's safe to close the dialog and re-run the macro later to pick up where you left off.
  *
- * There's no fully automatic migration: nothing in the old data says which physical item (if any)
- * an isMatrix spell was meant to represent, or who besides the caster was ever meant to hold it -
- * that's a GM judgment call. This macro does the mechanical part instead: for each isMatrix spell
- * you pick, it creates a new Gear item on the same actor with the Spell Matrix Enchantment already
- * linked and set to the same points, named after the spell. It never touches or deletes the
- * original spell - move/rename/reassign the new item to wherever it should really live, and remove
- * the old spell's "Matrix" checkbox by hand once you're happy with the result.
+ * Scope: only scans actors in the world Actors directory (game.actors) - not compendium actors, and
+ * not unlinked token actor data on scenes.
  */
 async function migrateIsMatrixSpells() {
   const candidates = [];
@@ -25,79 +32,118 @@ async function migrateIsMatrixSpells() {
 
   if (!candidates.length) {
     ui.notifications.info(
-      "No Spirit Magic spells with the old 'Matrix' checkbox were found - nothing to migrate.",
+      "No Spirit Magic spells with the old 'Held in Matrix' checkbox were found - nothing to migrate.",
     );
     return;
   }
+
+  const actorLink = (actor) =>
+    `<a class="content-link" draggable="true" aria-label="Actor" data-link data-uuid="Actor.${actor.id}" data-id="${actor.id}" data-type="Actor" data-tooltip=""><i class="fa-solid fa-user" inert></i>${actor.name}</a>`;
+
+  const itemLink = (actor, item) =>
+    `<a class="content-link" draggable="true" aria-label="Spirit Magic Item" data-link data-uuid="Actor.${actor.id}.Item.${item.id}" data-id="${item.id}" data-type="Item" data-tooltip=""><i class="fa-solid fa-suitcase" inert></i>${item.name}</a>`;
+
+  const escape = (text) =>
+    text.replace(
+      /[&<>"']/g,
+      (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch],
+    );
 
   const rows = candidates
     .map((c, i) => {
       const warning = c.rqid
         ? ""
         : ` <span style="color:#a33">— no rqid, can't be resolved live; assign one via the Rqid Editor first, then re-run this macro</span>`;
+      const focus = c.item.system.spellFocus
+        ? ` <span style="font-style:italic;">— focus: ${escape(c.item.system.spellFocus)}</span>`
+        : "";
       return `
-      <div style="margin-bottom:4px;">
-        <label>
-          <input type="checkbox" name="pick" value="${i}" ${c.rqid ? "checked" : "disabled"}>
-          <strong>${c.actor.name}</strong> — ${c.item.name}
-          (${c.item.system.points} point${c.item.system.points === 1 ? "" : "s"})${warning}
-        </label>
+      <div class="matrix-row" data-index="${i}" style="margin-bottom:8px; padding-bottom:8px; border-bottom:1px solid #8882;">
+        <div>
+          ${actorLink(c.actor)} — ${itemLink(c.actor, c.item)}
+          (${c.item.system.points} point${c.item.system.points === 1 ? "" : "s"})${focus}${warning}
+        </div>
+        <div style="margin-top:4px; display:flex; gap:8px; justify-content:flex-end;">
+          <button type="button" class="create-gear" ${c.rqid ? "" : "disabled"}>Create Gear</button>
+          <button type="button" class="delete-spell">Delete Spirit Magic</button>
+        </div>
       </div>`;
     })
     .join("");
 
   const content = `
     <p>Found ${candidates.length} Spirit Magic spell${candidates.length === 1 ? "" : "s"} still using
-    the old "Matrix" checkbox, superseded by real Spell Matrix Enchantment items.</p>
-    <p>For each one checked below, this creates a new Gear item <strong>on the same actor</strong>,
-    named "&lt;Spell&gt; Matrix", with the Spell Matrix Enchantment already linked and set to the
-    same points. It does <em>not</em> touch or delete the original spell, and does <em>not</em>
-    decide which actual physical item - or which character - the matrix should really belong to:
-    move, rename, and reassign the new item as needed, then remove the old spell's "Matrix" checkbox
-    by hand once you're happy with it.</p>
+    the old "Held in Matrix" checkbox. That checkbox was overloaded for two different things: a real
+    spell matrix, or a bound/allied spirit's spell copied onto the character so it wouldn't count
+    against their own points. Decide which applies to each row below before acting on it - this
+    macro can't tell them apart.</p>
+    <p>Handle these one at a time. <strong>Create Gear</strong> is only for the real-matrix case, and
+    only when no gear item for it exists yet: it makes a new Gear item on the same actor, named
+    "&lt;Spell&gt; Matrix", with the Spell Matrix Enchantment already linked and set to the same
+    points, then opens it so you can rename or do other edits to it. If a matching gear item already
+    exists, edit that one by hand instead of creating another - and if a row is actually a
+    bound/allied spirit's spell, set up that spirit's proper spell-sharing instead of using this
+    button. Once the spell's real new home is sorted - or already existed - <strong>Delete Spirit
+    Magic</strong> removes the old spell; it will ask you to confirm first. A row is gone for good as
+    soon as its spell is deleted, so it's safe to close this dialog and re-run the macro later to
+    pick up where you left off.</p>
     <form>${rows}</form>
   `;
 
-  new Dialog({
-    title: "Migrate isMatrix Spells to Spell Matrix Items",
-    content,
-    buttons: {
-      migrate: {
-        icon: '<i class="fas fa-right-left"></i>',
-        label: "Create Matrix Items",
-        callback: async (html) => {
-          const picked = Array.from(html[0].querySelectorAll('input[name="pick"]:checked')).map(
-            (el) => candidates[Number(el.value)],
-          );
-          let created = 0;
-          for (const { actor, item, rqid } of picked) {
-            await actor.createEmbeddedDocuments("Item", [
-              {
-                name: `${item.name} Matrix`,
-                type: "gear",
-                img: item.img,
-                system: {
-                  matrixSpell: {
-                    spellRqidLink: { rqid, name: item.name },
-                    points: item.system.points,
-                  },
+  new Dialog(
+    {
+      title: "Migrate isMatrix Spells",
+      content,
+      buttons: {
+        close: { label: "Close" },
+      },
+      render: (html) => {
+        html.closest(".window-content").scrollTop(0);
+
+        html.on("click", "button.create-gear", async (ev) => {
+          const button = ev.currentTarget;
+          const row = button.closest(".matrix-row");
+          const { actor, item, rqid } = candidates[Number(row.dataset.index)];
+
+          button.disabled = true;
+          const [gear] = await actor.createEmbeddedDocuments("Item", [
+            {
+              name: `${item.name} Matrix`,
+              type: "gear",
+              img: item.img,
+              system: {
+                matrixSpell: {
+                  spellRqidLink: { rqid, name: item.name },
+                  points: item.system.points,
                 },
               },
-            ]);
-            created++;
+            },
+          ]);
+          gear.sheet.render(true);
+
+          button.textContent = "Gear Created";
+        });
+
+        html.on("click", "button.delete-spell", async (ev) => {
+          const row = ev.currentTarget.closest(".matrix-row");
+          const { item } = candidates[Number(row.dataset.index)];
+          const confirmed = await Dialog.confirm({
+            title: "Delete Spirit Magic Spell",
+            content: `<p>Have you finished setting up <strong>${item.name}</strong>'s real new home -
+              a Spell Matrix Enchantment gear item, a bound/allied spirit's spell-sharing, or
+              otherwise - or did it already exist? This deletes the original spell and can't be
+              undone.</p>`,
+          });
+          if (!confirmed) {
+            return;
           }
-          ui.notifications.info(
-            `Created ${created} Matrix item${created === 1 ? "" : "s"}. Review, rename, and ` +
-              `reassign as needed, then remove the old spell's Matrix checkbox by hand.`,
-          );
-        },
-      },
-      cancel: {
-        label: "Cancel",
+          await item.delete();
+          row.remove();
+        });
       },
     },
-    default: "migrate",
-  }).render(true);
+    { width: 600 },
+  ).render(true);
 }
 
 migrateIsMatrixSpells();

--- a/src/assets/pack-templates/system-macros/migrate-is-matrix-spells.yaml
+++ b/src/assets/pack-templates/system-macros/migrate-is-matrix-spells.yaml
@@ -1,6 +1,6 @@
-name: Migrate isMatrix Spells to Spell Matrix Items
+name: Migrate isMatrix Spells
 type: script
-img: icons/svg/upgrade.svg
+img: icons/tools/scribal/magnifying-glass.webp
 scope: global
 flags:
   rqg:

--- a/src/assets/pack-templates/system-macros/migrate-is-matrix-spells.yaml
+++ b/src/assets/pack-templates/system-macros/migrate-is-matrix-spells.yaml
@@ -1,0 +1,11 @@
+name: Migrate isMatrix Spells to Spell Matrix Items
+type: script
+img: icons/svg/upgrade.svg
+scope: global
+flags:
+  rqg:
+    documentRqidFlags:
+      id: m..migrate-is-matrix-spells
+      lang: en
+      priority: 0
+command: "file:macros/migrate-is-matrix-spells.js"


### PR DESCRIPTION
## Summary
- Replaces the batch checkbox + single "Create Matrix Items" button in the "Migrate isMatrix Spells" macro with a per-row workflow: **Create Gear** creates the Spell Matrix gear item and opens it for editing; **Delete Spirit Magic** removes the old spell (with a confirmation prompt) once its replacement is sorted out. A resolved row simply isn't a candidate the next time the macro runs.
- `isMatrix` turns out to have been overloaded for two unrelated situations - a real physical matrix, and a bound/allied spirit's spell copied onto the character to exempt it from the character's own CHA point limit (now properly handled by #1002's spell-sharing). The macro can't tell these apart, so the text now says so instead of assuming every row needs a matrix gear item.
- Adds clickable actor/spell content-links and the spell's `spellFocus` text to each row (many GMs use that field to note which physical item a matrix should live in).
- Renames the macro from "Migrate isMatrix Spells to Spell Matrix Items" to "Migrate isMatrix Spells" and gives it a new icon.
- UX fixes: wider dialog, "Held in Matrix" wording matching the sheet label, and a scroll-to-top fix (the dialog previously opened scrolled to the bottom, hiding the explanatory text).

Closes #1017

## Test plan
- [x] `pnpm typecheck`, `pnpm i18n:audit:en`, and `pnpm test` all pass (ran automatically on push)
- [x] Manually run the macro in a world with `isMatrix` Spirit Magic spells: verify per-row Create Gear / Delete Spirit Magic buttons work, the confirmation dialog appears before delete, actor/spell links open the right sheets, and the dialog opens scrolled to the top