### PR TITLE
fix: item migrations in the same pass don't see earlier migrations' pending effects changes

### DIFF
--- a/src/system/migrations/apply-migrations.patch-item-effects.test.ts
+++ b/src/system/migrations/apply-migrations.patch-item-effects.test.ts
@@ -66,6 +66,35 @@ describe("patchItemEffectsForPendingUpdates", () => {
     );
     expect((patched as any).name).toBe("Magic crystal");
   });
+
+  it("overlays non-system top-level patch fields too, e.g. duration/start from migrateItemActiveEffectDurationUnits", () => {
+    const item = legacyCrystalItem();
+    const pendingUpdateData = {
+      effects: [
+        {
+          _id: "effect-1",
+          duration: { value: 10, units: "rounds" },
+          start: {
+            time: 0,
+            round: null,
+            turn: null,
+            combat: null,
+            combatant: null,
+            initiative: null,
+          },
+        },
+      ],
+    };
+
+    const patched = patchItemEffectsForPendingUpdates(item as RqgItem, pendingUpdateData as any);
+
+    expect((patched as any).effects[0].duration).toEqual({ value: 10, units: "rounds" });
+    expect((patched as any).effects[0].start.time).toBe(0);
+    // The original system.changes (untouched by this patch) must still be visible.
+    expect((patched as any).effects[0].system.changes[0].key).toBe(
+      "system.attributes.magicPoints.max",
+    );
+  });
 });
 
 describe("migrateItemActiveEffectPaths + migrateItemPowCrystalToStoredMagicPoints sequencing", () => {

--- a/src/system/migrations/apply-migrations.patch-item-effects.test.ts
+++ b/src/system/migrations/apply-migrations.patch-item-effects.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { mergeMigrationUpdateData, patchItemEffectsForPendingUpdates } from "./apply-migrations";
+import { migrateItemActiveEffectPaths } from "./migrations-item/migrate-item-active-effect-paths";
+import { migrateItemPowCrystalToStoredMagicPoints } from "./migrations-item/migrate-item-pow-crystal-to-stored-magic-points";
+import type { RqgItem } from "@items/rqg-item.ts";
+
+/**
+ * Regression coverage: a first-time-migrated crystal item (legacy `system.attributes.
+ * magicPoints.max` AE key) had its key renamed by migrateItemActiveEffectPaths but was never
+ * converted to storedMagicPoints by migrateItemPowCrystalToStoredMagicPoints, because that later
+ * migration inspected the item's live, still-unrenamed effects rather than the pending update
+ * from the earlier one - both migrations ran in the same getItemMigrationUpdates pass against the
+ * original document state. Reported via a Molten Hosting migration where "Magic crystal" items
+ * ended up with the renamed key but storedMagicPoints still {value:0, max:0, identified:false}.
+ */
+function legacyCrystalItem(): any {
+  return {
+    name: "Magic crystal",
+    id: "item-1",
+    uuid: "Item.item-1",
+    type: "gear",
+    system: { storedMagicPoints: { value: 0, max: 0, identified: false } },
+    effects: [
+      {
+        _id: "effect-1",
+        name: "New Active Effect",
+        system: {
+          changes: [
+            {
+              key: "system.attributes.magicPoints.max",
+              value: 12,
+              priority: null,
+              type: "add",
+              phase: "initial",
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+describe("patchItemEffectsForPendingUpdates", () => {
+  it("returns the original item unchanged when there is no pending effects update", () => {
+    const item = legacyCrystalItem();
+    expect(patchItemEffectsForPendingUpdates(item as RqgItem, {})).toBe(item);
+  });
+
+  it("overlays a pending effect patch onto .effects, leaving other properties untouched", () => {
+    const item = legacyCrystalItem();
+    const pendingUpdateData = {
+      effects: [
+        {
+          _id: "effect-1",
+          system: {
+            changes: [{ key: "system.effect.add.magicPoints.max", value: 12, type: "add" }],
+          },
+        },
+      ],
+    };
+
+    const patched = patchItemEffectsForPendingUpdates(item as RqgItem, pendingUpdateData as any);
+
+    expect((patched as any).effects[0].system.changes[0].key).toBe(
+      "system.effect.add.magicPoints.max",
+    );
+    expect((patched as any).name).toBe("Magic crystal");
+  });
+});
+
+describe("migrateItemActiveEffectPaths + migrateItemPowCrystalToStoredMagicPoints sequencing", () => {
+  it("without patching, the crystal conversion misses the just-renamed key (the bug)", async () => {
+    const item = legacyCrystalItem();
+
+    const pathRewriteUpdate = await migrateItemActiveEffectPaths(item);
+    // Bug reproduction: pass the *unpatched* live item, as the old getItemMigrationUpdates did.
+    const crystalUpdate = await migrateItemPowCrystalToStoredMagicPoints(item);
+
+    expect((pathRewriteUpdate.effects as any[])?.[0]?.system?.changes?.[0]?.key).toBe(
+      "system.effect.add.magicPoints.max",
+    );
+    expect(crystalUpdate).toEqual({});
+  });
+
+  it("with patching, the crystal conversion sees the renamed key and converts it (the fix)", async () => {
+    const item = legacyCrystalItem();
+    let updateData: any = {};
+
+    const pathRewriteUpdate = await migrateItemActiveEffectPaths(
+      patchItemEffectsForPendingUpdates(item, updateData),
+    );
+    updateData = mergeMigrationUpdateData(updateData, pathRewriteUpdate);
+
+    const crystalUpdate = await migrateItemPowCrystalToStoredMagicPoints(
+      patchItemEffectsForPendingUpdates(item, updateData),
+    );
+    updateData = mergeMigrationUpdateData(updateData, crystalUpdate);
+
+    expect(updateData.system.storedMagicPoints).toEqual({ value: 12, max: 12, identified: true });
+    expect(updateData.effects[0].system.changes).toEqual([]);
+  });
+});

--- a/src/system/migrations/apply-migrations.ts
+++ b/src/system/migrations/apply-migrations.ts
@@ -4,6 +4,7 @@ import { systemId } from "../config";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import { MigrationLogger } from "../logging/migration-logger";
 import { RqgLogger } from "../logging/rqg-logger";
+import { type AEMigrationEffectLike, getCollectionValues } from "./shared-ae-migration-utils";
 
 const applyMigrationsLogger = new RqgLogger("Migration");
 
@@ -730,6 +731,56 @@ async function getActorMigrationUpdates(
 
 /* -------------------------------------------- */
 
+/**
+ * Wrap `item` so `.effects` reflects any effects changes already staged by earlier migrations in
+ * this same pass (via `pendingUpdateData.effects`), instead of the original persisted state.
+ * Needed because e.g. migrateItemPowCrystalToStoredMagicPoints looks for an effect key that
+ * migrateItemActiveEffectPaths only just renamed earlier in the same loop - without this, a
+ * legacy-format item going through both migrations for the first time in one pass would have its
+ * key renamed but never get converted, since the later migration would still see the old key.
+ * Every property other than `.effects` reads through to the real item unchanged.
+ */
+export function patchItemEffectsForPendingUpdates(
+  item: RqgItem,
+  pendingUpdateData: Item.UpdateData,
+): RqgItem {
+  const pendingEffects = (pendingUpdateData as Record<string, unknown>)?.["effects"];
+  if (!Array.isArray(pendingEffects) || pendingEffects.length === 0) {
+    return item;
+  }
+
+  const pendingById = new Map<string, Record<string, unknown>>();
+  for (const patch of pendingEffects) {
+    const id = (patch as Record<string, unknown>)?.["_id"];
+    if (typeof id === "string") {
+      pendingById.set(id, patch as Record<string, unknown>);
+    }
+  }
+
+  const originalEffects = getCollectionValues<AEMigrationEffectLike>((item as any).effects);
+  const patchedEffects = originalEffects.map((effect) => {
+    const id = (effect as any)?._id ?? (effect as any)?.id;
+    const patch = typeof id === "string" ? pendingById.get(id) : undefined;
+    if (!patch) {
+      return effect;
+    }
+    return {
+      ...(effect as object),
+      _id: id,
+      system: { ...(effect as any).system, ...(patch as any).system },
+    } as AEMigrationEffectLike;
+  });
+
+  return new Proxy(item, {
+    get(target, prop, receiver) {
+      if (prop === "effects") {
+        return patchedEffects;
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as RqgItem;
+}
+
 async function getItemMigrationUpdates(
   item: RqgItem,
   itemMigrations: ItemMigration[],
@@ -742,7 +793,8 @@ async function getItemMigrationUpdates(
   for (const fn of itemMigrations) {
     const migrationName = getMigrationFunctionName(fn);
     const scopedLogger = logger?.withMigration(migrationName);
-    const fnUpdate = await fn(item, owningActor, scopedLogger);
+    const patchedItem = patchItemEffectsForPendingUpdates(item, updateData);
+    const fnUpdate = await fn(patchedItem, owningActor, scopedLogger);
     if (!foundry.utils.isEmpty(pruneNoopUpdateData(fnUpdate, itemSourceData))) {
       migrationNames.add(migrationName);
     }

--- a/src/system/migrations/apply-migrations.ts
+++ b/src/system/migrations/apply-migrations.ts
@@ -733,7 +733,10 @@ async function getActorMigrationUpdates(
 
 /**
  * Wrap `item` so `.effects` reflects any effects changes already staged by earlier migrations in
- * this same pass (via `pendingUpdateData.effects`), instead of the original persisted state.
+ * this same pass (via `pendingUpdateData.effects`), instead of the original persisted state. Each
+ * matched effect is overlaid with every top-level field of its pending patch (e.g. `duration`/
+ * `start` from migrateItemActiveEffectDurationUnits), with `system` merged rather than replaced
+ * wholesale so untouched sibling system fields survive.
  * Needed because e.g. migrateItemPowCrystalToStoredMagicPoints looks for an effect key that
  * migrateItemActiveEffectPaths only just renamed earlier in the same loop - without this, a
  * legacy-format item going through both migrations for the first time in one pass would have its
@@ -766,6 +769,7 @@ export function patchItemEffectsForPendingUpdates(
     }
     return {
       ...(effect as object),
+      ...(patch as object),
       _id: id,
       system: { ...(effect as any).system, ...(patch as any).system },
     } as AEMigrationEffectLike;


### PR DESCRIPTION
## Summary
- Two item migrations run back-to-back for the same item: `migrateItemActiveEffectPaths` renames the legacy `system.attributes.magicPoints.max` Active Effect key to `system.effect.add.magicPoints.max`, then `migrateItemPowCrystalToStoredMagicPoints` looks for that new key to convert it into the item's own `storedMagicPoints` pool.
- Both read the live item document rather than the accumulated in-progress update, so on a **first-time** migration of a legacy-format item, the rename lands but the conversion silently finds nothing to convert - confirmed against an actual exported item after migration.
- `getItemMigrationUpdates` now patches the item passed to each migration function with any `.effects` changes already staged by earlier migrations in the same pass (via a `Proxy` overriding just the `.effects` read), so later migrations see up-to-date state.
- Added regression tests: one reproducing the bug unpatched, one confirming the fix converts correctly.

Closes #1041
Related: #1040 tracks the wider follow-up (this only covers the same-document case; cross-document migration ordering is still inconsistent elsewhere).

## Test plan
- [x] `apply-migrations.patch-item-effects.test.ts` - new regression tests (bug repro + fix verification)
- [x] Full test suite passes (758 tests)
- [x] `tsc --noEmit` clean