### PR TITLE
fix: Spirit Magic edit-mode points input width (#1016)

### DIFF
--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -2078,7 +2078,10 @@
         grid-template-columns: [col-start] 30px auto auto 1fr [col-end];
       }
 
-      & .spirit-magic-points-input {
+      /* The extra [type="number"] raises specificity above the generic
+         `.grid input[type="number"]` width:100% rule (which otherwise wins over the
+         single-class .spirit-magic-points-input selector) without needing !important. */
+      & input.spirit-magic-points-input[type="number"] {
         width: 3ch;
         text-align: center;
         margin-right: 0.25rem;


### PR DESCRIPTION
## Summary
- Fixes #1016: in edit mode, the Spirit Magic tab's variable-point number input (`.spirit-magic-points-input`) rendered far wider than its intended `3ch`, breaking row alignment and pushing the "Points Variable"/focus text out from the Spell Summary column.

## Root cause
The generic `.grid input[type="number"] { width: 100%; }` rule has higher CSS specificity than the single-class `.spirit-magic-points-input` selector, so it silently won the cascade. Added the `input` element and `[type="number"]` attribute to the selector to raise its specificity above the generic rule, following the same specificity-based approach already used elsewhere in this file (no `!important`).

## Test plan
- [x] `pnpm lint:styles` passes
- [x] `tsc`, i18n audit, and full test suite pass (via pre-push hook)
- [x] Manually verified in-browser: Spirit Magic tab, edit mode, variable-point spell (e.g. Farsee) — input stays narrow and row stays aligned