### PR TITLE
fix: avoid Proxy invariant violation patching embedded item effects

### DIFF
--- a/src/system/migrations/apply-migrations.ts
+++ b/src/system/migrations/apply-migrations.ts
@@ -775,14 +775,19 @@ export function patchItemEffectsForPendingUpdates(
     } as AEMigrationEffectLike;
   });
 
-  return new Proxy(item, {
-    get(target, prop, receiver) {
-      if (prop === "effects") {
-        return patchedEffects;
-      }
-      return Reflect.get(target, prop, receiver);
-    },
-  }) as RqgItem;
+  // A real embedded item's `effects` is a non-configurable, non-writable own property
+  // (Foundry's EmbeddedCollectionField), so a Proxy targeting `item` directly can't override
+  // the get trap's return value for it - the engine enforces that non-configurable data
+  // properties report their actual value, and throws otherwise. Use `item` as the prototype
+  // of a fresh object instead and shadow only `effects` as an own property on top of it;
+  // every other property still resolves through the prototype chain to the real item.
+  const patched: RqgItem = Object.create(item);
+  Object.defineProperty(patched, "effects", {
+    value: patchedEffects,
+    enumerable: true,
+    configurable: true,
+  });
+  return patched;
 }
 
 async function getItemMigrationUpdates(


### PR DESCRIPTION
## Summary
- `patchItemEffectsForPendingUpdates` (added in #1042) wraps an item in `new Proxy(item, { get... })` to overlay pending `.effects` changes staged earlier in the same migration pass.
- On a real item embedded in an actor, Foundry defines `.effects` as a non-configurable, non-writable own property (the `EmbeddedCollection`). A Proxy `get` trap can't legally return a different value for that - the engine throws instead of silently allowing the override.
- This aborted the whole actor-level migration (caught and reported as `Failed system migration for Actor X`) for any actor owning an item with existing Active Effects that hit a migration staging a pending `.effects` update.
- Fix: use `item` as the prototype of a fresh object (`Object.create(item)`) and shadow only `.effects` as an own property on it, instead of using a Proxy at all. Every other property still resolves through the prototype chain to the real item.

Closes #1043

## Test plan
- [x] Existing `apply-migrations.patch-item-effects.test.ts` regression tests still pass (5/5)
- [x] Full test suite passes (759 tests)
- [x] `tsc --noEmit` clean
- [x] Reproduced against a real exported actor (owns items with effects) that triggered the original error