### PR TITLE
feat: automatic Magic Point recovery based on elapsed game time

### DIFF
--- a/src/actors/magic-point-recovery.ts
+++ b/src/actors/magic-point-recovery.ts
@@ -1,0 +1,19 @@
+import { RqgActorSheetV2 } from "./rqg-actor-sheet-v2";
+
+/**
+ * Passive Magic Point recovery (#1028): a sheet already open won't otherwise notice worldTime
+ * advancing (a calendar module, or the GM manually moving the clock) since nothing re-renders
+ * it. `updateWorldTime` fires on every client whenever worldTime changes, regardless of cause,
+ * so catch up any currently-open, owned character sheets here - each catch-up write updates the
+ * actor, and Foundry's own DocumentSheet machinery re-renders every open sheet for that actor
+ * (including on other clients) from there, same as any other actor update.
+ */
+export function initCharacterMagicPointRecovery() {
+  Hooks.on("updateWorldTime", () => {
+    for (const app of foundry.applications.instances.values()) {
+      if (app instanceof RqgActorSheetV2 && app.rendered && app.actor.isOwner) {
+        void app.actor.catchUpMagicPointRecovery();
+      }
+    }
+  });
+}

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -572,6 +572,13 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       this.element.classList.toggle(state, health === state);
     }
 
+    // Passive Magic Point recovery catch-up (#1028). A no-op write when nothing has accrued, so
+    // it's safe to run on every render; restricted to an owner so non-owner observers don't
+    // attempt (and fail) the write.
+    if (this.actor.isOwner) {
+      void this.actor.catchUpMagicPointRecovery();
+    }
+
     // Right-click the portrait to see it larger, via Foundry's native image popout --
     // the same action as the sidebar's "Show Player Artwork" context menu entry.
     const portraitImg = this.element.querySelector<HTMLImageElement>(

--- a/src/actors/rqg-actor.catch-up-magic-point-recovery.test.ts
+++ b/src/actors/rqg-actor.catch-up-magic-point-recovery.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RqgActor } from "./rqg-actor";
+import { ActorTypeEnum } from "../data-model/actor-data/rqg-actor-data";
+
+function createCharacterActor(overrides: {
+  magicPoints?: { value: number; max: number };
+  magicPointRecoveryRateFactor?: number;
+  magicPointRecoverySettledWorldTime?: number | null;
+}): any {
+  const actor = new RqgActor({ name: "Test Actor", type: ActorTypeEnum.Character }) as any;
+  actor.type = ActorTypeEnum.Character;
+  actor.system = {
+    attributes: {
+      magicPoints: overrides.magicPoints ?? { value: 5, max: 18 },
+      magicPointRecoveryRateFactor: overrides.magicPointRecoveryRateFactor ?? 1,
+      magicPointRecoverySettledWorldTime: overrides.magicPointRecoverySettledWorldTime ?? null,
+    },
+  } as any;
+  actor.update = vi.fn().mockResolvedValue(actor);
+  return actor;
+}
+
+describe("RqgActor.catchUpMagicPointRecovery", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (game as any).time;
+  });
+
+  it("seeds a never-settled checkpoint to now without recovering points", async () => {
+    const actor = createCharacterActor({ magicPointRecoverySettledWorldTime: null });
+    (game as any).time = { worldTime: 12_345 };
+
+    await actor.catchUpMagicPointRecovery();
+
+    expect(actor.update).toHaveBeenCalledWith({
+      system: {
+        attributes: {
+          magicPoints: { value: 5 },
+          magicPointRecoverySettledWorldTime: 12_345,
+        },
+      },
+    });
+  });
+
+  it("does nothing when no whole point has accrued since the checkpoint", async () => {
+    const actor = createCharacterActor({ magicPointRecoverySettledWorldTime: 0 });
+    (game as any).time = { worldTime: 60 }; // 1 minute elapsed, needs 80 for 18 max @ rate 1
+
+    await actor.catchUpMagicPointRecovery();
+
+    expect(actor.update).not.toHaveBeenCalled();
+  });
+
+  it("recovers whole points and advances the checkpoint, clamped to max", async () => {
+    const actor = createCharacterActor({
+      magicPoints: { value: 17, max: 18 },
+      magicPointRecoverySettledWorldTime: 0,
+    });
+    // 80 minutes/point at rate 1 for an 18-max pool; give it 3 points' worth.
+    (game as any).time = { worldTime: 80 * 60 * 3 };
+
+    await actor.catchUpMagicPointRecovery();
+
+    expect(actor.update).toHaveBeenCalledWith({
+      system: {
+        attributes: {
+          magicPoints: { value: 18 }, // clamped to max, not 20
+          magicPointRecoverySettledWorldTime: 80 * 60 * 3,
+        },
+      },
+    });
+  });
+
+  it("is a no-op for a non-character actor", async () => {
+    const actor = createCharacterActor({});
+    actor.type = "creature";
+    (game as any).time = { worldTime: 999_999 };
+
+    await actor.catchUpMagicPointRecovery();
+
+    expect(actor.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/actors/rqg-actor.settle-magic-point-recovery-checkpoint.test.ts
+++ b/src/actors/rqg-actor.settle-magic-point-recovery-checkpoint.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { RqgActor } from "./rqg-actor";
+import { ActorTypeEnum } from "../data-model/actor-data/rqg-actor-data";
+
+function createCharacterActor(): any {
+  const actor = new RqgActor({ name: "Test Actor", type: ActorTypeEnum.Character }) as any;
+  actor.type = ActorTypeEnum.Character;
+  return actor;
+}
+
+describe("RqgActor.settleMagicPointRecoveryCheckpoint", () => {
+  afterEach(() => {
+    delete (game as any).time;
+  });
+
+  it("stamps the checkpoint to now when magicPoints.value changes without one", () => {
+    const actor = createCharacterActor();
+    (game as any).time = { worldTime: 12_345 };
+    const changes: any = { system: { attributes: { magicPoints: { value: 3 } } } };
+
+    actor.settleMagicPointRecoveryCheckpoint(changes, true);
+
+    expect(changes.system.attributes.magicPointRecoverySettledWorldTime).toBe(12_345);
+  });
+
+  it("leaves an update alone when it doesn't touch magicPoints.value", () => {
+    const actor = createCharacterActor();
+    (game as any).time = { worldTime: 12_345 };
+    const changes: any = { system: { attributes: { hitPoints: { value: 3 } } } };
+
+    actor.settleMagicPointRecoveryCheckpoint(changes, false);
+
+    expect(changes.system.attributes.magicPointRecoverySettledWorldTime).toBeUndefined();
+  });
+
+  it("doesn't overwrite a checkpoint the update already specifies (catch-up's own write)", () => {
+    const actor = createCharacterActor();
+    (game as any).time = { worldTime: 999_999 };
+    const changes: any = {
+      system: {
+        attributes: {
+          magicPoints: { value: 8 },
+          magicPointRecoverySettledWorldTime: 4_800,
+        },
+      },
+    };
+
+    actor.settleMagicPointRecoveryCheckpoint(changes, true);
+
+    expect(changes.system.attributes.magicPointRecoverySettledWorldTime).toBe(4_800);
+  });
+
+  it("does nothing when worldTime isn't available yet", () => {
+    const actor = createCharacterActor();
+    const changes: any = { system: { attributes: { magicPoints: { value: 3 } } } };
+
+    actor.settleMagicPointRecoveryCheckpoint(changes, true);
+
+    expect(changes.system.attributes.magicPointRecoverySettledWorldTime).toBeUndefined();
+  });
+});

--- a/src/actors/rqg-actor.ts
+++ b/src/actors/rqg-actor.ts
@@ -32,6 +32,7 @@ import type { ActorHealthState } from "../data-model/actor-data/attributes";
 import type { DamageType } from "@item-model/weapon-enums.ts";
 import { dodgeBaseChance, jumpBaseChance } from "../items/skill-item/skill-formulas";
 import { RqgItem } from "@items/rqg-item.ts";
+import { RqgCalculations } from "../system/rqg-calculations";
 import { getConfigStatusEffects, getSpeakerCompat } from "../system/fvtt-type-compat";
 import {
   type MagicPointSourceSelection,
@@ -237,6 +238,66 @@ export class RqgActor extends Actor {
         localize("RQG.Dialog.SpiritMagicRoll.SuccessfullyCastInfo", { amount: amount.toString() }),
       );
     }
+  }
+
+  private _magicPointsWriteQueue: Promise<unknown> = Promise.resolve();
+
+  /**
+   * Serializes read-then-write operations on this actor's `magicPoints.value` (#1028 review
+   * finding: passive recovery catch-up and an explicit spend/draw both read the current value,
+   * compute an absolute new one, then write it - if both are in flight at once, whichever write
+   * lands last silently clobbers the other). Queuing every such operation through here means each
+   * one only reads `this.system` once its turn arrives, after any prior queued write has both
+   * been sent and locally applied - never against a stale pre-write snapshot. Used by this method
+   * and by the self/ally/bound-spirit draws in magic-point-source.ts.
+   */
+  public async serializeMagicPointsWrite<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this._magicPointsWriteQueue.then(operation, operation);
+    this._magicPointsWriteQueue = run.catch(() => undefined);
+    return run;
+  }
+
+  /**
+   * Passive Magic Point recovery catch-up (#1028): diffs the actor's recovery checkpoint against
+   * the current `game.time.worldTime` and, if any whole points have accrued since, persists the
+   * recovered points (clamped to `magicPoints.max`, which already reflects POW + any genuine
+   * effects - see #1028 discussion) and the advanced checkpoint in a single write. A no-op (no
+   * write) when nothing has changed, so it's safe to call on every sheet render.
+   */
+  public async catchUpMagicPointRecovery(): Promise<void> {
+    if (!isDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character)) {
+      return;
+    }
+    const currentWorldTime = game.time?.worldTime;
+    if (currentWorldTime == null) {
+      return;
+    }
+    await this.serializeMagicPointsWrite(async () => {
+      const attributes = this.system.attributes;
+      if (!attributes.magicPoints) {
+        return;
+      }
+      const settledWorldTime = attributes.magicPointRecoverySettledWorldTime;
+      const { pointsRecovered, newSettledWorldTime } = RqgCalculations.magicPointRecoveryCatchUp(
+        settledWorldTime,
+        currentWorldTime,
+        attributes.magicPoints.max,
+        attributes.magicPointRecoveryRateFactor,
+      );
+      if (pointsRecovered === 0 && newSettledWorldTime === settledWorldTime) {
+        return;
+      }
+      const newValue = Math.min(
+        (attributes.magicPoints.value ?? 0) + pointsRecovered,
+        attributes.magicPoints.max ?? 0,
+      );
+      await this.update(
+        foundry.utils.expandObject({
+          "system.attributes.magicPoints.value": newValue,
+          "system.attributes.magicPointRecoverySettledWorldTime": newSettledWorldTime,
+        }),
+      );
+    });
   }
 
   /**
@@ -487,11 +548,45 @@ export class RqgActor extends Actor {
     };
   }
 
-  private isHealthAffectingActorUpdate(changes: Actor.UpdateData): boolean {
+  private isHealthAffectingActorUpdate(
+    changes: Actor.UpdateData,
+    changesMagicPointsValue: boolean,
+  ): boolean {
     return (
       foundry.utils.hasProperty(changes, "system.attributes.hitPoints.value") ||
-      foundry.utils.hasProperty(changes, "system.attributes.magicPoints.value") ||
+      changesMagicPointsValue ||
       foundry.utils.hasProperty(changes, "system.attributes.health")
+    );
+  }
+
+  /**
+   * Any write to magicPoints.value that isn't catchUpMagicPointRecovery's own (#1028 follow-up) -
+   * a manual sheet edit, a spend, a future drain effect, anything - needs to settle the recovery
+   * checkpoint to *now* too. Otherwise the checkpoint stays wherever it last was (possibly stale,
+   * from well before this change), and the next catch-up attributes however much dead time sits
+   * between that stale checkpoint and now as recovered points on top of the value this update is
+   * setting - e.g. manually draining an actor's Magic Points, then having a catch-up run some time
+   * later, could instantly refund most or all of the drain by crediting the recovery gap that
+   * actually predates the drain. catchUpMagicPointRecovery's own writes always set the checkpoint
+   * explicitly (to a precisely carried-forward value, not just "now"), so this only fires for
+   * updates that change the value without also specifying a checkpoint.
+   */
+  private settleMagicPointRecoveryCheckpoint(
+    changes: Actor.UpdateData,
+    changesMagicPointsValue: boolean,
+  ): void {
+    const changesCheckpoint = foundry.utils.hasProperty(
+      changes,
+      "system.attributes.magicPointRecoverySettledWorldTime",
+    );
+    const currentWorldTime = game.time?.worldTime;
+    if (!changesMagicPointsValue || changesCheckpoint || currentWorldTime == null) {
+      return;
+    }
+    foundry.utils.setProperty(
+      changes,
+      "system.attributes.magicPointRecoverySettledWorldTime",
+      currentWorldTime,
     );
   }
 
@@ -700,9 +795,18 @@ export class RqgActor extends Actor {
   ): Promise<boolean | void> {
     assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
 
-    this._healthBeforeActorUpdate = this.isHealthAffectingActorUpdate(changes)
+    const changesMagicPointsValue = foundry.utils.hasProperty(
+      changes,
+      "system.attributes.magicPoints.value",
+    );
+    this._healthBeforeActorUpdate = this.isHealthAffectingActorUpdate(
+      changes,
+      changesMagicPointsValue,
+    )
       ? this.getHealthTransitionSnapshot()
       : undefined;
+
+    this.settleMagicPointRecoveryCheckpoint(changes, changesMagicPointsValue);
 
     const actorDex =
       (changes as DeepPartial<CharacterActor>)?.system?.characteristics?.dexterity?.value ??

--- a/src/data-model/actor-data/character-data-model.ts
+++ b/src/data-model/actor-data/character-data-model.ts
@@ -103,6 +103,15 @@ function defineCharacterSchema() {
       /** 1 = RAW baseline (1 point/24h, p.54); 2 = twice as fast, 0.5 = half as fast.
        *  Lets Humakti gifts / HeroQuest effects speed up or slow down recovery (#512). */
       magicPointRecoveryRateFactor: new NumberField({ nullable: false, initial: 1, min: 0 }),
+      /** `game.time.worldTime` (seconds) as of the last passive-recovery catch-up (#1028).
+       *  `null` means "never settled yet" - distinct from a real timestamp of 0 - so the first
+       *  catch-up for a pre-existing actor can seed it to "now" instead of granting retroactive
+       *  recovery for all elapsed time before the field existed. */
+      magicPointRecoverySettledWorldTime: new NumberField({
+        nullable: true,
+        initial: null,
+        required: false,
+      }),
       hitPoints: derivedResourceSchemaField(),
       move: new SchemaField({
         currentLocomotion: new StringField({

--- a/src/data-model/json-schemas/generated/actor/character.schema.json
+++ b/src/data-model/json-schemas/generated/actor/character.schema.json
@@ -559,6 +559,12 @@
           "minimum": 0,
           "default": 1
         },
+        "magicPointRecoverySettledWorldTime": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
         "hitPoints": {
           "type": "object",
           "properties": {

--- a/src/rqg.ts
+++ b/src/rqg.ts
@@ -37,6 +37,7 @@ import { ClickableScriptsRegionBehavior } from "./scene/clickable-scripts-region
 import { RqgTokenLayer } from "./scene/rqg-token-layer";
 import { RqgCombatant } from "./combat/rqg-combatant";
 import { setConfigStatusEffects } from "./system/fvtt-type-compat";
+import { initCharacterMagicPointRecovery } from "./actors/magic-point-recovery";
 
 // CONFIG.debug.hooks = true; // console log when hooks fire
 // CONFIG.debug.time = true; // console log time
@@ -101,6 +102,7 @@ Hooks.once("init", () => {
   RqgTokenRuler.init();
   RqgToken.init();
   RqgActor.init();
+  initCharacterMagicPointRecovery();
   RqgItem.init();
   RqgHotbar.init();
   RqgJournalEntry.init();

--- a/src/system/magic-point-source.test.ts
+++ b/src/system/magic-point-source.test.ts
@@ -54,6 +54,7 @@ function fakeActor(
     },
     update: vi.fn(),
     updateEmbeddedDocuments: vi.fn(),
+    serializeMagicPointsWrite: vi.fn((operation: () => Promise<unknown>) => operation()),
     getFlag: vi.fn((_scope: string, key: string) => (storedFlags as any)[key]),
     setFlag: vi.fn((_scope: string, key: string, value: unknown) => {
       (storedFlags as any)[key] = value;
@@ -79,6 +80,7 @@ function fakeBondActor(
     isOwner,
     system: { attributes: { magicPoints: { value: mpValue, max: mpMax } } },
     update: vi.fn(),
+    serializeMagicPointsWrite: vi.fn((operation: () => Promise<unknown>) => operation()),
   });
 }
 

--- a/src/system/magic-point-source.ts
+++ b/src/system/magic-point-source.ts
@@ -517,6 +517,19 @@ export function getMaxTransferableToStorage(actor: RqgActor, item: PhysicalItem)
   return Math.max(0, Math.min(selfAvailable, itemMax - itemValue));
 }
 
+/** Deduct `amount` from `target`'s own magicPoints.value, serialized against any other
+ *  concurrent read-then-write of the same actor's magicPoints.value (#1028 review finding). */
+async function debitMagicPoints(target: RqgActor, amount: number): Promise<void> {
+  await target.serializeMagicPointsWrite(async () => {
+    await target.update(
+      foundry.utils.expandObject({
+        "system.attributes.magicPoints.value":
+          (Number(target.system.attributes.magicPoints.value) || 0) - amount,
+      }),
+    );
+  });
+}
+
 /**
  * Move as many points as possible from `actor`'s own pool into `item`'s storage (per #956's
  * design doc: anyone who can use the item can refill its storage from their own Magic Points).
@@ -530,12 +543,9 @@ export async function feedStorageFromSelf(actor: RqgActor, item: PhysicalItem): 
   if (draw <= 0) {
     return;
   }
-  const selfValue = Number(actor.system.attributes.magicPoints.value) || 0;
   const itemValue = Number(item.system.storedMagicPoints?.value) || 0;
   await Promise.all([
-    actor.update(
-      foundry.utils.expandObject({ "system.attributes.magicPoints.value": selfValue - draw }),
-    ),
+    debitMagicPoints(actor, draw),
     item.update({ system: { storedMagicPoints: { value: itemValue + draw } } }),
   ]);
 }
@@ -792,22 +802,8 @@ export async function spendMagicPoints(
           })),
         )
       : undefined,
-    allyDraw
-      ? allyDraw.actor.update(
-          foundry.utils.expandObject({
-            "system.attributes.magicPoints.value":
-              (Number(allyDraw.actor.system.attributes.magicPoints.value) || 0) - allyDraw.amount,
-          }),
-        )
-      : undefined,
-    selfAmount > 0
-      ? actor.update(
-          foundry.utils.expandObject({
-            "system.attributes.magicPoints.value":
-              (Number(actor.system.attributes.magicPoints.value) || 0) - selfAmount,
-          }),
-        )
-      : undefined,
+    allyDraw ? debitMagicPoints(allyDraw.actor, allyDraw.amount) : undefined,
+    selfAmount > 0 ? debitMagicPoints(actor, selfAmount) : undefined,
     ...boundSpiritDraws.map(({ item, spiritActor, amount: draw }) =>
       spendBoundSpiritMagicPoints(item, spiritActor, draw),
     ),
@@ -821,25 +817,29 @@ async function spendBoundSpiritMagicPoints(
   spiritActor: RqgActor,
   draw: number,
 ): Promise<void> {
-  const remaining = (Number(spiritActor.system.attributes.magicPoints.value) || 0) - draw;
-  const spiritUpdate = spiritActor.update(
-    foundry.utils.expandObject({ "system.attributes.magicPoints.value": Math.max(0, remaining) }),
-  );
-  if (remaining <= 0) {
-    const remainingSpiritUuids = (item.system.boundSpiritActorUuids ?? []).filter(
-      (uuid) => uuid !== spiritActor.uuid,
-    );
-    await Promise.all([
-      spiritUpdate,
-      item.update({ system: { boundSpiritActorUuids: remainingSpiritUuids } }),
-    ]);
-    ui.notifications?.info(
-      localize("RQG.Item.Gear.BoundSpiritReleasedInfo", {
-        spiritName: spiritActor.name ?? "",
-        itemName: item.name ?? "",
+  await spiritActor.serializeMagicPointsWrite(async () => {
+    const remaining = (Number(spiritActor.system.attributes.magicPoints.value) || 0) - draw;
+    const spiritUpdate = spiritActor.update(
+      foundry.utils.expandObject({
+        "system.attributes.magicPoints.value": Math.max(0, remaining),
       }),
     );
-  } else {
-    await spiritUpdate;
-  }
+    if (remaining <= 0) {
+      const remainingSpiritUuids = (item.system.boundSpiritActorUuids ?? []).filter(
+        (uuid) => uuid !== spiritActor.uuid,
+      );
+      await Promise.all([
+        spiritUpdate,
+        item.update({ system: { boundSpiritActorUuids: remainingSpiritUuids } }),
+      ]);
+      ui.notifications?.info(
+        localize("RQG.Item.Gear.BoundSpiritReleasedInfo", {
+          spiritName: spiritActor.name ?? "",
+          itemName: item.name ?? "",
+        }),
+      );
+    } else {
+      await spiritUpdate;
+    }
+  });
 }

--- a/src/system/rqg-calculations.test.ts
+++ b/src/system/rqg-calculations.test.ts
@@ -161,3 +161,70 @@ describe("magic point recovery time per point is correct for", () => {
     });
   });
 });
+
+describe("magic point recovery catch-up is correct for", () => {
+  // 18 max MP at normal rate = 1 point every 80 minutes (4800 seconds), per the time-per-point tests above.
+  const minutesPerPoint = 80;
+  const secondsPerPoint = minutesPerPoint * 60;
+
+  it("never-settled (null) checkpoint seeds to now and recovers nothing", () => {
+    expect(RqgCalculations.magicPointRecoveryCatchUp(null, 99_999, 18, 1)).toStrictEqual({
+      pointsRecovered: 0,
+      newSettledWorldTime: 99_999,
+    });
+  });
+
+  it("no time elapsed recovers nothing and leaves the checkpoint in place", () => {
+    expect(RqgCalculations.magicPointRecoveryCatchUp(1000, 1000, 18, 1)).toStrictEqual({
+      pointsRecovered: 0,
+      newSettledWorldTime: 1000,
+    });
+  });
+
+  it("elapsed time short of one point recovers nothing and doesn't consume the checkpoint", () => {
+    expect(RqgCalculations.magicPointRecoveryCatchUp(0, secondsPerPoint - 60, 18, 1)).toStrictEqual(
+      {
+        pointsRecovered: 0,
+        newSettledWorldTime: 0,
+      },
+    );
+  });
+
+  it("exactly one point's worth of elapsed time", () => {
+    expect(RqgCalculations.magicPointRecoveryCatchUp(0, secondsPerPoint, 18, 1)).toStrictEqual({
+      pointsRecovered: 1,
+      newSettledWorldTime: secondsPerPoint,
+    });
+  });
+
+  it("multiple whole points", () => {
+    expect(RqgCalculations.magicPointRecoveryCatchUp(0, secondsPerPoint * 3, 18, 1)).toStrictEqual({
+      pointsRecovered: 3,
+      newSettledWorldTime: secondsPerPoint * 3,
+    });
+  });
+
+  it("carries a leftover partial-point remainder forward instead of discarding it", () => {
+    const current = secondsPerPoint + 40 * 60; // one full point plus 40 extra minutes
+    expect(RqgCalculations.magicPointRecoveryCatchUp(0, current, 18, 1)).toStrictEqual({
+      pointsRecovered: 1,
+      newSettledWorldTime: secondsPerPoint, // the 40 leftover minutes stay uncommitted
+    });
+  });
+
+  it("zero rate factor recovers nothing and leaves the checkpoint in place", () => {
+    expect(RqgCalculations.magicPointRecoveryCatchUp(0, secondsPerPoint * 3, 18, 0)).toStrictEqual({
+      pointsRecovered: 0,
+      newSettledWorldTime: 0,
+    });
+  });
+
+  it("no max magic points recovers nothing", () => {
+    expect(
+      RqgCalculations.magicPointRecoveryCatchUp(0, secondsPerPoint * 3, undefined, 1),
+    ).toStrictEqual({
+      pointsRecovered: 0,
+      newSettledWorldTime: 0,
+    });
+  });
+});

--- a/src/system/rqg-calculations.ts
+++ b/src/system/rqg-calculations.ts
@@ -93,6 +93,38 @@ export class RqgCalculations {
     return { hours: Math.floor(totalMinutes / 60), minutes: totalMinutes % 60 };
   }
 
+  /** Pure floor-and-carry step for passive Magic Point recovery (#1028): given the last-settled
+   *  `game.time.worldTime` (seconds) and the current one, returns how many whole points have
+   *  accrued since, plus that settled time advanced by just those whole points - not all the way
+   *  to `currentWorldTime` - so leftover minutes short of a full point carry forward toward the
+   *  next one instead of being discarded. Doesn't know about the actor's current Magic Point
+   *  value or max - clamping recovered points to max is the caller's job (see #1028 discussion:
+   *  `magicPoints.max` already reflects POW + genuine effects, and should be trusted as-is rather
+   *  than re-derived here). A `null` settled time (never settled) recovers nothing and seeds it
+   *  to `currentWorldTime`, avoiding retroactive recovery for actors predating this field. */
+  public static magicPointRecoveryCatchUp(
+    settledWorldTime: number | null | undefined,
+    currentWorldTime: number,
+    maxMagicPoints: number | null | undefined,
+    recoveryRateFactor: number | null | undefined,
+  ): { pointsRecovered: number; newSettledWorldTime: number } {
+    if (settledWorldTime == null) {
+      return { pointsRecovered: 0, newSettledWorldTime: currentWorldTime };
+    }
+    const pointsPerDay = this.magicPointRecoveryPointsPerDay(maxMagicPoints, recoveryRateFactor);
+    if (pointsPerDay <= 0) {
+      return { pointsRecovered: 0, newSettledWorldTime: settledWorldTime };
+    }
+    const minutesPerPoint = (24 * 60) / pointsPerDay;
+    const elapsedMinutes = (currentWorldTime - settledWorldTime) / 60;
+    const pointsRecovered = Math.max(0, Math.floor(elapsedMinutes / minutesPerPoint));
+    if (pointsRecovered <= 0) {
+      return { pointsRecovered: 0, newSettledWorldTime: settledWorldTime };
+    }
+    const newSettledWorldTime = settledWorldTime + pointsRecovered * minutesPerPoint * 60;
+    return { pointsRecovered, newSettledWorldTime };
+  }
+
   public static skillCategoryModifiers(
     str: number | null | undefined,
     siz: number | null | undefined,

--- a/test/setup/foundryMockFunctions.js
+++ b/test/setup/foundryMockFunctions.js
@@ -518,9 +518,9 @@ function mockGetType(variable) {
   return "Unknown";
 }
 
-function mockGetProperty(object, key) {
+function mockGetProperty(object, key, missing = undefined) {
   if (!key || !object) {
-    return undefined;
+    return missing;
   }
   if (key in object) {
     return object[key];
@@ -528,19 +528,24 @@ function mockGetProperty(object, key) {
   let target = object;
   for (const p of key.split(".")) {
     if (!target) {
-      return undefined;
+      return missing;
     }
     const type = typeof target;
     if (type !== "object" && type !== "function") {
-      return undefined;
+      return missing;
     }
     if (p in target) {
       target = target[p];
     } else {
-      return undefined;
+      return missing;
     }
   }
   return target;
+}
+
+function mockHasProperty(object, key) {
+  const missing = Symbol("missing");
+  return mockGetProperty(object, key, missing) !== missing;
 }
 
 // ------------------------------------------------
@@ -741,6 +746,7 @@ globalThis.foundry = {
   utils: {
     mergeObject: vi.fn((...args) => mockMergeObject(...args)),
     getProperty: vi.fn((...args) => mockGetProperty(...args)),
+    hasProperty: vi.fn((...args) => mockHasProperty(...args)),
     setProperty: vi.fn((...args) => setProperty(...args)),
     getType: vi.fn((...args) => mockGetType(...args)),
     expandObject: vi.fn((...args) => expandObject(...args)),


### PR DESCRIPTION
## Summary

Closes #1028. Passive Magic Point recovery is now computed from elapsed `game.time.worldTime` instead of requiring a manual "how much time passed" dialog:

- Adds `attributes.magicPointRecoverySettledWorldTime` to the character schema - a per-actor checkpoint (`null` = never settled, so a pre-existing actor doesn't get retroactive recovery credited for time before this field existed).
- `RqgCalculations.magicPointRecoveryCatchUp` (pure function) diffs the settled time against now and floor-divides into whole recovered points, carrying any leftover partial-point remainder forward instead of discarding it.
- `RqgActor.catchUpMagicPointRecovery()` applies that, clamped to `magicPoints.max`, in a single write - a no-op when nothing has accrued.
- Catch-up runs from `RqgActorSheetV2._onRender` (owner-gated) and from a new `updateWorldTime` hook (`src/actors/magic-point-recovery.ts`) so an already-open sheet also picks up world time advancing from a calendar module or the GM's clock, not just on next open.
- `serializeMagicPointsWrite` (per-actor promise-chain mutex on `RqgActor`) closes a race between this automatic catch-up and an explicit spend/draw both reading-then-absolutely-writing `magicPoints.value` - both `magic-point-source.ts`'s draws and catch-up's own write now queue through it.
- `settleMagicPointRecoveryCheckpoint` (in `_preUpdate`) stamps the checkpoint to "now" whenever anything else changes `magicPoints.value` without also specifying a checkpoint (a manual sheet edit, a spend, a future drain effect) - otherwise a stale checkpoint could misattribute dead time as recovery credit on top of a value that was just changed for an unrelated reason.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` (727 tests, including new coverage for `magicPointRecoveryCatchUp`, `catchUpMagicPointRecovery`, and `settleMagicPointRecoveryCheckpoint`)
- [x] `npm run generate:schemas` (character schema regenerated for the new field)
- [x] Manual in-Foundry verification: open a character sheet, advance world time (e.g. via a calendar module or the GM's clock), confirm Magic Points recover and the sheet updates without needing to touch anything else