### PR TITLE
fix: clear actor sheet drop-highlight when drag moves onto an overlapping Item Sheet

### DIFF
--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -1419,13 +1419,20 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     // but are not valid drop areas, so dragging into them should clear indicators.
     const dropArea = this.element.querySelector<HTMLElement>(".sheet-content") ?? this.element;
     const rect = dropArea.getBoundingClientRect();
-    const leftSheet =
+    const outsideBounds =
       event.clientX < rect.left ||
       event.clientX > rect.right ||
       event.clientY < rect.top ||
       event.clientY > rect.bottom;
 
-    if (leftSheet) {
+    // A bounds check alone misses the case where a floating Item Sheet window overlaps
+    // this sheet on screen: the cursor can stay geometrically inside our rect while it's
+    // actually now over the other window's (topmost) DOM, so we'd never clear the glow.
+    // Hit-test what's really under the cursor and confirm it's still part of this sheet.
+    const hitElement = event.view?.document?.elementFromPoint(event.clientX, event.clientY);
+    const stillInsideSheet = !!hitElement && this.element.contains(hitElement);
+
+    if (outsideBounds || !stillInsideSheet) {
       this._clearDropIndicators();
       this._clearDragState();
     }


### PR DESCRIPTION
## Summary
- The actor sheet's blue dropzone glow (`drag-hover-sheet`) got stuck on when a floating Item Sheet overlapped it on screen and a spell was dragged into that item sheet instead of the actor sheet.
- Root cause: `_onDragLeave` only checked cursor coordinates against the actor sheet's bounding rect. Since Foundry app windows are same-page positioned divs (not separate OS windows), the coordinates stayed geometrically "inside" the actor sheet even after the drag moved onto the overlapping item sheet's (topmost) DOM, so the glow never cleared - and since the drag ended over the item sheet, the actor sheet's `_onDragEnd`/`_onDrop` never fired either.
- Fix: hit-test with `document.elementFromPoint` and confirm the element actually under the cursor is still part of the actor sheet's own DOM before treating the drag as still hovering, in addition to the existing bounds check.

Closes #1025

## Test plan
- [x] Full `tsc --noEmit`, i18n unused-key audit, and full test suite all pass (pre-push hook)
- [x] Manual: open a character sheet and an overlapping Item Sheet, drag a spell into the item sheet, confirm the actor sheet's glow clears (native drag-and-drop isn't reliably simulable via browser automation, so this needs a manual check)