### PR TITLE
fix: cast a Matrix Spell whose linked Spirit Magic spell is compendium-sourced

### DIFF
--- a/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-data.types.ts
+++ b/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-data.types.ts
@@ -23,6 +23,10 @@ export type SpiritMagicRollDialogFormData = {
   otherModifierDescription: string;
 
   spellItemUuid?: string; // hidden field
+  // Set only when spellItem is unembedded (e.g. a transient Matrix Spell resolution, #959) -
+  // spellItemUuid alone can't round-trip through fromUuid for those. Same "unpersisted item
+  // survives as JSON" idiom as reputationItemJson in ability-roll-dialog-data.types.ts.
+  spellItemJson?: string; // hidden field
   tokenUuid?: string; // hidden field
   casterActorUuid?: string; // hidden field
   powX5: number; // hidden field

--- a/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-v2.hbs
+++ b/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-v2.hbs
@@ -51,6 +51,7 @@
   </div>
 
   <input type="hidden" value="{{formData.spellItemUuid}}" name="spellItemUuid">
+  <input type="hidden" value="{{formData.spellItemJson}}" name="spellItemJson">
   <input type="hidden" value="{{formData.tokenUuid}}" name="tokenUuid">
   <input type="hidden" value="{{formData.casterActorUuid}}" name="casterActorUuid">
   <input type="hidden" data-dtype="Number" value="{{formData.powX5}}" name="powX5">

--- a/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-v2.ts
+++ b/src/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-v2.ts
@@ -138,6 +138,9 @@ export class SpiritMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
     formData.otherModifierDescription ??= localize("RQG.Dialog.Common.OtherModifier");
     formData.powX5 ??= this.powX5;
     formData.spellItemUuid ??= this.spellItem.uuid ?? undefined;
+    formData.spellItemJson ??= this.spellItem.isEmbedded
+      ? undefined
+      : JSON.stringify(this.spellItem.toObject());
     formData.tokenUuid ??= this.token?.uuid ?? undefined;
     formData.casterActorUuid ??= this.casterActor.uuid ?? undefined;
 
@@ -189,9 +192,19 @@ export class SpiritMagicRollDialogV2 extends RqgInteractiveRollApplicationBase {
         )?.dataset["rollMode"],
       ) ?? getDefaultRollMode();
 
-    const spellItem: RqgItem | PartialAbilityItem | undefined = (await fromUuid(
+    let spellItem: RqgItem | PartialAbilityItem | undefined = (await fromUuid(
       formDataObject.spellItemUuid ?? "",
     )) as RqgItem | undefined;
+
+    // spellItemUuid doesn't round-trip for an unembedded/transient spell (e.g. a Matrix Spell
+    // resolution, #959, see resolveMatrixSpellItem) - fall back to the JSON snapshot taken at
+    // dialog-open time, same "unpersisted item survives as JSON" idiom as reputationItemJson in
+    // ability-roll-dialog-v2.ts.
+    if (!spellItem && formDataObject.spellItemJson) {
+      spellItem = new CONFIG.Item.documentClass(
+        JSON.parse(formDataObject.spellItemJson),
+      ) as unknown as RqgItem;
+    }
 
     const token = formDataObject.tokenUuid
       ? ((await fromUuid(formDataObject.tokenUuid)) as TokenDocument | undefined)

--- a/src/system/spell-matrix.ts
+++ b/src/system/spell-matrix.ts
@@ -18,6 +18,12 @@ import { isDocumentSubType, localize } from "./util";
  *
  * Returns undefined (and warns) if the item has no matrix spell set, or the rqid can't be resolved
  * - e.g. the wiki-rqg compendium isn't installed, or the spell's rqid was renamed upstream.
+ *
+ * The returned item is never embedded/persisted anywhere (`.isEmbedded` is false), so its `.uuid`
+ * isn't resolvable via fromUuid - callers that need it to survive a round-trip through a form
+ * submission (e.g. SpiritMagicRollDialogV2's onSubmit) can't rely on the uuid for that; see
+ * spellItemJson there for the fallback (same "unpersisted item survives as JSON" idiom already used
+ * for Reputation's PartialAbilityItem in ability-roll-dialog-v2.ts).
  */
 export async function resolveMatrixSpellItem(
   item: PhysicalItem,


### PR DESCRIPTION
## Summary

- `resolveMatrixSpellItem` (#959) builds a transient, unpersisted `SpiritMagicItem` for casting a Spell Matrix Enchantment, so its `.uuid` isn't resolvable via `fromUuid`.
- `SpiritMagicRollDialogV2`'s submit handler used to round-trip the cast spell through a hidden form field holding that `.uuid`, which only "worked" for world-sourced spells by accidentally colliding with an unrelated real item of the same id, and failed outright ("Could not find an spirit magic spellItem to roll.") for compendium-sourced ones.
- Adds a `spellItemJson` fallback: a JSON snapshot of the spell taken when the dialog opens, used to reconstruct the item directly on submit whenever it isn't embedded. Same idiom already used for Reputation's `PartialAbilityItem` in `ability-roll-dialog-v2.ts`.

Fixes #1019

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Full `vitest` suite passes (700 tests)
- [x] Manually verified live in a dev world: casting a Matrix Spell linked to a compendium-sourced Spirit Magic spell (e.g. Protection from a Crown) now rolls correctly instead of erroring on submit