### PR TITLE
feat: show available Magic Points on each source in the picker

### DIFF
--- a/src/system/magic-point-source.test.ts
+++ b/src/system/magic-point-source.test.ts
@@ -39,6 +39,7 @@ function fakeActor(
     alliedSpiritActorUuid?: string;
     uuid?: string;
     isOwner?: boolean;
+    selfMpMax?: number;
   } = {},
 ) {
   const storedFlags = { ...flags };
@@ -48,7 +49,7 @@ function fakeActor(
     isOwner: options.isOwner ?? true,
     items: storageItems,
     system: {
-      attributes: { magicPoints: { value: selfMp } },
+      attributes: { magicPoints: { value: selfMp, max: options.selfMpMax ?? selfMp } },
       alliedSpiritActorUuid: options.alliedSpiritActorUuid,
     },
     update: vi.fn(),
@@ -349,8 +350,8 @@ describe("getMagicPointSourceOptions", () => {
     // getMagicPointDrawOrder - and this picker should mirror that exactly.
     expect(getMagicPointSourceOptions(actor)).toEqual([
       { value: "auto", label: "RQG.Dialog.Common.MagicPointSourceOptions.Auto" },
-      { value: "c1", label: "Crystal A" },
-      { value: "self", label: "RQG.Dialog.Common.MagicPointSourceOptions.Self" },
+      { value: "c1", label: "Crystal A (3/5 MP)" },
+      { value: "self", label: "RQG.Dialog.Common.MagicPointSourceOptions.Self +  (6/6 MP)" },
     ]);
   });
 
@@ -364,9 +365,9 @@ describe("getMagicPointSourceOptions", () => {
     );
     expect(getMagicPointSourceOptions(actor)).toEqual([
       { value: "auto", label: "RQG.Dialog.Common.MagicPointSourceOptions.Auto" },
-      { value: "c2", label: "Crystal B" },
-      { value: "self", label: "RQG.Dialog.Common.MagicPointSourceOptions.Self" },
-      { value: "c1", label: "Crystal A" },
+      { value: "c2", label: "Crystal B (1/1 MP)" },
+      { value: "self", label: "RQG.Dialog.Common.MagicPointSourceOptions.Self +  (6/6 MP)" },
+      { value: "c1", label: "Crystal A (3/5 MP)" },
     ]);
   });
 
@@ -375,8 +376,8 @@ describe("getMagicPointSourceOptions", () => {
     (globalThis as any).fromUuidSync.mockReturnValue(fakeAlly(4, 6, true, "Whiskers"));
     expect(getMagicPointSourceOptions(actor)).toEqual([
       { value: "auto", label: "RQG.Dialog.Common.MagicPointSourceOptions.Auto" },
-      { value: "self", label: "RQG.Dialog.Common.MagicPointSourceOptions.Self" },
-      { value: "ally", label: "Whiskers" },
+      { value: "self", label: "RQG.Dialog.Common.MagicPointSourceOptions.Self +  (6/6 MP)" },
+      { value: "ally", label: "Whiskers (4/6 MP)" },
     ]);
   });
 
@@ -919,8 +920,8 @@ describe("getMagicPointSourceOptions — bound spirits (#999)", () => {
 
     expect(getMagicPointSourceOptions(actor)).toEqual([
       { value: "auto", label: "RQG.Dialog.Common.MagicPointSourceOptions.Auto" },
-      { value: boundSpiritSourceId(item as any, spirit), label: "Wisp" },
-      { value: "self", label: "RQG.Dialog.Common.MagicPointSourceOptions.Self" },
+      { value: boundSpiritSourceId(item as any, spirit), label: "Wisp (2/4 MP)" },
+      { value: "self", label: "RQG.Dialog.Common.MagicPointSourceOptions.Self +  (6/6 MP)" },
     ]);
   });
 });

--- a/src/system/magic-point-source.ts
+++ b/src/system/magic-point-source.ts
@@ -384,13 +384,24 @@ export function moveSourceBefore(order: string[], id: string, beforeId: string |
   return reordered;
 }
 
+/** " (value/max MP)" suffix appended to a source option's label, e.g. " (14/20 MP)" - lets the
+ *  picker show how many points are actually available from each source without opening it. */
+function magicPointsSuffix(
+  points: { value?: number | null; max?: number | null } | undefined | null,
+): string {
+  const value = Number(points?.value) || 0;
+  const max = Number(points?.max) || 0;
+  return ` (${value}/${max} MP)`;
+}
+
 /**
  * Options for a magic-point-source picker, excluding "auto" - only populated (non-empty) when the
  * actor actually has one or more storage items or a usable Allied Spirit bond partner (#957),
  * since the dialog should only show a picker at all when there is more than one possible source.
  * "Self"/ally/storage-item options are listed in the same order as the Magic Point Source Order
  * popout (see getMagicPointDrawOrder) - "auto" is pinned first regardless, since it's a
- * meta-option ("let the system decide") rather than a specific source pick.
+ * meta-option ("let the system decide") rather than a specific source pick, so it doesn't get a
+ * points suffix like the specific sources below it do.
  */
 export function getMagicPointSourceOptions(
   actor: RqgActor | null | undefined,
@@ -406,21 +417,27 @@ export function getMagicPointSourceOptions(
         case "self":
           return {
             value: SELF_MAGIC_POINT_SOURCE,
-            label: "RQG.Dialog.Common.MagicPointSourceOptions.Self",
+            label: `${localize("RQG.Dialog.Common.MagicPointSourceOptions.Self")}${magicPointsSuffix(actor!.system.attributes.magicPoints)}`,
           };
         case "ally":
           // Just the bond partner's name, not a templated "Allied Spirit (Name)" label: this
           // option shows up from either side of the bond (see getAlliedBondActor), and "Allied
           // Spirit" would read backwards when an ally casts using its bonded priest's Magic
           // Points.
-          return { value: ALLY_MAGIC_POINT_SOURCE, label: entry.actor.name ?? "" };
+          return {
+            value: ALLY_MAGIC_POINT_SOURCE,
+            label: `${entry.actor.name ?? ""}${magicPointsSuffix(entry.actor.system.attributes.magicPoints)}`,
+          };
         case "item":
-          return { value: entry.item.id ?? "", label: entry.item.name ?? "" };
+          return {
+            value: entry.item.id ?? "",
+            label: `${entry.item.name ?? ""}${magicPointsSuffix(entry.item.system.storedMagicPoints)}`,
+          };
         case "boundSpirit":
           // The bound spirit's own name, like ally - see the "ally" case above.
           return {
             value: boundSpiritSourceId(entry.item, entry.spiritActor),
-            label: entry.spiritActor.name ?? "",
+            label: `${entry.spiritActor.name ?? ""}${magicPointsSuffix(entry.spiritActor.system.attributes.magicPoints)}`,
           };
       }
     }),


### PR DESCRIPTION
## Summary
- The "Magic Point Source" dropdown in the Cast Spirit Magic / Cast Rune Magic dialogs now shows each source's current/max Magic Points, computed by the system, instead of relying on some item names happening to have a number typed into them.
- Applies to every option except "Auto" (a meta-option, not a single pool): Self, an Allied Spirit bond partner, storage items, and bound spirits.

Closes #1023

## Test plan
- [x] `vitest run src/system/magic-point-source.test.ts` (updated expectations for the new label suffix)
- [x] Full `tsc --noEmit`, i18n unused-key audit, and full test suite all pass (pre-push hook)