### PR TITLE
feat: display Magic Point recovery rate on the actor sheet

### DIFF
--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -219,6 +219,23 @@
       }
     }
 
+/* Icon next to "Magic Points" showing the recovery rate on hover (#512) - kept as a small icon
+   rather than inline text since the header row is already tight (characteristics, SR badges, MP,
+   MP storage toggle, and movement/encumbrance all share this line). Custom two-tone SVG (white
+   circle badge + dark counter-clockwise arrow baked in) rather than mask-image, since this needs
+   two explicit colors, not one recolorable silhouette - the white circle makes it stand out
+   against the busy parchment background, similar to how .mp-storage-icon's sun already does. */
+    & .mp-recovery-rate-icon {
+      display: inline-block;
+      width: 1.1rem;
+      height: 1.1rem;
+      margin: 0 0.125rem;
+      background-image: url("/systems/rqg/assets/images/ui/mp-recovery.svg");
+      background-size: contain;
+      background-repeat: no-repeat;
+      background-position: center;
+    }
+
 /* Shared "magic capacity limit" status banner, used by the Spirit Magic, Sorcery and Rune Magic tabs. */
     & .magic-limit-banner {
       font-size: 0.875rem;

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-header.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-header.hbs
@@ -112,6 +112,12 @@
         {{#if system.attributes.magicPoints.max}}
           <label class="flex-row flex-align-center">
             <span>{{localize "RQG.Actor.Attributes.MagicPoints"}}</span>
+            <span class="mp-recovery-rate-icon"
+               data-tooltip-html="<div class='text-left'>{{localize 'RQG.Actor.Attributes.MagicPointRecoveryTooltip'
+                                                             pointsPerDay=system.attributes.magicPointRecoveryPointsPerDay}}<br>
+               {{localize 'RQG.Actor.Attributes.MagicPointRecoveryTimePerPoint'
+                 duration=(magicPointRecoveryDuration system.attributes.magicPointRecoveryHoursPerPoint
+                                                       system.attributes.magicPointRecoveryMinutesPerPoint)}}</div>"></span>
             <span class="nowrap">
               <input type="number" min="0" max="99" name="system.attributes.magicPoints.value"
                      value="{{system.attributes.magicPoints.value}}" size="2">

--- a/src/data-model/actor-data/character-data-model.ts
+++ b/src/data-model/actor-data/character-data-model.ts
@@ -100,6 +100,9 @@ function defineCharacterSchema() {
 
     attributes: new SchemaField({
       magicPoints: derivedResourceSchemaField(),
+      /** 1 = RAW baseline (1 point/24h, p.54); 2 = twice as fast, 0.5 = half as fast.
+       *  Lets Humakti gifts / HeroQuest effects speed up or slow down recovery (#512). */
+      magicPointRecoveryRateFactor: new NumberField({ nullable: false, initial: 1, min: 0 }),
       hitPoints: derivedResourceSchemaField(),
       move: new SchemaField({
         currentLocomotion: new StringField({
@@ -355,6 +358,17 @@ export class CharacterDataModel extends RqgActorDataModel<
     if (system.attributes.magicPoints) {
       const magicPointsFromEffects = system.effect.add.magicPoints.max ?? 0;
       system.attributes.magicPoints.max = (pow ?? 0) + magicPointsFromEffects;
+      system.attributes.magicPointRecoveryPointsPerDay =
+        RqgCalculations.magicPointRecoveryPointsPerDay(
+          system.attributes.magicPoints.max,
+          system.attributes.magicPointRecoveryRateFactor,
+        );
+      const timePerPoint = RqgCalculations.magicPointRecoveryTimePerPoint(
+        system.attributes.magicPoints.max,
+        system.attributes.magicPointRecoveryRateFactor,
+      );
+      system.attributes.magicPointRecoveryHoursPerPoint = timePerPoint.hours;
+      system.attributes.magicPointRecoveryMinutesPerPoint = timePerPoint.minutes;
     }
     if (system.attributes.hitPoints) {
       const hitPointsFromEffects = system.effect.add.hitPoints.max ?? 0;

--- a/src/data-model/actor-data/rqg-actor-data.ts
+++ b/src/data-model/actor-data/rqg-actor-data.ts
@@ -33,6 +33,9 @@ interface CharacteristicDerivedAttributes {
   damageBonus: string;
   healingRate: number | undefined;
   spiritCombatDamage: string;
+  magicPointRecoveryPointsPerDay: number;
+  magicPointRecoveryHoursPerPoint: number;
+  magicPointRecoveryMinutesPerPoint: number;
 }
 
 type DerivedAttributes = ItemDependentDerivedAttributes & CharacteristicDerivedAttributes;

--- a/src/data-model/json-schemas/generated/actor/character.schema.json
+++ b/src/data-model/json-schemas/generated/actor/character.schema.json
@@ -554,6 +554,11 @@
             "max"
           ]
         },
+        "magicPointRecoveryRateFactor": {
+          "type": "number",
+          "minimum": 0,
+          "default": 1
+        },
         "hitPoints": {
           "type": "object",
           "properties": {
@@ -679,6 +684,7 @@
       "additionalProperties": false,
       "required": [
         "magicPoints",
+        "magicPointRecoveryRateFactor",
         "hitPoints",
         "move",
         "heroPoints",

--- a/src/system/register-handlebars-helpers.ts
+++ b/src/system/register-handlebars-helpers.ts
@@ -3,6 +3,7 @@ import {
   assertDocumentSubType,
   formatListByUserLanguage,
   getAvailableRunes,
+  getUserLanguage,
   localize,
   localizeDynamic,
   localizeItemType,
@@ -82,6 +83,20 @@ export const registerHandlebarsHelpers = function () {
       // eslint-disable-next-line no-irregular-whitespace
     }).format(total)} ${unit}`;
   });
+
+  Handlebars.registerHelper(
+    "magicPointRecoveryDuration",
+    (hours: number, minutes: number): string => {
+      const duration: Partial<Record<Intl.DurationFormatUnit, number>> = {};
+      if (hours) {
+        duration.hours = hours;
+      }
+      if (minutes || !hours) {
+        duration.minutes = minutes;
+      }
+      return new Intl.DurationFormat(getUserLanguage(), { style: "long" }).format(duration);
+    },
+  );
 
   Handlebars.registerHelper("decimalMultiply", (quantity, value, decimals) => {
     const fractionDigits = isNaN(decimals) ? undefined : Number(decimals);

--- a/src/system/rqg-calculations.test.ts
+++ b/src/system/rqg-calculations.test.ts
@@ -98,3 +98,66 @@ describe("damage bonus calculations are correct for", () => {
     expect(hp).toBe("0");
   });
 });
+
+describe("magic point recovery points per day are correct for", () => {
+  it("normal (RAW baseline) rate factor recovers full max in a day", () => {
+    expect(RqgCalculations.magicPointRecoveryPointsPerDay(18, 1)).toBe(18);
+  });
+
+  it("doubled rate factor", () => {
+    expect(RqgCalculations.magicPointRecoveryPointsPerDay(18, 2)).toBe(36);
+  });
+
+  it("halved rate factor", () => {
+    expect(RqgCalculations.magicPointRecoveryPointsPerDay(11, 0.5)).toBe(5.5);
+  });
+
+  it("zero rate factor", () => {
+    expect(RqgCalculations.magicPointRecoveryPointsPerDay(18, 0)).toBe(0);
+  });
+
+  it("no max magic points", () => {
+    expect(RqgCalculations.magicPointRecoveryPointsPerDay(undefined, 1)).toBe(0);
+  });
+
+  it("undefined rate factor", () => {
+    expect(RqgCalculations.magicPointRecoveryPointsPerDay(18, undefined)).toBe(0);
+  });
+});
+
+describe("magic point recovery time per point is correct for", () => {
+  it("round POW at normal rate (exact whole hours)", () => {
+    expect(RqgCalculations.magicPointRecoveryTimePerPoint(12, 1)).toStrictEqual({
+      hours: 2,
+      minutes: 0,
+    });
+  });
+
+  it("POW with a minute remainder", () => {
+    expect(RqgCalculations.magicPointRecoveryTimePerPoint(18, 1)).toStrictEqual({
+      hours: 1,
+      minutes: 20,
+    });
+  });
+
+  it("fast enough recovery to be under an hour per point", () => {
+    expect(RqgCalculations.magicPointRecoveryTimePerPoint(18, 2)).toStrictEqual({
+      hours: 0,
+      minutes: 40,
+    });
+  });
+
+  it("no max magic points", () => {
+    expect(RqgCalculations.magicPointRecoveryTimePerPoint(undefined, 1)).toStrictEqual({
+      hours: 0,
+      minutes: 0,
+    });
+  });
+
+  it("zero rate factor", () => {
+    expect(RqgCalculations.magicPointRecoveryTimePerPoint(18, 0)).toStrictEqual({
+      hours: 0,
+      minutes: 0,
+    });
+  });
+});

--- a/src/system/rqg-calculations.ts
+++ b/src/system/rqg-calculations.ts
@@ -71,6 +71,28 @@ export class RqgCalculations {
     return con ? Math.ceil(con / 6) : 0;
   }
 
+  /** RAW baseline (p.54) is a full recovery (= max/POW magic points) over 24 hours - stated as
+   *  both "1/4 of MP every six hours" and "1/24 per hour", i.e. proportional to max, not a flat
+   *  rate. recoveryRateFactor scales that linearly (2 = twice as fast, 0.5 = half as fast) to
+   *  cover gifts/HeroQuest effects. */
+  public static magicPointRecoveryPointsPerDay(
+    maxMagicPoints: number | null | undefined,
+    recoveryRateFactor: number | null | undefined,
+  ): number {
+    return (maxMagicPoints ?? 0) * (recoveryRateFactor ?? 0);
+  }
+
+  /** Time to recover a single magic point, split into whole hours + remainder minutes for
+   *  display (e.g. "1 point every 2h 40m"). */
+  public static magicPointRecoveryTimePerPoint(
+    maxMagicPoints: number | null | undefined,
+    recoveryRateFactor: number | null | undefined,
+  ): { hours: number; minutes: number } {
+    const pointsPerDay = this.magicPointRecoveryPointsPerDay(maxMagicPoints, recoveryRateFactor);
+    const totalMinutes = pointsPerDay > 0 ? Math.round((24 * 60) / pointsPerDay) : 0;
+    return { hours: Math.floor(totalMinutes / 60), minutes: totalMinutes % 60 };
+  }
+
   public static skillCategoryModifiers(
     str: number | null | undefined,
     siz: number | null | undefined,

--- a/src/system/util.ts
+++ b/src/system/util.ts
@@ -783,6 +783,18 @@ export function formatListByWorldLanguage(
 }
 
 /**
+ * Foundry's core UI language setting (what {@link foundry.helpers.Localization} / `localize()`
+ * resolves to), not the rqg world language setting used for rqid-linked content translation.
+ * Use this for `Intl.*` formatting embedded in localized UI strings, so numbers/durations match
+ * the surrounding text's language rather than the raw (and possibly different) browser locale.
+ */
+export function getUserLanguage(): string {
+  return (
+    (game.settings?.get("core", "language") as unknown as string) ?? CONFIG.RQG.fallbackLanguage
+  );
+}
+
+/**
  * Convert a list of strings to a string using language sensitive formatting. Use the user language setting.
  *
  * Output can look like `one, two, and three` given `["one", "two", "three"]`
@@ -791,9 +803,7 @@ export function formatListByUserLanguage(
   list: string[],
   concatType: ListFormatType = "conjunction",
 ): string {
-  const userLanguage =
-    (game.settings?.get("core", "language") as unknown as string) ?? CONFIG.RQG.fallbackLanguage;
-  return formatListByLanguage(userLanguage, list, concatType);
+  return formatListByLanguage(getUserLanguage(), list, concatType);
 }
 
 function formatListByLanguage(

--- a/static/assets/images/ui/mp-recovery.svg
+++ b/static/assets/images/ui/mp-recovery.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10.5" fill="#fff"/><path fill="none" stroke="#2b1d12" stroke-linecap="round" stroke-width="2.4" d="M13 18a6 6 0 1 0-7-5"/><path fill="#2b1d12" d="m7 19-4-5 7-1z"/></svg>

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -95,6 +95,8 @@
         "SizeAbbr": "SIZ",
         "DexterityAbbr": "DEX",
         "MagicPoints": "Magic Points",
+        "MagicPointRecoveryTooltip": "Recovers {pointsPerDay} magic points per day",
+        "MagicPointRecoveryTimePerPoint": "1 point every {duration}",
         "MagicPointSources": "Magic Point Source Order",
         "MagicPointSourcesFeedFromSelfHint": "Move {amount} Magic Points from Self into this storage item",
         "MagicPointSourcesAlliedSpiritHint": "Allied Spirit",


### PR DESCRIPTION
## Summary
- Closes #512 - shows a recovery-rate indicator next to Magic Points on the character header, with a hover tooltip giving points/day and time-per-point (locale-aware duration via `Intl.DurationFormat`).
- Recovery is proportional to max MP (POW), matching the core rulebook (p.54/244): a full recovery in 24 hours at the baseline rate - not a flat rate independent of POW.
- New persisted field `attributes.magicPointRecoveryRateFactor` (default `1`) lets gifts/HeroQuest effects speed up or slow down recovery **via a normal Active Effect targeting `system.attributes.magicPointRecoveryRateFactor` directly** - e.g. a Humakti gift that doubles recovery speed would use `ADD` mode with value `1` (baseline `1` → `2`), or `OVERRIDE` to replace it outright. No shadow `effect.add.*` field needed here (unlike `magicPoints.max`) since `prepareDerivedData()` only reads this field and never reassigns it, so Foundry's native `applyActiveEffects()` (which runs before `prepareDerivedData()`) isn't clobbered.
- Regenerated the character JSON schema (`check:schemas`) for the new field.

## Test plan
- [x] `vitest run` (711 tests passing)
- [x] `tsc --noEmit`
- [x] `check:schemas` / `i18n:audit:en`
- [x] Manual check in a live world: MP recovery tooltip renders correctly for a few different POW values, and an Active Effect on `system.attributes.magicPointRecoveryRateFactor` visibly changes the displayed rate