### PR TITLE
feat: add quadruped hit-location visualization to actor sheet

### DIFF
--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -1647,6 +1647,121 @@
         }
       }
 
+/* --- Quadruped hit location layout --- */
+      & .quadruped {
+        position: relative;
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 0.5rem;
+        width: 24rem;
+
+        &::before {
+          content: "";
+          background: center/contain no-repeat url("/systems/rqg/assets/images/runes/horse.svg");
+          position: absolute;
+          inset: 0;
+          filter: invert(1);
+          mix-blend-mode: overlay;
+        }
+
+        & .actor-state {
+          grid-column: 4;
+          grid-row: 1;
+          place-self: start end;
+
+          & img {
+            height: 5rem;
+            filter: brightness(0) invert(14%) sepia(33%) saturate(5726%) hue-rotate(350deg)
+              brightness(99%) contrast(105%) drop-shadow(3px 3px 3px #000000b5);
+          }
+        }
+
+        & .stats {
+          position: relative;
+          border: 1px solid #666;
+          border-radius: var(--rqg-radius-lg);
+          padding: 0.375rem;
+          background-color: var(--rqg-color-hl-stats-bg);
+
+          &.useless,
+          &.severed {
+            background-color: var(--rqg-color-hl-stats-severed-bg);
+          }
+
+          &:not(.healthy) {
+            border-color: var(--rqg-highlight);
+            border-width: 2px;
+          }
+
+          & .roll-range {
+            font-size: 80%;
+          }
+
+          & .hl-header-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 0.5rem;
+          }
+
+          & .hl-status-row {
+            text-align: left;
+
+            & .health-state {
+              white-space: nowrap;
+            }
+          }
+
+          & .hl-stat-row {
+            display: flex;
+          }
+
+          & .hl-wounds-row {
+            display: flex;
+            justify-content: space-between;
+
+            & [data-action="addWound"] {
+              cursor: pointer;
+            }
+          }
+
+          &.head {
+            grid-column: 1;
+            grid-row: 1;
+          }
+
+          &.forequarter {
+            grid-column: 2;
+            grid-row: 1;
+          }
+
+          &.hindquarter {
+            grid-column: 3;
+            grid-row: 1;
+          }
+
+          &.left-foreleg {
+            grid-column: 1;
+            grid-row: 2;
+          }
+
+          &.right-foreleg {
+            grid-column: 2;
+            grid-row: 2;
+          }
+
+          &.left-hind-leg {
+            grid-column: 3;
+            grid-row: 2;
+          }
+
+          &.right-hind-leg {
+            grid-column: 4;
+            grid-row: 2;
+          }
+        }
+      }
+
 /* --- SR buttons --- */
       & .sr-buttons {
         display: flex;

--- a/src/actors/rqg-actor.ts
+++ b/src/actors/rqg-actor.ts
@@ -458,20 +458,22 @@ export class RqgActor extends Actor {
   }
 
   /**
-   * Return the bodyType of an actor. Currently only "humanoid" or "other"
+   * Return the bodyType of an actor. Currently "humanoid", "quadruped", or "other"
    */
   public getBodyType(): string {
     assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
     const actorHitlocationRqids = this.items
       .filter((i) => isDocumentSubType<HitLocationItem>(i, ItemTypeEnum.HitLocation))
       .map((hl: HitLocationItem) => hl.flags?.rqg?.documentRqidFlags?.id ?? "") as string[];
-    if (
-      CONFIG.RQG.bodytypes.humanoid.length === actorHitlocationRqids.length &&
-      CONFIG.RQG.bodytypes.humanoid.every((hitLocationRqid) =>
-        actorHitlocationRqids.includes(hitLocationRqid),
-      )
-    ) {
+
+    const matchesBodytype = (bodytypeRqids: string[]): boolean =>
+      bodytypeRqids.length === actorHitlocationRqids.length &&
+      bodytypeRqids.every((hitLocationRqid) => actorHitlocationRqids.includes(hitLocationRqid));
+
+    if (matchesBodytype(CONFIG.RQG.bodytypes.humanoid)) {
       return "humanoid";
+    } else if (matchesBodytype(CONFIG.RQG.bodytypes.quadruped)) {
+      return "quadruped";
     } else {
       return "other";
     }

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
@@ -74,8 +74,50 @@
               {{#if (eq system.attributes.health "unconscious")}}<img src="systems/rqg/assets/images/token-effects/unconscious.svg">{{/if}}
             </div>
           </div>
+        {{else if (eq bodyType "quadruped")}}
+          <div class="quadruped">
+            {{#each embeddedItems.hitLocation}}
+              <div class="hit-location contextmenu item stats {{rqidName}} {{system.hitLocationHealthState}}" data-item-id="{{id}}">
+                <div class="hl-header-row">
+                  <div class="flex-1"></div>
+                  <div class="roll-range"><i class="fa-solid fa-dice-d20"></i> {{#if (eq system.dieFrom system.dieTo)}}{{system.dieFrom}}{{else}}{{system.dieFrom}}-{{system.dieTo}}{{/if}}</div>
+                </div>
+                <b>{{name}}</b>
+                {{#unless (eq system.hitLocationHealthState "healthy")}}
+                  {{#unless (eq system.hitLocationHealthState "wounded")}}
+                    <div class="hl-status-row">
+                      <i class="health-state">{{toLowerCase
+                        (localizeDynamic "RQG.Item.HitLocation.HealthStatusEnum." system.hitLocationHealthState)}}</i>
+                    </div>
+                  {{/unless}}
+                {{/unless}}
+                <div class="hl-stat-row">
+                  <div>
+                    {{localize "RQG.Actor.Health.ArmorPointsAbbr"}}<br>
+                    {{localize "RQG.Actor.Health.HitPointsAbbr"}}
+                  </div>
+                  <div class="flex-1">
+                    &nbsp;{{system.armorPoints}}<br>
+                    <span class="nowrap{{#unless (eq system.hitPoints.value system.hitPoints.max)}} strike{{/unless}}">
+                      &nbsp;{{system.hitPoints.max}}&nbsp;
+                    </span>
+                    {{#unless (eq system.hitPoints.value system.hitPoints.max)}} <span class="ml-5">{{system.hitPoints.value}}</span>{{/unless}}
+                  </div>
+                </div>
+                <div class="hl-wounds-row">
+                  <div class="health-state break-word" data-action="healWound" title="{{localize "RQG.Actor.Health.HealWound"}}">{{#if system.woundsString}}<i class="fas fa-heart-pulse"></i> {{system.woundsString}}{{/if}}</div>
+                  <div class="ml-5" title="{{localize "RQG.Actor.Health.AddWound"}}" data-action="addWound"><i class="fas fa-burst"></i></div>
+                </div>
+              </div>
+            {{/each}}
+            <div class="actor-state">
+              {{#if (eq system.attributes.health "shock")}}<img src="systems/rqg/assets/images/token-effects/shock.svg">{{/if}}
+              {{#if (eq system.attributes.health "dead")}}<img src="systems/rqg/assets/images/token-effects/dead.svg">{{/if}}
+              {{#if (eq system.attributes.health "unconscious")}}<img src="systems/rqg/assets/images/token-effects/unconscious.svg">{{/if}}
+            </div>
+          </div>
         {{else}}
-          {{!-- Default (non-humanoid) hit locations grid --}}
+          {{!-- Default (non-humanoid, non-quadruped) hit locations grid --}}
           <div class="grid hit-location item-list">
             <div class="headings"></div>
             <div class="head1-4">

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -29,6 +29,15 @@ export const RQG_CONFIG = {
       "i.hit-location.left-leg" as RqidString,
       "i.hit-location.right-leg" as RqidString,
     ] as RqidString[],
+    quadruped: [
+      "i.hit-location.head" as RqidString,
+      "i.hit-location.forequarter" as RqidString,
+      "i.hit-location.hindquarter" as RqidString,
+      "i.hit-location.left-foreleg" as RqidString,
+      "i.hit-location.right-foreleg" as RqidString,
+      "i.hit-location.left-hind-leg" as RqidString,
+      "i.hit-location.right-hind-leg" as RqidString,
+    ] as RqidString[],
   },
 
   fallbackLanguage: "en",

--- a/src/theme.css
+++ b/src/theme.css
@@ -70,7 +70,7 @@
     --rqg-color-enc-legend: #4a3820;
     --rqg-color-dex-sr-bg: #ffe34190;
     --rqg-color-siz-sr-bg: #2bd72b90;
-    --rqg-color-hl-stats-bg: #1a1a1ab3;
+    --rqg-color-hl-stats-bg: #1a1a1a59;
     --rqg-color-hl-stats-severed-bg: #3a3a3a;
     --rqg-color-wounded-bg: #ff400030;
     --rqg-color-wounded-border: #cc8060;


### PR DESCRIPTION
## Summary
- Adds a grid-based hit-location layout for quadruped creatures (horse rune silhouette with head/forequarter/hindquarter/legs), matching the existing humanoid visualization.
- `getBodyType()` now detects `"quadruped"` alongside `"humanoid"`/`"other"` based on the actor's hit-location rqids.
- Lowers the dark-theme hit-location card background opacity (`--rqg-color-hl-stats-bg`) so the rune silhouette stays visible behind the cards.

Fixes #1033

## Test plan
- [x] `tsc -noEmit`, i18n audit, and `vitest run` all pass (pre-push hooks)
- [x] Manually verified in dark and light theme: rune silhouette visible behind cards, heal/add-wound buttons clickable