### PR TITLE
Add world settings to opt out of automatic MP recovery and natural healing

### DIFF
--- a/src/actors/rqg-actor.catch-up-magic-point-recovery.test.ts
+++ b/src/actors/rqg-actor.catch-up-magic-point-recovery.test.ts
@@ -94,4 +94,16 @@ describe("RqgActor.catchUpMagicPointRecovery", () => {
 
     expect(actor.update).not.toHaveBeenCalled();
   });
+
+  it("is a no-op when the magicPointRecoveryEnabled world setting is off (#1035)", async () => {
+    const actor = createCharacterActor({ magicPointRecoverySettledWorldTime: 0 });
+    (game as any).time = { worldTime: 80 * 60 * 3 };
+    const originalSettings = (game as any).settings;
+    (game as any).settings = { get: vi.fn().mockReturnValue(false) };
+
+    await actor.catchUpMagicPointRecovery();
+
+    expect(actor.update).not.toHaveBeenCalled();
+    (game as any).settings = originalSettings;
+  });
 });

--- a/src/actors/rqg-actor.catch-up-natural-healing.test.ts
+++ b/src/actors/rqg-actor.catch-up-natural-healing.test.ts
@@ -183,4 +183,17 @@ describe("RqgActor.catchUpNaturalHealing", () => {
 
     expect(actor.update).not.toHaveBeenCalled();
   });
+
+  it("is a no-op when the naturalHealingEnabled world setting is off (#1035)", async () => {
+    const secondsPerWeek = 7 * 24 * 60 * 60;
+    const actor = createCharacterActor({ healingSettledWorldTime: 0 });
+    (game as any).time = { worldTime: secondsPerWeek };
+    const originalSettings = (game as any).settings;
+    (game as any).settings = { get: vi.fn().mockReturnValue(false) };
+
+    await actor.catchUpNaturalHealing();
+
+    expect(actor.update).not.toHaveBeenCalled();
+    (game as any).settings = originalSettings;
+  });
 });

--- a/src/actors/rqg-actor.ts
+++ b/src/actors/rqg-actor.ts
@@ -285,10 +285,15 @@ export class RqgActor extends Actor {
    * write) when nothing has changed, so it's safe to call on every sheet render. Only applies to
    * player-owned actors: a GM-only-owned NPC could otherwise silently recover between the moment a
    * GM preps it and whenever the party actually reaches it in-game, changing state the GM set up
-   * on purpose without them noticing.
+   * on purpose without them noticing. A GM can turn this off entirely with the
+   * `magicPointRecoveryEnabled` world setting (#1035) for tables that want to gate recovery on
+   * resting by hand instead.
    */
   public async catchUpMagicPointRecovery(): Promise<void> {
     if (!isDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character) || !this.hasPlayerOwner) {
+      return;
+    }
+    if ((game.settings?.get(systemId, "magicPointRecoveryEnabled") ?? true) === false) {
       return;
     }
     const currentWorldTime = game.time?.worldTime;
@@ -336,10 +341,15 @@ export class RqgActor extends Actor {
    * every other narrow RAW edge case this codebase doesn't build UI/logic around. Only applies to
    * player-owned actors: a GM-only-owned NPC staged for a future scene could otherwise heal itself
    * in the background while the party takes their time getting there, changing state the GM set up
-   * on purpose without them noticing.
+   * on purpose without them noticing. A GM can turn this off entirely with the
+   * `naturalHealingEnabled` world setting (#1035) for tables that want to gate healing on resting
+   * by hand instead.
    */
   public async catchUpNaturalHealing(): Promise<void> {
     if (!isDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character) || !this.hasPlayerOwner) {
+      return;
+    }
+    if ((game.settings?.get(systemId, "naturalHealingEnabled") ?? true) === false) {
       return;
     }
     const currentWorldTime = game.time?.worldTime;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -148,6 +148,8 @@ declare global {
     "rqg.allowCombatWithoutToken": boolean;
     "rqg.matchEffectSuspensionToEquippedStatusDefault": boolean;
     "rqg.showActorActiveEffectsTab": boolean;
+    "rqg.naturalHealingEnabled": boolean;
+    "rqg.magicPointRecoveryEnabled": boolean;
   }
 
   interface ConfiguredCombatant {

--- a/src/system/rqg-system-settings.ts
+++ b/src/system/rqg-system-settings.ts
@@ -139,6 +139,24 @@ export const registerRqgSystemSettings = function () {
     default: false,
   });
 
+  game.settings?.register(systemId, "naturalHealingEnabled", {
+    name: "RQG.Settings.NaturalHealingEnabled.settingName",
+    hint: "RQG.Settings.NaturalHealingEnabled.settingHint",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
+
+  game.settings?.register(systemId, "magicPointRecoveryEnabled", {
+    name: "RQG.Settings.MagicPointRecoveryEnabled.settingName",
+    hint: "RQG.Settings.MagicPointRecoveryEnabled.settingHint",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
+
   game.settings?.register(systemId, "actor-wizard-feature-flag", {
     name: "Feature Flag: Enable Actor Wizard",
     hint: "For RnD use only",

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -1463,6 +1463,14 @@
         "settingName": "Show Hero Points",
         "settingHint": "Show an input field to track the optional rule of hero points."
       },
+      "NaturalHealingEnabled": {
+        "settingName": "Automatic Natural Healing",
+        "settingHint": "If enabled, wounded hit locations on player-owned characters automatically recover their healing rate as game time passes. Disable this if you'd rather apply natural healing by hand, for example to enforce that a character was actually resting."
+      },
+      "MagicPointRecoveryEnabled": {
+        "settingName": "Automatic Magic Point Recovery",
+        "settingHint": "If enabled, player-owned characters automatically recover Magic Points as game time passes. Disable this if you'd rather apply Magic Point recovery by hand."
+      },
       "WorldMigrationVersion": {
         "settingName": "World Migration Version",
         "settingHint": "The RQG system version this world has been migrated to."


### PR DESCRIPTION
## Summary
- Adds two GM-configurable world settings, `naturalHealingEnabled` and `magicPointRecoveryEnabled` (both default on), so tables that want to gate recovery/healing on the party actually resting can apply it by hand instead of automatically as game time passes.
- `catchUpMagicPointRecovery` / `catchUpNaturalHealing` on `RqgActor` now short-circuit when the corresponding setting is off.
- Fixes the Magic Point Recovery setting hint, which incorrectly referenced "resting" — resting isn't a RAW requirement for MP recovery (unlike natural healing).

Closes #1035

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm i18n:audit:en`
- [x] `pnpm test` (new no-op tests for both settings included)