### PR TITLE
Sort and interleave Spell Matrix spells with owned Spirit Magic spells

### DIFF
--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -2270,7 +2270,7 @@
         }
       }
 
-/* Marks a matrix spell as matrix-derived (#1047); margin matches the row icon-to-name gap. */
+/* Margin matches the row icon-to-name gap. */
       & .matrix-source-badge {
         margin-left: 0.35rem;
         flex: 0 0 auto;

--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -1041,8 +1041,11 @@
     }
 
     /* Shared icon size for item-list row icons across Spirit Magic, Rune Magic, Sorcery,
-       Skills, Gear, Passion, and the Background tab's reputation icon. */
-    .row-icon {
+       Skills, Gear, Passion, and the Background tab's reputation icon. Also used by the Spell
+       Matrix source badge (#1047, .matrix-source-badge below) so it reads as a second icon, not a
+       dimmed overlay. */
+    .row-icon,
+    .matrix-source-badge {
       width: 26px;
       height: 26px;
       object-fit: contain;
@@ -2270,15 +2273,11 @@
 
 /* Source-item badge (#1047): shown on a matrix spell's name, marking it as matrix-derived since
    matrix entries no longer get their own "Matrix: ..." divider - see
-   matrixSpellSpiritMagicRow.hbs. Sized to match .row-icon so it reads as a second icon, not a
-   small overlay. */
+   matrixSpellSpiritMagicRow.hbs. Sizing/border shared with .row-icon above, so it reads as a
+   second icon at full strength, not a dimmed overlay; margin-left matches the gap between the
+   row's own icon and the spell name. */
       & .matrix-source-badge {
-        width: 26px;
-        height: 26px;
-        object-fit: contain;
-        border: none;
-        margin-left: 0.25rem;
-        opacity: 0.85;
+        margin-left: 0.35rem;
         flex: 0 0 auto;
       }
     }

--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -2268,14 +2268,15 @@
         }
       }
 
-/* Source-item badge (#1047): shown on a matrix spell's name in place of a "Matrix: ..." divider
-   when its item holds only that one spell - see matrixSpellSpiritMagicRow.hbs. */
+/* Source-item badge (#1047): shown on a matrix spell's name, marking it as matrix-derived since
+   matrix entries no longer get their own "Matrix: ..." divider - see
+   matrixSpellSpiritMagicRow.hbs. Sized to match .row-icon so it reads as a second icon, not a
+   small overlay. */
       & .matrix-source-badge {
-        width: 14px;
-        height: 14px;
+        width: 26px;
+        height: 26px;
         object-fit: contain;
         border: none;
-        border-radius: var(--rqg-radius-sm);
         margin-left: 0.25rem;
         opacity: 0.85;
         flex: 0 0 auto;

--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -1041,9 +1041,8 @@
     }
 
     /* Shared icon size for item-list row icons across Spirit Magic, Rune Magic, Sorcery,
-       Skills, Gear, Passion, and the Background tab's reputation icon. Also used by the Spell
-       Matrix source badge (#1047, .matrix-source-badge below) so it reads as a second icon, not a
-       dimmed overlay. */
+       Skills, Gear, Passion, and the Background tab's reputation icon. Also the Spell Matrix
+       source badge (#1047). */
     .row-icon,
     .matrix-source-badge {
       width: 26px;
@@ -2271,11 +2270,7 @@
         }
       }
 
-/* Source-item badge (#1047): shown on a matrix spell's name, marking it as matrix-derived since
-   matrix entries no longer get their own "Matrix: ..." divider - see
-   matrixSpellSpiritMagicRow.hbs. Sizing/border shared with .row-icon above, so it reads as a
-   second icon at full strength, not a dimmed overlay; margin-left matches the gap between the
-   row's own icon and the spell name. */
+/* Marks a matrix spell as matrix-derived (#1047); margin matches the row icon-to-name gap. */
       & .matrix-source-badge {
         margin-left: 0.35rem;
         flex: 0 0 auto;

--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -2267,6 +2267,19 @@
           box-shadow: none;
         }
       }
+
+/* Source-item badge (#1047): shown on a matrix spell's name in place of a "Matrix: ..." divider
+   when its item holds only that one spell - see matrixSpellSpiritMagicRow.hbs. */
+      & .matrix-source-badge {
+        width: 14px;
+        height: 14px;
+        object-fit: contain;
+        border: none;
+        border-radius: var(--rqg-radius-sm);
+        margin-left: 0.25rem;
+        opacity: 0.85;
+        flex: 0 0 auto;
+      }
     }
 
 /* --- Rune Magic tab --- */

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -72,6 +72,7 @@ import {
 import { getWeaponEffectModifier } from "../items/weapon-item/weapon-skill-links";
 import {
   getMatrixSpellRows,
+  getMatrixSpellSlots,
   resolveMatrixSpellItem,
   type MatrixSpellStorageEntry,
 } from "../system/spell-matrix";
@@ -144,6 +145,13 @@ type SpiritMagicSortSibling =
       sourceItem: PhysicalItem;
       entryIndex: number;
     };
+
+/** Identifies one Spirit Magic sibling (owned Item or matrix entry) without needing the resolved
+ *  SpiritMagicSortSibling itself - shared shape between a drag source (_reorderSpiritMagic's
+ *  `source` param) and a drop-target row's dataset (_resolveSpiritMagicSibling). See
+ *  _findSpiritMagicSibling. */
+type SpiritMagicSiblingId =
+  { kind: "owned"; itemId: string } | { kind: "matrix"; sourceItemId: string; entryIndex: number };
 
 /** Custom drag payload for reordering a Spell Matrix entry (#1047, see _onMatrixSpellDragStart) -
  *  it isn't a real embedded Item, so it can't ride Foundry's native "Item" drag/drop handling. */
@@ -1713,7 +1721,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         return "into";
       }
 
-      const rect = dropCell.getBoundingClientRect();
+      const rect = RqgActorSheetV2._realBoundingRect(dropCell);
       const upperBoundary = rect.top + rect.height / 3;
       const lowerBoundary = rect.bottom - rect.height / 3;
       if (event.clientY >= upperBoundary && event.clientY <= lowerBoundary) {
@@ -1721,8 +1729,21 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       }
     }
 
-    const rect = dropCell.getBoundingClientRect();
+    const rect = RqgActorSheetV2._realBoundingRect(dropCell);
     return event.clientY < rect.top + rect.height / 2 ? "before" : "after";
+  }
+
+  /** Several row wrappers across the sheet are `display: contents` (their children render as if
+   *  direct grid children - e.g. `.spirit-magic-row`, `.gear-row`, `.skill-row`), which makes their
+   *  own getBoundingClientRect() degenerate (all zero). Fall back to the first real child's rect in
+   *  that case, so drop-position math above stays correct regardless of which element - a row
+   *  wrapper or an inner cell - was passed in. */
+  private static _realBoundingRect(element: HTMLElement): DOMRect {
+    const rect = element.getBoundingClientRect();
+    if (rect.width || rect.height) {
+      return rect;
+    }
+    return (element.firstElementChild as HTMLElement | null)?.getBoundingClientRect() ?? rect;
   }
 
   private _isLocationContainerDropTarget(
@@ -1886,7 +1907,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
    *  and Spell Matrix entries together (they share one visual list - see spiritMagicRows),
    *  assigning fresh `sort` values across both by spell name. */
   private static async _sortSpiritMagicAlphabetically(actor: RqgActor): Promise<void> {
-    const siblings = await RqgActorSheetV2._getSpiritMagicSortSiblings(actor);
+    const siblings = RqgActorSheetV2._getSpiritMagicSortSiblings(actor);
     const ordered = [...siblings].sort((a, b) => a.name.localeCompare(b.name));
     const updates = ordered.map((sibling, index) => ({
       target: sibling,
@@ -1899,12 +1920,13 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
    *  Magic tab, wrapped for foundry.utils.performIntegerSort - a generic algorithm that only needs
    *  objects carrying a `sort` property, not real Documents, which is exactly what lets a matrix
    *  entry (plain data on another Item's `matrixSpells` array, not a Document of its own)
-   *  interleave with owned Items in one sequence. See SpiritMagicSortSibling. */
-  private static async _getSpiritMagicSortSiblings(
-    actor: RqgActor,
-  ): Promise<SpiritMagicSortSibling[]> {
+   *  interleave with owned Items in one sequence. See SpiritMagicSortSibling. Uses
+   *  getMatrixSpellSlots rather than getMatrixSpellRows - sort math only needs each entry's
+   *  already-stored sort/name, not its resolved SpiritMagicItem, so this stays synchronous and
+   *  skips a compendium/world lookup per entry on every drag-drop and "sort alphabetically" click. */
+  private static _getSpiritMagicSortSiblings(actor: RqgActor): SpiritMagicSortSibling[] {
     const ownedItems = actor.items.filter((i) => i.type === ItemTypeEnum.SpiritMagic) as RqgItem[];
-    const matrixRows = await getMatrixSpellRows(actor);
+    const matrixSlots = getMatrixSpellSlots(actor);
     return [
       ...ownedItems.map((item): SpiritMagicSortSibling => ({
         kind: "owned",
@@ -1912,12 +1934,12 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         name: item.name ?? "",
         item,
       })),
-      ...matrixRows.map((row): SpiritMagicSortSibling => ({
+      ...matrixSlots.map((slot): SpiritMagicSortSibling => ({
         kind: "matrix",
-        sort: row.sort,
-        name: row.item.name ?? "",
-        sourceItem: row.sourceItem,
-        entryIndex: row.entryIndex,
+        sort: slot.sort,
+        name: slot.name,
+        sourceItem: slot.sourceItem,
+        entryIndex: slot.entryIndex,
       })),
     ];
   }
@@ -1971,13 +1993,21 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     await Promise.all(updatePromises);
   }
 
-  /** `.spirit-magic-row` is `display: contents` (its children render as if they were direct
-   *  children of the grid - see actorsheet-v2.css), so it generates no box of its own:
-   *  getBoundingClientRect() on it is degenerate (all zero). _getSameActorDropAction needs a real
-   *  rendered element to compare the drop's clientY against, so give it the row's first real
-   *  child instead of the row itself. */
-  private static _spiritMagicDropRectElement(row: HTMLElement): HTMLElement {
-    return (row.firstElementChild as HTMLElement | null) ?? row;
+  /** Find the sibling identified by `id` (an owned Item's id, or a matrix entry's host item id +
+   *  entry index) - shared by _resolveSpiritMagicSibling (identifies a drop-target row) and
+   *  _reorderSpiritMagic (identifies the drag source, already in this shape). */
+  private static _findSpiritMagicSibling(
+    id: SpiritMagicSiblingId,
+    siblings: SpiritMagicSortSibling[],
+  ): SpiritMagicSortSibling | undefined {
+    return id.kind === "owned"
+      ? siblings.find((s) => s.kind === "owned" && s.item.id === id.itemId)
+      : siblings.find(
+          (s) =>
+            s.kind === "matrix" &&
+            s.sourceItem.id === id.sourceItemId &&
+            s.entryIndex === id.entryIndex,
+        );
   }
 
   /** Resolve a Spirit Magic row element (owned or matrix - see actor-sheet-v2-spirit-magic.hbs /
@@ -1991,13 +2021,11 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       return undefined;
     }
     const matrixIndexStr = row.dataset["matrixSpellRowIndex"];
-    if (matrixIndexStr !== undefined) {
-      const entryIndex = Number(matrixIndexStr);
-      return siblings.find(
-        (s) => s.kind === "matrix" && s.sourceItem.id === itemId && s.entryIndex === entryIndex,
-      );
-    }
-    return siblings.find((s) => s.kind === "owned" && s.item.id === itemId);
+    const id: SpiritMagicSiblingId =
+      matrixIndexStr !== undefined
+        ? { kind: "matrix", sourceItemId: itemId, entryIndex: Number(matrixIndexStr) }
+        : { kind: "owned", itemId };
+    return RqgActorSheetV2._findSpiritMagicSibling(id, siblings);
   }
 
   /** Reorder one Spirit Magic row (owned or matrix - #1047) relative to another, sharing one
@@ -2006,22 +2034,12 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
    *  dropped on/near, and `dropAction` which side of it. */
   private static async _reorderSpiritMagic(
     actor: RqgActor,
-    source:
-      | { kind: "owned"; itemId: string }
-      | { kind: "matrix"; sourceItemId: string; entryIndex: number },
+    source: SpiritMagicSiblingId,
     dropRow: HTMLElement,
     dropAction: "before" | "after",
   ): Promise<void> {
-    const siblings = await RqgActorSheetV2._getSpiritMagicSortSiblings(actor);
-    const resolvedSource =
-      source.kind === "owned"
-        ? siblings.find((s) => s.kind === "owned" && s.item.id === source.itemId)
-        : siblings.find(
-            (s) =>
-              s.kind === "matrix" &&
-              s.sourceItem.id === source.sourceItemId &&
-              s.entryIndex === source.entryIndex,
-          );
+    const siblings = RqgActorSheetV2._getSpiritMagicSortSiblings(actor);
+    const resolvedSource = RqgActorSheetV2._findSpiritMagicSibling(source, siblings);
     const target = RqgActorSheetV2._resolveSpiritMagicSibling(dropRow, siblings);
     if (!resolvedSource || !target || target === resolvedSource) {
       return;
@@ -2086,11 +2104,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
           ".spirit-magic-row[data-item-id]",
         );
         if (spiritMagicDropRow) {
-          const dropAction = this._getSameActorDropAction(
-            event,
-            RqgActorSheetV2._spiritMagicDropRectElement(spiritMagicDropRow),
-            null,
-          );
+          const dropAction = this._getSameActorDropAction(event, spiritMagicDropRow, null);
           if (dropAction === "before" || dropAction === "after") {
             await RqgActorSheetV2._reorderSpiritMagic(
               this.actor,
@@ -2646,11 +2660,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       return;
     }
 
-    const dropAction = this._getSameActorDropAction(
-      event,
-      RqgActorSheetV2._spiritMagicDropRectElement(dropRow),
-      null,
-    );
+    const dropAction = this._getSameActorDropAction(event, dropRow, null);
     if (dropAction !== "before" && dropAction !== "after") {
       return;
     }

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -130,8 +130,7 @@ type PhysicalTransferResult =
   | { kind: "failed" }
   | { kind: "cancelled" };
 
-/** An owned spiritMagic Item or one matrix entry, wrapped for foundry.utils.performIntegerSort
- *  (#1047) - see _applySpiritMagicSortUpdates. */
+/** For foundry.utils.performIntegerSort, which needs a plain `sort` field, not a real Document. */
 type SpiritMagicSortSibling =
   | { kind: "owned"; sort: number; name: string; item: RqgItem }
   | {
@@ -142,13 +141,11 @@ type SpiritMagicSortSibling =
       entryIndex: number;
     };
 
-/** Identifies a Spirit Magic sibling without the resolved SpiritMagicSortSibling - see
- *  _findSpiritMagicSibling. */
+/** Lightweight identifier, so a lookup doesn't need the full resolved sibling. */
 type SpiritMagicSiblingId =
   { kind: "owned"; itemId: string } | { kind: "matrix"; sourceItemId: string; entryIndex: number };
 
-/** Custom drag payload for a Spell Matrix entry (#1047) - not a real Item, so it can't use
- *  Foundry's native drag/drop. */
+/** Not a real Item, so it can't use Foundry's native Item drag/drop. */
 type RqgMatrixSpellSortDragData = {
   type: "RqgMatrixSpellSort";
   actorUuid: string;
@@ -168,7 +165,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
   // Runtime override of ActorSheetV2 _dragDrop; current fvtt-types do not expose this member.
   protected get _dragDrop(): foundry.applications.ux.DragDrop.Implementation {
     this._rqgDragDrop ??= new foundry.applications.ux.DragDrop.implementation({
-      // #1047: also matches Spell Matrix drag handles (not real Items) - see _onDragStart.
+      // Also matches Spell Matrix drag handles (not real Items).
       dragSelector:
         "[data-item-drag-handle][data-item-id], [data-matrix-spell-drag-handle][data-item-id]",
       // Include a non-root content drop target for generic Foundry handling.
@@ -329,7 +326,6 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       getMatrixSpellRows(this.actor),
       DataPrep.organizeEmbeddedItems(this.actor, incorrectRunes),
     ]);
-    // #1047: owned spells and matrix entries share one sort-ordered list.
     const spiritMagicRows: SpiritMagicListRow[] = [
       ...((embeddedItems[ItemTypeEnum.SpiritMagic] ?? []) as RqgItem[]).map(
         (item): SpiritMagicListRow => ({ isMatrixRow: false, sort: item.sort ?? 0, item }),
@@ -1413,8 +1409,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
   protected override async _onDragStart(event: DragEvent): Promise<void> {
     const eventTarget = getEventTargetElement(event);
 
-    // #1047: matrix entries aren't real Items, so they need their own drag payload (see
-    // _onMatrixSpellDragStart) instead of super._onDragStart's Item-drag handling below.
+    // Matrix entries aren't real Items - skip super._onDragStart's Item-drag handling.
     const matrixHandle = eventTarget?.closest("[data-matrix-spell-drag-handle]");
     if (isFoundryElementInstanceOf(matrixHandle, HTMLElement)) {
       this._onMatrixSpellDragStart(event, matrixHandle);
@@ -1451,7 +1446,6 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     }
   }
 
-  /** Builds the custom matrix-entry drag payload (#1047) - see RqgMatrixSpellSortDragData. */
   private _onMatrixSpellDragStart(event: DragEvent, matrixHandle: HTMLElement): void {
     const sourceItemId = matrixHandle.dataset["itemId"];
     const entryIndexStr = matrixHandle.dataset["matrixSpellIndex"];
@@ -1865,7 +1859,6 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       return;
     }
 
-    // #1047: alphabetize owned spells and matrix entries together.
     if (itemType === ItemTypeEnum.SpiritMagic) {
       await RqgActorSheetV2._sortSpiritMagicAlphabetically(actor);
       return;
@@ -1883,7 +1876,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     await actor.updateEmbeddedDocuments("Item", updateData);
   }
 
-  /** Alphabetizes owned spells and matrix entries together (#1047). */
+  /** Alphabetizes owned spells and matrix entries together. */
   private static async _sortSpiritMagicAlphabetically(actor: RqgActor): Promise<void> {
     const siblings = RqgActorSheetV2._getSpiritMagicSortSiblings(actor);
     const ordered = [...siblings].sort((a, b) => a.name.localeCompare(b.name));
@@ -1894,8 +1887,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     await RqgActorSheetV2._applySpiritMagicSortUpdates(actor, updates);
   }
 
-  /** Owned spells + matrix entries as SpiritMagicSortSiblings. Uses getMatrixSpellSlots, not
-   *  getMatrixSpellRows - sort math needs no spell resolution. */
+  /** Uses getMatrixSpellSlots, not getMatrixSpellRows - sort math needs no spell resolution. */
   private static _getSpiritMagicSortSiblings(actor: RqgActor): SpiritMagicSortSibling[] {
     const ownedItems = actor.items.filter((i) => i.type === ItemTypeEnum.SpiritMagic) as RqgItem[];
     const matrixSlots = getMatrixSpellSlots(actor);
@@ -1962,7 +1954,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     await Promise.all(updatePromises);
   }
 
-  /** Finds the sibling matching `id` - shared by row lookup and drag-source lookup. */
+  /** Shared by row lookup and drag-source lookup, to avoid duplicating the match logic. */
   private static _findSpiritMagicSibling(
     id: SpiritMagicSiblingId,
     siblings: SpiritMagicSortSibling[],
@@ -1977,7 +1969,6 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         );
   }
 
-  /** Resolves a Spirit Magic row element to its sibling. */
   private static _resolveSpiritMagicSibling(
     row: HTMLElement,
     siblings: SpiritMagicSortSibling[],
@@ -1994,7 +1985,6 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     return RqgActorSheetV2._findSpiritMagicSibling(id, siblings);
   }
 
-  /** Reorders one Spirit Magic row relative to another (#1047). */
   private static async _reorderSpiritMagic(
     actor: RqgActor,
     source: SpiritMagicSiblingId,
@@ -2056,8 +2046,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     if (sameActorDrop) {
       const eventTarget = getEventTargetElement(event);
 
-      // #1047: matrix rows aren't real Items and won't match dropCell below, so Spirit Magic
-      // gets its own reorder path instead of the generic sortRelative one.
+      // Matrix rows aren't real Items and won't match dropCell below - route separately.
       if (resolvedItem.type === ItemTypeEnum.SpiritMagic) {
         const spiritMagicDropRow = eventTarget?.closest<HTMLElement>(
           ".spirit-magic-row[data-item-id]",
@@ -2560,7 +2549,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       event,
     ) as ActorSheet.DropData;
 
-    // #1047: custom payload for reordering a matrix entry - not a real Item.
+    // Not a real Item - custom payload for reordering a matrix entry.
     if ((data as { type?: string } | null)?.type === "RqgMatrixSpellSort") {
       await this._onDropMatrixSpellReorder(event, data as unknown as RqgMatrixSpellSortDragData);
       return;
@@ -2597,7 +2586,6 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     await super._onDrop(event);
   }
 
-  /** Reorders a dragged matrix entry via the custom drag payload (#1047). */
   private async _onDropMatrixSpellReorder(
     event: DragEvent,
     data: RqgMatrixSpellSortDragData,

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -130,12 +130,8 @@ type PhysicalTransferResult =
   | { kind: "failed" }
   | { kind: "cancelled" };
 
-/** One thing that can occupy a slot in the Spirit Magic tab's own-spells list (#1047): either an
- *  owned spiritMagic Item, or one entry of a Spell Matrix's `matrixSpells` array. Wraps whichever
- *  it is together with its current `sort` and `name`, so foundry.utils.performIntegerSort (a
- *  generic algorithm - it only needs objects with a `sort` property, not real Documents) can
- *  compute new positions for either kind in one shared pass; _applySpiritMagicSortUpdates then
- *  dispatches each update to wherever it actually needs to be persisted. */
+/** An owned spiritMagic Item or one matrix entry, wrapped for foundry.utils.performIntegerSort
+ *  (#1047) - see _applySpiritMagicSortUpdates. */
 type SpiritMagicSortSibling =
   | { kind: "owned"; sort: number; name: string; item: RqgItem }
   | {
@@ -146,15 +142,13 @@ type SpiritMagicSortSibling =
       entryIndex: number;
     };
 
-/** Identifies one Spirit Magic sibling (owned Item or matrix entry) without needing the resolved
- *  SpiritMagicSortSibling itself - shared shape between a drag source (_reorderSpiritMagic's
- *  `source` param) and a drop-target row's dataset (_resolveSpiritMagicSibling). See
+/** Identifies a Spirit Magic sibling without the resolved SpiritMagicSortSibling - see
  *  _findSpiritMagicSibling. */
 type SpiritMagicSiblingId =
   { kind: "owned"; itemId: string } | { kind: "matrix"; sourceItemId: string; entryIndex: number };
 
-/** Custom drag payload for reordering a Spell Matrix entry (#1047, see _onMatrixSpellDragStart) -
- *  it isn't a real embedded Item, so it can't ride Foundry's native "Item" drag/drop handling. */
+/** Custom drag payload for a Spell Matrix entry (#1047) - not a real Item, so it can't use
+ *  Foundry's native drag/drop. */
 type RqgMatrixSpellSortDragData = {
   type: "RqgMatrixSpellSort";
   actorUuid: string;
@@ -174,8 +168,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
   // Runtime override of ActorSheetV2 _dragDrop; current fvtt-types do not expose this member.
   protected get _dragDrop(): foundry.applications.ux.DragDrop.Implementation {
     this._rqgDragDrop ??= new foundry.applications.ux.DragDrop.implementation({
-      // #1047: [data-matrix-spell-drag-handle] lets a Spell Matrix entry be dragged too, even
-      // though it isn't a real embedded Item - see _onDragStart.
+      // #1047: also matches Spell Matrix drag handles (not real Items) - see _onDragStart.
       dragSelector:
         "[data-item-drag-handle][data-item-id], [data-matrix-spell-drag-handle][data-item-id]",
       // Include a non-root content drop target for generic Foundry handling.
@@ -336,11 +329,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       getMatrixSpellRows(this.actor),
       DataPrep.organizeEmbeddedItems(this.actor, incorrectRunes),
     ]);
-    // #1047: owned Spirit Magic spells and Spell Matrix entries are listed together on the Spirit
-    // Magic tab, ordered by `sort` (a shared numeric space - matrix entries carry their own `sort`
-    // precisely so they can interleave with owned items' `sort` field here). See
-    // _getSpiritMagicSortSiblings/_reorderSpiritMagic for how drag-and-drop keeps this in sync, and
-    // _sortSpiritMagicAlphabetically for what the "Sort Items alphabetically" button does to it.
+    // #1047: owned spells and matrix entries share one sort-ordered list.
     const spiritMagicRows: SpiritMagicListRow[] = [
       ...((embeddedItems[ItemTypeEnum.SpiritMagic] ?? []) as RqgItem[]).map(
         (item): SpiritMagicListRow => ({ isMatrixRow: false, sort: item.sort ?? 0, item }),
@@ -1424,10 +1413,8 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
   protected override async _onDragStart(event: DragEvent): Promise<void> {
     const eventTarget = getEventTargetElement(event);
 
-    // #1047: a Spell Matrix entry isn't a real embedded Item, so dragging it needs its own
-    // payload instead of the generic Item-drag handling below (super._onDragStart would resolve
-    // the handle's data-item-id to the *host* item - e.g. dragging "Bronze Key" itself - since
-    // that's the only real Document at that id).
+    // #1047: matrix entries aren't real Items, so they need their own drag payload (see
+    // _onMatrixSpellDragStart) instead of super._onDragStart's Item-drag handling below.
     const matrixHandle = eventTarget?.closest("[data-matrix-spell-drag-handle]");
     if (isFoundryElementInstanceOf(matrixHandle, HTMLElement)) {
       this._onMatrixSpellDragStart(event, matrixHandle);
@@ -1464,9 +1451,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     }
   }
 
-  /** Build the custom "RqgMatrixSpellSort" drag payload for a Spell Matrix entry (#1047) - it
-   *  isn't a real embedded Item, so it can't ride Foundry's native "Item" drag/drop handling. See
-   *  RqgMatrixSpellSortDragData and _onDropMatrixSpellReorder. */
+  /** Builds the custom matrix-entry drag payload (#1047) - see RqgMatrixSpellSortDragData. */
   private _onMatrixSpellDragStart(event: DragEvent, matrixHandle: HTMLElement): void {
     const sourceItemId = matrixHandle.dataset["itemId"];
     const entryIndexStr = matrixHandle.dataset["matrixSpellIndex"];
@@ -1733,11 +1718,8 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     return event.clientY < rect.top + rect.height / 2 ? "before" : "after";
   }
 
-  /** Several row wrappers across the sheet are `display: contents` (their children render as if
-   *  direct grid children - e.g. `.spirit-magic-row`, `.gear-row`, `.skill-row`), which makes their
-   *  own getBoundingClientRect() degenerate (all zero). Fall back to the first real child's rect in
-   *  that case, so drop-position math above stays correct regardless of which element - a row
-   *  wrapper or an inner cell - was passed in. */
+  /** `display: contents` rows (e.g. `.spirit-magic-row`) have a degenerate own rect - fall back
+   *  to the first real child. */
   private static _realBoundingRect(element: HTMLElement): DOMRect {
     const rect = element.getBoundingClientRect();
     if (rect.width || rect.height) {
@@ -1883,9 +1865,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       return;
     }
 
-    // #1047: the Spirit Magic tab's own-spells list mixes owned Items with Spell Matrix entries
-    // (not real embedded Items) - see spiritMagicRows/SpiritMagicSortSibling. "Sort alphabetically"
-    // needs to alphabetize both together, not just the owned Items.
+    // #1047: alphabetize owned spells and matrix entries together.
     if (itemType === ItemTypeEnum.SpiritMagic) {
       await RqgActorSheetV2._sortSpiritMagicAlphabetically(actor);
       return;
@@ -1903,9 +1883,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     await actor.updateEmbeddedDocuments("Item", updateData);
   }
 
-  /** #1047: "Sort Items alphabetically" on the Spirit Magic tab needs to alphabetize owned Items
-   *  and Spell Matrix entries together (they share one visual list - see spiritMagicRows),
-   *  assigning fresh `sort` values across both by spell name. */
+  /** Alphabetizes owned spells and matrix entries together (#1047). */
   private static async _sortSpiritMagicAlphabetically(actor: RqgActor): Promise<void> {
     const siblings = RqgActorSheetV2._getSpiritMagicSortSiblings(actor);
     const ordered = [...siblings].sort((a, b) => a.name.localeCompare(b.name));
@@ -1916,14 +1894,8 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     await RqgActorSheetV2._applySpiritMagicSortUpdates(actor, updates);
   }
 
-  /** Every owned spiritMagic Item and Spell Matrix entry the actor currently shows on the Spirit
-   *  Magic tab, wrapped for foundry.utils.performIntegerSort - a generic algorithm that only needs
-   *  objects carrying a `sort` property, not real Documents, which is exactly what lets a matrix
-   *  entry (plain data on another Item's `matrixSpells` array, not a Document of its own)
-   *  interleave with owned Items in one sequence. See SpiritMagicSortSibling. Uses
-   *  getMatrixSpellSlots rather than getMatrixSpellRows - sort math only needs each entry's
-   *  already-stored sort/name, not its resolved SpiritMagicItem, so this stays synchronous and
-   *  skips a compendium/world lookup per entry on every drag-drop and "sort alphabetically" click. */
+  /** Owned spells + matrix entries as SpiritMagicSortSiblings. Uses getMatrixSpellSlots, not
+   *  getMatrixSpellRows - sort math needs no spell resolution. */
   private static _getSpiritMagicSortSiblings(actor: RqgActor): SpiritMagicSortSibling[] {
     const ownedItems = actor.items.filter((i) => i.type === ItemTypeEnum.SpiritMagic) as RqgItem[];
     const matrixSlots = getMatrixSpellSlots(actor);
@@ -1944,11 +1916,8 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     ];
   }
 
-  /** Dispatch the updates performIntegerSort computed across a mixed owned-Item/matrix-entry
-   *  siblings list (#1047): owned items batch into one updateEmbeddedDocuments call; matrix
-   *  entries are grouped by host item first (an item can hold more than one matrix spell - e.g.
-   *  Crown's two - so each host gets one `.update()` with its full matrixSpells array, not one
-   *  call per entry, which would otherwise clobber each other). */
+  /** Dispatches performIntegerSort's updates: owned items batch into one update call; matrix
+   *  entries group by host item (one `.update()` per host, not per entry). */
   private static async _applySpiritMagicSortUpdates(
     actor: RqgActor,
     updates: { target: SpiritMagicSortSibling; update: { sort: number } }[],
@@ -1993,9 +1962,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     await Promise.all(updatePromises);
   }
 
-  /** Find the sibling identified by `id` (an owned Item's id, or a matrix entry's host item id +
-   *  entry index) - shared by _resolveSpiritMagicSibling (identifies a drop-target row) and
-   *  _reorderSpiritMagic (identifies the drag source, already in this shape). */
+  /** Finds the sibling matching `id` - shared by row lookup and drag-source lookup. */
   private static _findSpiritMagicSibling(
     id: SpiritMagicSiblingId,
     siblings: SpiritMagicSortSibling[],
@@ -2010,8 +1977,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         );
   }
 
-  /** Resolve a Spirit Magic row element (owned or matrix - see actor-sheet-v2-spirit-magic.hbs /
-   *  matrixSpellSpiritMagicRow.hbs) to its sibling in a freshly-fetched siblings list. */
+  /** Resolves a Spirit Magic row element to its sibling. */
   private static _resolveSpiritMagicSibling(
     row: HTMLElement,
     siblings: SpiritMagicSortSibling[],
@@ -2028,10 +1994,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     return RqgActorSheetV2._findSpiritMagicSibling(id, siblings);
   }
 
-  /** Reorder one Spirit Magic row (owned or matrix - #1047) relative to another, sharing one
-   *  drag-reorderable sequence across both kinds - see SpiritMagicSortSibling. `source` identifies
-   *  what's being dragged; `dropRow` is the `.spirit-magic-row[data-item-id]` element it was
-   *  dropped on/near, and `dropAction` which side of it. */
+  /** Reorders one Spirit Magic row relative to another (#1047). */
   private static async _reorderSpiritMagic(
     actor: RqgActor,
     source: SpiritMagicSiblingId,
@@ -2093,12 +2056,8 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     if (sameActorDrop) {
       const eventTarget = getEventTargetElement(event);
 
-      // #1047: a dragged Spirit Magic item needs to interleave with Spell Matrix entries (not
-      // real embedded Items - see SpiritMagicSortSibling), so it gets its own reorder path
-      // instead of the generic same-type-agnostic sortRelative below - which would otherwise
-      // (a) miss matrix rows as drop targets entirely (they don't carry the .contextmenu class
-      // dropCell below requires) and (b) sort against every actor item regardless of type,
-      // drifting out of sync with the sort space _reorderSpiritMagic maintains.
+      // #1047: matrix rows aren't real Items and won't match dropCell below, so Spirit Magic
+      // gets its own reorder path instead of the generic sortRelative one.
       if (resolvedItem.type === ItemTypeEnum.SpiritMagic) {
         const spiritMagicDropRow = eventTarget?.closest<HTMLElement>(
           ".spirit-magic-row[data-item-id]",
@@ -2601,8 +2560,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       event,
     ) as ActorSheet.DropData;
 
-    // #1047: reordering a Spell Matrix entry among the actor's own Spirit Magic spells - a custom
-    // payload type since the entry isn't a real embedded Item (see _onMatrixSpellDragStart).
+    // #1047: custom payload for reordering a matrix entry - not a real Item.
     if ((data as { type?: string } | null)?.type === "RqgMatrixSpellSort") {
       await this._onDropMatrixSpellReorder(event, data as unknown as RqgMatrixSpellSortDragData);
       return;
@@ -2639,14 +2597,13 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     await super._onDrop(event);
   }
 
-  /** Handle the custom "RqgMatrixSpellSort" payload (#1047, see _onMatrixSpellDragStart) - reorder
-   *  the dragged Spell Matrix entry relative to whichever Spirit Magic row it was dropped on. */
+  /** Reorders a dragged matrix entry via the custom drag payload (#1047). */
   private async _onDropMatrixSpellReorder(
     event: DragEvent,
     data: RqgMatrixSpellSortDragData,
   ): Promise<void> {
     if (!this.actor.isOwner || data.actorUuid !== this.actor.uuid) {
-      // Matrix entries only reorder within their own actor - no cross-actor drag support.
+      // No cross-actor reorder.
       return;
     }
     const sourceItem = this.actor.items.get(data.sourceItemId) as PhysicalItem | undefined;

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -1,4 +1,8 @@
-import type { RqgSheetHeaderControl, RqgActorSheetV2Context } from "./rqg-actor-sheet-v2.types";
+import type {
+  RqgSheetHeaderControl,
+  RqgActorSheetV2Context,
+  SpiritMagicListRow,
+} from "./rqg-actor-sheet-v2.types";
 import type { DeepPartial } from "fvtt-types/utils";
 import { ActorTypeEnum, type CharacterActor } from "../data-model/actor-data/rqg-actor-data";
 import { CharacterDataModel } from "../data-model/actor-data/character-data-model";
@@ -66,7 +70,11 @@ import {
   updateRqidLink,
 } from "../documents/drag-drop";
 import { getWeaponEffectModifier } from "../items/weapon-item/weapon-skill-links";
-import { getMatrixSpellSources, resolveMatrixSpellItem } from "../system/spell-matrix";
+import {
+  getMatrixSpellRows,
+  resolveMatrixSpellItem,
+  type MatrixSpellStorageEntry,
+} from "../system/spell-matrix";
 import type { SpiritMagicItem } from "@item-model/spirit-magic-data-model.ts";
 import type { RuneMagicItem } from "@item-model/rune-magic-data-model.ts";
 import type { CultItem } from "@item-model/cult-data-model.ts";
@@ -121,6 +129,31 @@ type PhysicalTransferResult =
   | { kind: "failed" }
   | { kind: "cancelled" };
 
+/** One thing that can occupy a slot in the Spirit Magic tab's own-spells list (#1047): either an
+ *  owned spiritMagic Item, or one entry of a Spell Matrix's `matrixSpells` array. Wraps whichever
+ *  it is together with its current `sort` and `name`, so foundry.utils.performIntegerSort (a
+ *  generic algorithm - it only needs objects with a `sort` property, not real Documents) can
+ *  compute new positions for either kind in one shared pass; _applySpiritMagicSortUpdates then
+ *  dispatches each update to wherever it actually needs to be persisted. */
+type SpiritMagicSortSibling =
+  | { kind: "owned"; sort: number; name: string; item: RqgItem }
+  | {
+      kind: "matrix";
+      sort: number;
+      name: string;
+      sourceItem: PhysicalItem;
+      entryIndex: number;
+    };
+
+/** Custom drag payload for reordering a Spell Matrix entry (#1047, see _onMatrixSpellDragStart) -
+ *  it isn't a real embedded Item, so it can't ride Foundry's native "Item" drag/drop handling. */
+type RqgMatrixSpellSortDragData = {
+  type: "RqgMatrixSpellSort";
+  actorUuid: string;
+  sourceItemId: string;
+  entryIndex: number;
+};
+
 export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
   #skillFilterQuery = "";
 
@@ -133,7 +166,10 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
   // Runtime override of ActorSheetV2 _dragDrop; current fvtt-types do not expose this member.
   protected get _dragDrop(): foundry.applications.ux.DragDrop.Implementation {
     this._rqgDragDrop ??= new foundry.applications.ux.DragDrop.implementation({
-      dragSelector: "[data-item-drag-handle][data-item-id]",
+      // #1047: [data-matrix-spell-drag-handle] lets a Spell Matrix entry be dragged too, even
+      // though it isn't a real embedded Item - see _onDragStart.
+      dragSelector:
+        "[data-item-drag-handle][data-item-id], [data-matrix-spell-drag-handle][data-item-id]",
       // Include a non-root content drop target for generic Foundry handling.
       // Do not include the root selector here: if html.matches(dropSelector),
       // Foundry binds only the root and skips descendant dropzones.
@@ -285,13 +321,32 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     const externalSpiritMagic = getExternalSpiritMagicItems(this.actor, alliedBondActor);
     // #999: Spirit Magic spells known by each bound spirit, one group per spirit.
     const boundSpiritSpiritMagic = getBoundSpiritSpiritMagicItems(this.actor, boundSpiritItems);
-    // #959: Spirit Magic spells enchanted into the actor's own Spell Matrix items, one group per
-    // item - see getMatrixSpellSources.
+    // #959: Spirit Magic spells enchanted into the actor's own Spell Matrix items - see
+    // getMatrixSpellRows.
     const incorrectRunes: RqgItem[] = [];
-    const [matrixSpellSources, embeddedItems] = await Promise.all([
-      getMatrixSpellSources(this.actor),
+    const [matrixSpellRows, embeddedItems] = await Promise.all([
+      getMatrixSpellRows(this.actor),
       DataPrep.organizeEmbeddedItems(this.actor, incorrectRunes),
     ]);
+    // #1047: owned Spirit Magic spells and Spell Matrix entries are listed together on the Spirit
+    // Magic tab, ordered by `sort` (a shared numeric space - matrix entries carry their own `sort`
+    // precisely so they can interleave with owned items' `sort` field here). See
+    // _getSpiritMagicSortSiblings/_reorderSpiritMagic for how drag-and-drop keeps this in sync, and
+    // _sortSpiritMagicAlphabetically for what the "Sort Items alphabetically" button does to it.
+    const spiritMagicRows: SpiritMagicListRow[] = [
+      ...((embeddedItems[ItemTypeEnum.SpiritMagic] ?? []) as RqgItem[]).map(
+        (item): SpiritMagicListRow => ({ isMatrixRow: false, sort: item.sort ?? 0, item }),
+      ),
+      ...matrixSpellRows.map((row): SpiritMagicListRow => ({
+        isMatrixRow: true,
+        sort: row.sort,
+        item: row.item,
+        entryIndex: row.entryIndex,
+        sourceItemId: row.sourceItem.id ?? "",
+        sourceItemName: row.sourceItem.name ?? "",
+        sourceItemImg: row.sourceItem.img ?? "",
+      })),
+    ].sort((a, b) => a.sort - b.sort);
     const itemTree = new ItemTree(this.actor.items.contents);
     const uniqueGearItems = ((embeddedItems[ItemTypeEnum.Gear] ?? []) as GearItem[])
       .filter((item) => foundry.utils.getProperty(item, "system.physicalItemType") === "unique")
@@ -443,12 +498,7 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         sourceItemImg: sourceItem.img ?? "",
         items,
       })),
-      matrixSpellSources: matrixSpellSources.map(({ sourceItem, entries }) => ({
-        sourceItemId: sourceItem.id ?? "",
-        sourceItemName: sourceItem.name ?? "",
-        sourceItemImg: sourceItem.img ?? "",
-        entries,
-      })),
+      spiritMagicRows: spiritMagicRows,
 
       enrichedBiography: await foundry.applications.ux.TextEditor.implementation.enrichHTML(
         system.background.biography ?? "",
@@ -1364,9 +1414,20 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
   }
 
   protected override async _onDragStart(event: DragEvent): Promise<void> {
+    const eventTarget = getEventTargetElement(event);
+
+    // #1047: a Spell Matrix entry isn't a real embedded Item, so dragging it needs its own
+    // payload instead of the generic Item-drag handling below (super._onDragStart would resolve
+    // the handle's data-item-id to the *host* item - e.g. dragging "Bronze Key" itself - since
+    // that's the only real Document at that id).
+    const matrixHandle = eventTarget?.closest("[data-matrix-spell-drag-handle]");
+    if (isFoundryElementInstanceOf(matrixHandle, HTMLElement)) {
+      this._onMatrixSpellDragStart(event, matrixHandle);
+      return;
+    }
+
     await super._onDragStart(event);
 
-    const eventTarget = getEventTargetElement(event);
     const dragHandle = eventTarget?.closest("[data-item-drag-handle], [data-weapon-drag-handle]");
     if (!isFoundryElementInstanceOf(dragHandle, HTMLElement)) {
       return;
@@ -1390,6 +1451,35 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     if (item.img) {
       const iconElement = itemContainer.querySelector<HTMLImageElement>("img[data-item-id], img");
       const imgSrc = iconElement?.currentSrc || iconElement?.src || item.img;
+      this._activeDragPreview = this._buildDragPreview(imgSrc);
+      event.dataTransfer.setDragImage(this._activeDragPreview, 18, 18);
+    }
+  }
+
+  /** Build the custom "RqgMatrixSpellSort" drag payload for a Spell Matrix entry (#1047) - it
+   *  isn't a real embedded Item, so it can't ride Foundry's native "Item" drag/drop handling. See
+   *  RqgMatrixSpellSortDragData and _onDropMatrixSpellReorder. */
+  private _onMatrixSpellDragStart(event: DragEvent, matrixHandle: HTMLElement): void {
+    const sourceItemId = matrixHandle.dataset["itemId"];
+    const entryIndexStr = matrixHandle.dataset["matrixSpellIndex"];
+    if (!sourceItemId || entryIndexStr === undefined || !event.dataTransfer) {
+      return;
+    }
+    const dragData: RqgMatrixSpellSortDragData = {
+      type: "RqgMatrixSpellSort",
+      actorUuid: this.actor.uuid ?? "",
+      sourceItemId,
+      entryIndex: Number(entryIndexStr),
+    };
+    event.dataTransfer.setData("text/plain", JSON.stringify(dragData));
+
+    // Suppress sheet-level glow for same-actor reorders; clear when the drag operation ends.
+    this._isSameActorDrag = true;
+
+    const itemContainer = matrixHandle.closest("[data-item-id]");
+    const iconElement = itemContainer?.querySelector<HTMLImageElement>("img.row-icon, img");
+    const imgSrc = iconElement?.currentSrc || iconElement?.src;
+    if (imgSrc) {
       this._activeDragPreview = this._buildDragPreview(imgSrc);
       event.dataTransfer.setDragImage(this._activeDragPreview, 18, 18);
     }
@@ -1772,6 +1862,14 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       return;
     }
 
+    // #1047: the Spirit Magic tab's own-spells list mixes owned Items with Spell Matrix entries
+    // (not real embedded Items) - see spiritMagicRows/SpiritMagicSortSibling. "Sort alphabetically"
+    // needs to alphabetize both together, not just the owned Items.
+    if (itemType === ItemTypeEnum.SpiritMagic) {
+      await RqgActorSheetV2._sortSpiritMagicAlphabetically(actor);
+      return;
+    }
+
     const itemsToSort = actor.items.filter((i) => i.type === itemType) as RqgItem[];
     itemsToSort.sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
     itemsToSort.forEach((item, index) => {
@@ -1782,6 +1880,160 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
     });
     const updateData = itemsToSort.map((item) => ({ _id: item.id, sort: item.sort }));
     await actor.updateEmbeddedDocuments("Item", updateData);
+  }
+
+  /** #1047: "Sort Items alphabetically" on the Spirit Magic tab needs to alphabetize owned Items
+   *  and Spell Matrix entries together (they share one visual list - see spiritMagicRows),
+   *  assigning fresh `sort` values across both by spell name. */
+  private static async _sortSpiritMagicAlphabetically(actor: RqgActor): Promise<void> {
+    const siblings = await RqgActorSheetV2._getSpiritMagicSortSiblings(actor);
+    const ordered = [...siblings].sort((a, b) => a.name.localeCompare(b.name));
+    const updates = ordered.map((sibling, index) => ({
+      target: sibling,
+      update: { sort: (index + 1) * CONST.SORT_INTEGER_DENSITY },
+    }));
+    await RqgActorSheetV2._applySpiritMagicSortUpdates(actor, updates);
+  }
+
+  /** Every owned spiritMagic Item and Spell Matrix entry the actor currently shows on the Spirit
+   *  Magic tab, wrapped for foundry.utils.performIntegerSort - a generic algorithm that only needs
+   *  objects carrying a `sort` property, not real Documents, which is exactly what lets a matrix
+   *  entry (plain data on another Item's `matrixSpells` array, not a Document of its own)
+   *  interleave with owned Items in one sequence. See SpiritMagicSortSibling. */
+  private static async _getSpiritMagicSortSiblings(
+    actor: RqgActor,
+  ): Promise<SpiritMagicSortSibling[]> {
+    const ownedItems = actor.items.filter((i) => i.type === ItemTypeEnum.SpiritMagic) as RqgItem[];
+    const matrixRows = await getMatrixSpellRows(actor);
+    return [
+      ...ownedItems.map((item): SpiritMagicSortSibling => ({
+        kind: "owned",
+        sort: item.sort ?? 0,
+        name: item.name ?? "",
+        item,
+      })),
+      ...matrixRows.map((row): SpiritMagicSortSibling => ({
+        kind: "matrix",
+        sort: row.sort,
+        name: row.item.name ?? "",
+        sourceItem: row.sourceItem,
+        entryIndex: row.entryIndex,
+      })),
+    ];
+  }
+
+  /** Dispatch the updates performIntegerSort computed across a mixed owned-Item/matrix-entry
+   *  siblings list (#1047): owned items batch into one updateEmbeddedDocuments call; matrix
+   *  entries are grouped by host item first (an item can hold more than one matrix spell - e.g.
+   *  Crown's two - so each host gets one `.update()` with its full matrixSpells array, not one
+   *  call per entry, which would otherwise clobber each other). */
+  private static async _applySpiritMagicSortUpdates(
+    actor: RqgActor,
+    updates: { target: SpiritMagicSortSibling; update: { sort: number } }[],
+  ): Promise<void> {
+    const itemUpdates: { _id: string; sort: number }[] = [];
+    const matrixSpellsByHost = new Map<string, MatrixSpellStorageEntry[]>();
+
+    for (const { target, update } of updates) {
+      if (target.kind === "owned") {
+        if (target.item.id) {
+          itemUpdates.push({ _id: target.item.id, sort: update.sort });
+        }
+        continue;
+      }
+      const hostId = target.sourceItem.id;
+      if (!hostId) {
+        continue;
+      }
+      let matrixSpells = matrixSpellsByHost.get(hostId);
+      if (!matrixSpells) {
+        matrixSpells = foundry.utils.deepClone(
+          target.sourceItem.system.matrixSpells ?? [],
+        ) as MatrixSpellStorageEntry[];
+        matrixSpellsByHost.set(hostId, matrixSpells);
+      }
+      const entry = matrixSpells[target.entryIndex];
+      if (entry) {
+        matrixSpells[target.entryIndex] = { ...entry, sort: update.sort };
+      }
+    }
+
+    const updatePromises: Promise<unknown>[] = [];
+    if (itemUpdates.length) {
+      updatePromises.push(actor.updateEmbeddedDocuments("Item", itemUpdates));
+    }
+    for (const [hostId, matrixSpells] of matrixSpellsByHost) {
+      const hostItem = actor.items.get(hostId);
+      if (hostItem) {
+        updatePromises.push(hostItem.update({ system: { matrixSpells } }));
+      }
+    }
+    await Promise.all(updatePromises);
+  }
+
+  /** `.spirit-magic-row` is `display: contents` (its children render as if they were direct
+   *  children of the grid - see actorsheet-v2.css), so it generates no box of its own:
+   *  getBoundingClientRect() on it is degenerate (all zero). _getSameActorDropAction needs a real
+   *  rendered element to compare the drop's clientY against, so give it the row's first real
+   *  child instead of the row itself. */
+  private static _spiritMagicDropRectElement(row: HTMLElement): HTMLElement {
+    return (row.firstElementChild as HTMLElement | null) ?? row;
+  }
+
+  /** Resolve a Spirit Magic row element (owned or matrix - see actor-sheet-v2-spirit-magic.hbs /
+   *  matrixSpellSpiritMagicRow.hbs) to its sibling in a freshly-fetched siblings list. */
+  private static _resolveSpiritMagicSibling(
+    row: HTMLElement,
+    siblings: SpiritMagicSortSibling[],
+  ): SpiritMagicSortSibling | undefined {
+    const itemId = row.dataset["itemId"];
+    if (!itemId) {
+      return undefined;
+    }
+    const matrixIndexStr = row.dataset["matrixSpellRowIndex"];
+    if (matrixIndexStr !== undefined) {
+      const entryIndex = Number(matrixIndexStr);
+      return siblings.find(
+        (s) => s.kind === "matrix" && s.sourceItem.id === itemId && s.entryIndex === entryIndex,
+      );
+    }
+    return siblings.find((s) => s.kind === "owned" && s.item.id === itemId);
+  }
+
+  /** Reorder one Spirit Magic row (owned or matrix - #1047) relative to another, sharing one
+   *  drag-reorderable sequence across both kinds - see SpiritMagicSortSibling. `source` identifies
+   *  what's being dragged; `dropRow` is the `.spirit-magic-row[data-item-id]` element it was
+   *  dropped on/near, and `dropAction` which side of it. */
+  private static async _reorderSpiritMagic(
+    actor: RqgActor,
+    source:
+      | { kind: "owned"; itemId: string }
+      | { kind: "matrix"; sourceItemId: string; entryIndex: number },
+    dropRow: HTMLElement,
+    dropAction: "before" | "after",
+  ): Promise<void> {
+    const siblings = await RqgActorSheetV2._getSpiritMagicSortSiblings(actor);
+    const resolvedSource =
+      source.kind === "owned"
+        ? siblings.find((s) => s.kind === "owned" && s.item.id === source.itemId)
+        : siblings.find(
+            (s) =>
+              s.kind === "matrix" &&
+              s.sourceItem.id === source.sourceItemId &&
+              s.entryIndex === source.entryIndex,
+          );
+    const target = RqgActorSheetV2._resolveSpiritMagicSibling(dropRow, siblings);
+    if (!resolvedSource || !target || target === resolvedSource) {
+      return;
+    }
+
+    const updates = foundry.utils.performIntegerSort(resolvedSource, {
+      target,
+      siblings: siblings.filter((s) => s !== resolvedSource),
+      sortBefore: dropAction === "before",
+    }) as { target: SpiritMagicSortSibling; update: { sort: number } }[];
+
+    await RqgActorSheetV2._applySpiritMagicSortUpdates(actor, updates);
   }
 
   protected override async _onDropItem(event: DragEvent, item: RqgItem): Promise<RqgItem | null> {
@@ -1821,8 +2073,37 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
 
     // Same actor drop — sort/reorder within this actor.
     if (sameActorDrop) {
-      // Try to determine drag context for position-aware sorting
       const eventTarget = getEventTargetElement(event);
+
+      // #1047: a dragged Spirit Magic item needs to interleave with Spell Matrix entries (not
+      // real embedded Items - see SpiritMagicSortSibling), so it gets its own reorder path
+      // instead of the generic same-type-agnostic sortRelative below - which would otherwise
+      // (a) miss matrix rows as drop targets entirely (they don't carry the .contextmenu class
+      // dropCell below requires) and (b) sort against every actor item regardless of type,
+      // drifting out of sync with the sort space _reorderSpiritMagic maintains.
+      if (resolvedItem.type === ItemTypeEnum.SpiritMagic) {
+        const spiritMagicDropRow = eventTarget?.closest<HTMLElement>(
+          ".spirit-magic-row[data-item-id]",
+        );
+        if (spiritMagicDropRow) {
+          const dropAction = this._getSameActorDropAction(
+            event,
+            RqgActorSheetV2._spiritMagicDropRectElement(spiritMagicDropRow),
+            null,
+          );
+          if (dropAction === "before" || dropAction === "after") {
+            await RqgActorSheetV2._reorderSpiritMagic(
+              this.actor,
+              { kind: "owned", itemId: resolvedItem.id ?? "" },
+              spiritMagicDropRow,
+              dropAction,
+            );
+          }
+          return resolvedItem;
+        }
+      }
+
+      // Try to determine drag context for position-aware sorting
       const dropCell =
         eventTarget?.closest<HTMLElement>(".location-row[data-item-id]") ??
         eventTarget?.closest<HTMLElement>(".contextmenu.item[data-item-id]");
@@ -2306,6 +2587,13 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       event,
     ) as ActorSheet.DropData;
 
+    // #1047: reordering a Spell Matrix entry among the actor's own Spirit Magic spells - a custom
+    // payload type since the entry isn't a real embedded Item (see _onMatrixSpellDragStart).
+    if ((data as { type?: string } | null)?.type === "RqgMatrixSpellSort") {
+      await this._onDropMatrixSpellReorder(event, data as unknown as RqgMatrixSpellSortDragData);
+      return;
+    }
+
     // Handle compendium drops specially to embed all items from the pack
     if (data?.type === "Compendium") {
       if (!this.actor.isOwner) {
@@ -2335,6 +2623,44 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
 
     // For all other types, delegate to parent
     await super._onDrop(event);
+  }
+
+  /** Handle the custom "RqgMatrixSpellSort" payload (#1047, see _onMatrixSpellDragStart) - reorder
+   *  the dragged Spell Matrix entry relative to whichever Spirit Magic row it was dropped on. */
+  private async _onDropMatrixSpellReorder(
+    event: DragEvent,
+    data: RqgMatrixSpellSortDragData,
+  ): Promise<void> {
+    if (!this.actor.isOwner || data.actorUuid !== this.actor.uuid) {
+      // Matrix entries only reorder within their own actor - no cross-actor drag support.
+      return;
+    }
+    const sourceItem = this.actor.items.get(data.sourceItemId) as PhysicalItem | undefined;
+    if (!sourceItem) {
+      return;
+    }
+
+    const eventTarget = getEventTargetElement(event);
+    const dropRow = eventTarget?.closest<HTMLElement>(".spirit-magic-row[data-item-id]");
+    if (!isFoundryElementInstanceOf(dropRow, HTMLElement)) {
+      return;
+    }
+
+    const dropAction = this._getSameActorDropAction(
+      event,
+      RqgActorSheetV2._spiritMagicDropRectElement(dropRow),
+      null,
+    );
+    if (dropAction !== "before" && dropAction !== "after") {
+      return;
+    }
+
+    await RqgActorSheetV2._reorderSpiritMagic(
+      this.actor,
+      { kind: "matrix", sourceItemId: sourceItem.id ?? "", entryIndex: data.entryIndex },
+      dropRow,
+      dropAction,
+    );
   }
 
   /**

--- a/src/actors/rqg-actor-sheet-v2.types.ts
+++ b/src/actors/rqg-actor-sheet-v2.types.ts
@@ -14,6 +14,20 @@ export type RqgSheetHeaderControl = foundry.applications.api.ApplicationV2.Heade
   onClick?: () => Promise<void> | void;
 };
 
+/** One row of the Spirit Magic tab's own-spells list - see RqgActorSheetV2Context.spiritMagicRows. */
+export type SpiritMagicListRow =
+  | { isMatrixRow: false; sort: number; item: RqgItem }
+  | {
+      isMatrixRow: true;
+      sort: number;
+      item: RqgItem;
+      /** Which entry on sourceItemId's system.matrixSpells this is - see getMatrixSpellRows. */
+      entryIndex: number;
+      sourceItemId: string;
+      sourceItemName: string;
+      sourceItemImg: string;
+    };
+
 /**
  * Context passed to all V2 actor sheet parts.
  */
@@ -130,14 +144,13 @@ export interface RqgActorSheetV2Context {
     sourceItemImg: string;
     items: RqgItem[];
   }[];
-  /** Spirit Magic spells enchanted into this actor's own Spell Matrix items (#959), one group per
-   *  item (an item can hold more than one matrix spell) - see getMatrixSpellSources. */
-  matrixSpellSources: {
-    sourceItemId: string;
-    sourceItemName: string;
-    sourceItemImg: string;
-    entries: { entryIndex: number; item: RqgItem }[];
-  }[];
+  /** One row on the Spirit Magic tab's own-spells list (#1047): either an owned spiritMagic Item,
+   *  or a spell enchanted into one of the actor's equipped Spell Matrix items (#959, resolved live
+   *  - see getMatrixSpellRows). Both kinds share one `sort`-ordered list and one drag-reorderable
+   *  sequence (RqgActorSheetV2._getSpiritMagicSortSiblings/_reorderSpiritMagic) - the matrix kind
+   *  just carries extra fields identifying which matrix entry it came from, and renders with a
+   *  small source-item badge (matrixSpellSpiritMagicRow.hbs) instead of the owned-row markup. */
+  spiritMagicRows: SpiritMagicListRow[];
 
   /** Enriched biography HTML. */
   enrichedBiography: string;

--- a/src/actors/rqg-actor-sheet-v2.types.ts
+++ b/src/actors/rqg-actor-sheet-v2.types.ts
@@ -144,8 +144,7 @@ export interface RqgActorSheetV2Context {
     sourceItemImg: string;
     items: RqgItem[];
   }[];
-  /** The Spirit Magic tab's own-spells list (#1047) - owned Items and matrix entries, one
-   *  sort-ordered list. See SpiritMagicListRow. */
+  /** The Spirit Magic tab's own-spells list - see SpiritMagicListRow. */
   spiritMagicRows: SpiritMagicListRow[];
 
   /** Enriched biography HTML. */

--- a/src/actors/rqg-actor-sheet-v2.types.ts
+++ b/src/actors/rqg-actor-sheet-v2.types.ts
@@ -144,12 +144,8 @@ export interface RqgActorSheetV2Context {
     sourceItemImg: string;
     items: RqgItem[];
   }[];
-  /** One row on the Spirit Magic tab's own-spells list (#1047): either an owned spiritMagic Item,
-   *  or a spell enchanted into one of the actor's equipped Spell Matrix items (#959, resolved live
-   *  - see getMatrixSpellRows). Both kinds share one `sort`-ordered list and one drag-reorderable
-   *  sequence (RqgActorSheetV2._getSpiritMagicSortSiblings/_reorderSpiritMagic) - the matrix kind
-   *  just carries extra fields identifying which matrix entry it came from, and renders with a
-   *  small source-item badge (matrixSpellSpiritMagicRow.hbs) instead of the owned-row markup. */
+  /** The Spirit Magic tab's own-spells list (#1047) - owned Items and matrix entries, one
+   *  sort-ordered list. See SpiritMagicListRow. */
   spiritMagicRows: SpiritMagicListRow[];
 
   /** Enriched biography HTML. */

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
@@ -30,7 +30,7 @@
       <div class="head3">{{localize "RQG.Actor.SpiritMagic.SpellSummary"}}</div>
        <div class="head4">{{localize "RQG.Actor.SpiritMagic.SpellFocus"}}</div>
 
-    {{!-- Own spells + matrix entries, interleaved by sort (#1047, see spiritMagicRows). --}}
+    {{!-- Own spells + matrix entries, interleaved by sort. --}}
     {{#each spiritMagicRows}}
       {{#if isMatrixRow}}
         {{> matrixSpellSpiritMagicRow item=item sourceItemId=sourceItemId entryIndex=entryIndex

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
@@ -30,40 +30,49 @@
       <div class="head3">{{localize "RQG.Actor.SpiritMagic.SpellSummary"}}</div>
        <div class="head4">{{localize "RQG.Actor.SpiritMagic.SpellFocus"}}</div>
 
-    {{#each embeddedItems.spiritMagic}}
-    <div class="spirit-magic-row">
-       <div class="spirit-magic contextmenu item"
-         data-item-id="{{id}}"
-         {{#if system.descriptionRqidLink.rqid}}data-rqid-link="{{system.descriptionRqidLink.rqid}}"{{/if}}>
-         {{#if @root.isGM}}<span class="item-drag-handle item draggable" data-item-drag-handle data-item-id="{{id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{img}}">
-      </div>
-      <div class="spirit-magic contextmenu item"
-           data-item-id="{{id}}"
-           data-spirit-magic-roll
-           data-tooltip="{{localize 'RQG.Game.RollTitle'}}">
-        {{name}}{{#if system.isMatrix}} {{localize "RQG.Item.SpiritMagic.MatrixIndicator"}}{{/if}}
-      </div>
-      {{#if (and system.isVariable ../system.editMode)}}
-        <div class="spirit-magic contextmenu item"
-             data-item-id="{{id}}"
-             data-tooltip="{{spellSummaryTooltip}}">
-          <input type="number" class="spirit-magic-points-input" min="0" step="1"
-                 data-item-edit-value="system.points" data-item-id="{{id}}" value="{{system.points}}">
-          {{#if (eq system.points 1)}}{{localize "RQG.Item.Spell.Point"}}{{else}}{{localize "RQG.Item.Spell.Points"}}{{/if}}
-          {{localize "RQG.Item.SpiritMagic.Variable"}}{{#if spellSummaryRest}}, {{spellSummaryRest}}{{/if}}
-        </div>
+    {{!-- Spirit Magic tab own-spells list (#1047): owned spiritMagic Items and Spell Matrix
+         entries (#959, resolved live - see getMatrixSpellRows) interleaved by `sort`, one shared
+         drag-reorderable sequence rather than matrix spells grouped separately under their item -
+         see spiritMagicRows/_reorderSpiritMagic (rqg-actor-sheet-v2.ts). --}}
+    {{#each spiritMagicRows}}
+      {{#if isMatrixRow}}
+        {{> matrixSpellSpiritMagicRow item=item sourceItemId=sourceItemId entryIndex=entryIndex
+            sourceItemName=sourceItemName sourceItemImg=sourceItemImg}}
       {{else}}
-        <div class="spirit-magic contextmenu item"
-             data-item-id="{{id}}"
-           data-tooltip="{{spellSummaryTooltip}}"
-             data-spirit-magic-roll>
-          {{spellSummary}}
+      <div class="spirit-magic-row" data-item-id="{{item.id}}">
+         <div class="spirit-magic contextmenu item"
+           data-item-id="{{item.id}}"
+           {{#if item.system.descriptionRqidLink.rqid}}data-rqid-link="{{item.system.descriptionRqidLink.rqid}}"{{/if}}>
+           {{#if @root.isGM}}<span class="item-drag-handle item draggable" data-item-drag-handle data-item-id="{{item.id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{item.img}}">
         </div>
-      {{/if}}
-      <div class="spirit-magic contextmenu item" data-item-id="{{id}}">
-        <input type="text" data-item-edit-value="system.spellFocus" data-item-id="{{id}}" value="{{system.spellFocus}}" placeholder="—">
+        <div class="spirit-magic contextmenu item"
+             data-item-id="{{item.id}}"
+             data-spirit-magic-roll
+             data-tooltip="{{localize 'RQG.Game.RollTitle'}}">
+          {{item.name}}{{#if item.system.isMatrix}} {{localize "RQG.Item.SpiritMagic.MatrixIndicator"}}{{/if}}
+        </div>
+        {{#if (and item.system.isVariable ../system.editMode)}}
+          <div class="spirit-magic contextmenu item"
+               data-item-id="{{item.id}}"
+               data-tooltip="{{item.spellSummaryTooltip}}">
+            <input type="number" class="spirit-magic-points-input" min="0" step="1"
+                   data-item-edit-value="system.points" data-item-id="{{item.id}}" value="{{item.system.points}}">
+            {{#if (eq item.system.points 1)}}{{localize "RQG.Item.Spell.Point"}}{{else}}{{localize "RQG.Item.Spell.Points"}}{{/if}}
+            {{localize "RQG.Item.SpiritMagic.Variable"}}{{#if item.spellSummaryRest}}, {{item.spellSummaryRest}}{{/if}}
+          </div>
+        {{else}}
+          <div class="spirit-magic contextmenu item"
+               data-item-id="{{item.id}}"
+             data-tooltip="{{item.spellSummaryTooltip}}"
+               data-spirit-magic-roll>
+            {{item.spellSummary}}
+          </div>
+        {{/if}}
+        <div class="spirit-magic contextmenu item" data-item-id="{{item.id}}">
+          <input type="text" data-item-edit-value="system.spellFocus" data-item-id="{{item.id}}" value="{{item.system.spellFocus}}" placeholder="—">
+        </div>
       </div>
-    </div>
+      {{/if}}
     {{/each}}
 
     {{#if externalSpiritMagic.length}}
@@ -81,15 +90,6 @@
           name=sourceActor.name img=sourceActor.img itemName=sourceItemName itemImg=sourceItemImg}}
       {{#each items}}
         {{> spiritMagicExternalRow item=this ownerUuid=../sourceActor.uuid}}
-      {{/each}}
-    {{/each}}
-
-    {{!-- Spell Matrix Enchantments (#959): one "Matrix: [img] {itemName}" group per enchanted item. --}}
-    {{#each matrixSpellSources}}
-      {{> externalSpellDivider labelKey="RQG.Actor.SpiritMagic.MatrixFromLabel"
-          name=sourceItemName img=sourceItemImg}}
-      {{#each entries}}
-        {{> matrixSpellSpiritMagicRow item=item sourceItemId=../sourceItemId entryIndex=entryIndex}}
       {{/each}}
     {{/each}}
   </div>

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
@@ -30,10 +30,7 @@
       <div class="head3">{{localize "RQG.Actor.SpiritMagic.SpellSummary"}}</div>
        <div class="head4">{{localize "RQG.Actor.SpiritMagic.SpellFocus"}}</div>
 
-    {{!-- Spirit Magic tab own-spells list (#1047): owned spiritMagic Items and Spell Matrix
-         entries (#959, resolved live - see getMatrixSpellRows) interleaved by `sort`, one shared
-         drag-reorderable sequence rather than matrix spells grouped separately under their item -
-         see spiritMagicRows/_reorderSpiritMagic (rqg-actor-sheet-v2.ts). --}}
+    {{!-- Own spells + matrix entries, interleaved by sort (#1047, see spiritMagicRows). --}}
     {{#each spiritMagicRows}}
       {{#if isMatrixRow}}
         {{> matrixSpellSpiritMagicRow item=item sourceItemId=sourceItemId entryIndex=entryIndex

--- a/src/actors/sheet-parts-v2/matrix-spell-spirit-magic-row.hbs
+++ b/src/actors/sheet-parts-v2/matrix-spell-spirit-magic-row.hbs
@@ -1,27 +1,13 @@
-{{!-- Partial: one Spirit Magic spell row for a spell enchanted into one of this actor's own,
-     equipped Spell Matrix items (#959) - listed as an ordinary row among the actor's own known
-     spells (#1047), sharing one `sort`-ordered, drag-reorderable list with them (see
-     spiritMagicRows, rqg-actor-sheet-v2.ts) rather than grouped under a "Matrix: ..." divider by
-     item. `item` isn't an actual embedded/owned Item - it's resolved live from the matrix item's
-     rqid on each click, so this uses data-matrix-spell-cast + the matrix item's own id rather than
-     data-spirit-magic-roll/data-external-owner-uuid. It deliberately omits the "contextmenu" class
-     other Spirit Magic rows use: the shared spiritMagicMenuOptions context menu resolves its
-     target via resolveCastItem's actor.items.get(data-item-id), which here would return the
-     physical matrix item (sourceItemId), not a SpiritMagicItem - so it isn't wired up for this row.
-     A small badge on the name (sourceItemName/sourceItemImg) marks it as matrix-derived, since
-     there's no divider to say so any more. The drag handle carries data-matrix-spell-drag-handle
-     (not data-item-drag-handle - sourceItemId isn't this spell's own id, so the generic Item-drag
-     handling in RqgActorSheetV2._onDragStart would resolve the wrong document) so
-     _onDragStart/_onDrop can reorder it alongside owned spiritMagic Items via a custom drag
-     payload - see _reorderSpiritMagic.
+{{!-- Row for a Spell Matrix entry (#959, #1047) - `item` isn't a real embedded Item, it's
+     resolved live from the matrix item's rqid, so this uses data-matrix-spell-cast/
+     data-matrix-spell-drag-handle instead of the native equivalents, and omits "contextmenu"
+     (the shared context menu would resolve the wrong document via data-item-id). Badge marks it
+     as matrix-derived.
 
-     Params: item (the resolved transient spell), sourceItemId (the matrix item's id), entryIndex
-     (which matrixSpells array entry on that item this spell came from - an item can hold more than
-     one, see resolveMatrixSpellItem), sourceItemName, sourceItemImg. --}}
+     Params: item, sourceItemId (matrix item's id), entryIndex, sourceItemName, sourceItemImg. --}}
 <div class="spirit-magic-row" data-item-id="{{sourceItemId}}" data-matrix-spell-row-index="{{entryIndex}}">
   <div class="spirit-magic item">
-    {{!-- GM-only, matching every other drag handle in this list today (#1048 tracks lifting that
-         to @root.isEditable sheet-wide; this row should follow once that lands). --}}
+    {{!-- GM-only, matching the rest of the list (#1048 lifts this sheet-wide). --}}
     {{#if @root.isGM}}
       <span class="item-drag-handle item draggable"
             data-matrix-spell-drag-handle

--- a/src/actors/sheet-parts-v2/matrix-spell-spirit-magic-row.hbs
+++ b/src/actors/sheet-parts-v2/matrix-spell-spirit-magic-row.hbs
@@ -1,17 +1,31 @@
-{{!-- Partial: one Spirit Magic spell row for a spell enchanted into one of this actor's own
-     Spell Matrix items (#959). Unlike spiritMagicExternalRow.hbs, `item` isn't an actual
-     embedded/owned Item - it's resolved live from the matrix item's rqid on each click, so this
-     uses data-matrix-spell-cast + the matrix item's own id (see rqg-actor-sheet-v2.ts) rather than
+{{!-- Partial: one Spirit Magic spell row for a spell enchanted into one of this actor's own,
+     equipped Spell Matrix items (#959) - listed as an ordinary row among the actor's own known
+     spells (#1047), sharing one `sort`-ordered, drag-reorderable list with them (see
+     spiritMagicRows, rqg-actor-sheet-v2.ts) rather than grouped under a "Matrix: ..." divider by
+     item. `item` isn't an actual embedded/owned Item - it's resolved live from the matrix item's
+     rqid on each click, so this uses data-matrix-spell-cast + the matrix item's own id rather than
      data-spirit-magic-roll/data-external-owner-uuid. It deliberately omits the "contextmenu" class
      other Spirit Magic rows use: the shared spiritMagicMenuOptions context menu resolves its
      target via resolveCastItem's actor.items.get(data-item-id), which here would return the
      physical matrix item (sourceItemId), not a SpiritMagicItem - so it isn't wired up for this row.
+     A small badge on the name (sourceItemName/sourceItemImg) marks it as matrix-derived, since
+     there's no divider to say so any more. The drag handle carries data-matrix-spell-drag-handle
+     (not data-item-drag-handle - sourceItemId isn't this spell's own id, so the generic Item-drag
+     handling in RqgActorSheetV2._onDragStart would resolve the wrong document) so
+     _onDragStart/_onDrop can reorder it alongside owned spiritMagic Items via a custom drag
+     payload - see _reorderSpiritMagic.
 
-     Params: item (the resolved transient spell), sourceItemId (the matrix item's id),
-     entryIndex (which matrixSpells array entry on that item this spell came from - an item can
-     hold more than one, see resolveMatrixSpellItem). --}}
-<div class="spirit-magic-row external-item">
+     Params: item (the resolved transient spell), sourceItemId (the matrix item's id), entryIndex
+     (which matrixSpells array entry on that item this spell came from - an item can hold more than
+     one, see resolveMatrixSpellItem), sourceItemName, sourceItemImg. --}}
+<div class="spirit-magic-row" data-item-id="{{sourceItemId}}" data-matrix-spell-row-index="{{entryIndex}}">
   <div class="spirit-magic item">
+    {{#if @root.isEditable}}
+      <span class="item-drag-handle item draggable"
+            data-matrix-spell-drag-handle
+            data-item-id="{{sourceItemId}}"
+            data-matrix-spell-index="{{entryIndex}}"><span class="grip-icon"></span></span>
+    {{/if}}
     <img class="row-icon" src="{{item.img}}">
   </div>
   <div class="spirit-magic item"
@@ -20,6 +34,8 @@
        data-matrix-spell-index="{{entryIndex}}"
        data-tooltip="{{localize 'RQG.Game.RollTitle'}}">
     {{item.name}}
+    <img class="matrix-source-badge" src="{{sourceItemImg}}"
+         data-tooltip="{{localize 'RQG.Actor.SpiritMagic.MatrixSourceTooltip' itemName=sourceItemName}}">
   </div>
   <div class="spirit-magic item"
        data-tooltip="{{item.spellSummaryTooltip}}"

--- a/src/actors/sheet-parts-v2/matrix-spell-spirit-magic-row.hbs
+++ b/src/actors/sheet-parts-v2/matrix-spell-spirit-magic-row.hbs
@@ -20,7 +20,9 @@
      one, see resolveMatrixSpellItem), sourceItemName, sourceItemImg. --}}
 <div class="spirit-magic-row" data-item-id="{{sourceItemId}}" data-matrix-spell-row-index="{{entryIndex}}">
   <div class="spirit-magic item">
-    {{#if @root.isEditable}}
+    {{!-- GM-only, matching every other drag handle in this list today (#1048 tracks lifting that
+         to @root.isEditable sheet-wide; this row should follow once that lands). --}}
+    {{#if @root.isGM}}
       <span class="item-drag-handle item draggable"
             data-matrix-spell-drag-handle
             data-item-id="{{sourceItemId}}"

--- a/src/actors/sheet-parts-v2/matrix-spell-spirit-magic-row.hbs
+++ b/src/actors/sheet-parts-v2/matrix-spell-spirit-magic-row.hbs
@@ -1,8 +1,7 @@
-{{!-- Row for a Spell Matrix entry (#959, #1047) - `item` isn't a real embedded Item, it's
-     resolved live from the matrix item's rqid, so this uses data-matrix-spell-cast/
-     data-matrix-spell-drag-handle instead of the native equivalents, and omits "contextmenu"
-     (the shared context menu would resolve the wrong document via data-item-id). Badge marks it
-     as matrix-derived.
+{{!-- `item` isn't a real embedded Item, it's resolved live from the matrix item's rqid, so this
+     uses data-matrix-spell-cast/data-matrix-spell-drag-handle instead of the native equivalents,
+     and omits "contextmenu" (the shared context menu would resolve the wrong document via
+     data-item-id).
 
      Params: item, sourceItemId (matrix item's id), entryIndex, sourceItemName, sourceItemImg. --}}
 <div class="spirit-magic-row" data-item-id="{{sourceItemId}}" data-matrix-spell-row-index="{{entryIndex}}">

--- a/src/data-model/json-schemas/generated/item/armor.schema.json
+++ b/src/data-model/json-schemas/generated/item/armor.schema.json
@@ -142,11 +142,16 @@
             "type": "integer",
             "minimum": 0,
             "default": 0
+          },
+          "sort": {
+            "type": "integer",
+            "default": 0
           }
         },
         "additionalProperties": false,
         "required": [
-          "points"
+          "points",
+          "sort"
         ]
       }
     },

--- a/src/data-model/json-schemas/generated/item/gear.schema.json
+++ b/src/data-model/json-schemas/generated/item/gear.schema.json
@@ -142,11 +142,16 @@
             "type": "integer",
             "minimum": 0,
             "default": 0
+          },
+          "sort": {
+            "type": "integer",
+            "default": 0
           }
         },
         "additionalProperties": false,
         "required": [
-          "points"
+          "points",
+          "sort"
         ]
       }
     }

--- a/src/data-model/json-schemas/generated/item/weapon.schema.json
+++ b/src/data-model/json-schemas/generated/item/weapon.schema.json
@@ -142,11 +142,16 @@
             "type": "integer",
             "minimum": 0,
             "default": 0
+          },
+          "sort": {
+            "type": "integer",
+            "default": 0
           }
         },
         "additionalProperties": false,
         "required": [
-          "points"
+          "points",
+          "sort"
         ]
       }
     },

--- a/src/data-model/shared/physical-item-schema-fields.ts
+++ b/src/data-model/shared/physical-item-schema-fields.ts
@@ -61,7 +61,7 @@ export function physicalItemSchemaFields() {
     // while the spell's other mechanics (range/duration/concentration/isVariable/...) never diverge
     // per matrix instance, so they're resolved live from `spellRqidLink.rqid` via
     // resolveMatrixSpellItem (spell-matrix.ts) instead of being duplicated here.
-    // `sort` (#1047) orders this entry among the actor's own Spirit Magic spells.
+    // `sort` orders this entry among the actor's own Spirit Magic spells.
     matrixSpells: new ArrayField(
       new SchemaField({
         spellRqidLink: rqidLinkSchemaField({ nullable: true }),

--- a/src/data-model/shared/physical-item-schema-fields.ts
+++ b/src/data-model/shared/physical-item-schema-fields.ts
@@ -61,10 +61,16 @@ export function physicalItemSchemaFields() {
     // while the spell's other mechanics (range/duration/concentration/isVariable/...) never diverge
     // per matrix instance, so they're resolved live from `spellRqidLink.rqid` via
     // resolveMatrixSpellItem (spell-matrix.ts) instead of being duplicated here.
+    // `sort` (#1047) places an entry among the actor's own Spirit Magic spells on the Spirit
+    // Magic tab - the same CONST.SORT_INTEGER_DENSITY-spaced integer scheme Foundry uses for
+    // embedded Items' own `sort` field, just stored here instead since a matrix entry isn't a
+    // Document of its own. See getMatrixSpellRows (spell-matrix.ts) and RqgActorSheetV2's
+    // _getSpiritMagicSortSiblings/_reorderSpiritMagic for how the two sort spaces interleave.
     matrixSpells: new ArrayField(
       new SchemaField({
         spellRqidLink: rqidLinkSchemaField({ nullable: true }),
         points: new NumberField({ integer: true, min: 0, nullable: false, initial: 0 }),
+        sort: new NumberField({ integer: true, nullable: false, initial: 0 }),
       }),
     ),
   } as const;

--- a/src/data-model/shared/physical-item-schema-fields.ts
+++ b/src/data-model/shared/physical-item-schema-fields.ts
@@ -61,11 +61,7 @@ export function physicalItemSchemaFields() {
     // while the spell's other mechanics (range/duration/concentration/isVariable/...) never diverge
     // per matrix instance, so they're resolved live from `spellRqidLink.rqid` via
     // resolveMatrixSpellItem (spell-matrix.ts) instead of being duplicated here.
-    // `sort` (#1047) places an entry among the actor's own Spirit Magic spells on the Spirit
-    // Magic tab - the same CONST.SORT_INTEGER_DENSITY-spaced integer scheme Foundry uses for
-    // embedded Items' own `sort` field, just stored here instead since a matrix entry isn't a
-    // Document of its own. See getMatrixSpellRows (spell-matrix.ts) and RqgActorSheetV2's
-    // _getSpiritMagicSortSiblings/_reorderSpiritMagic for how the two sort spaces interleave.
+    // `sort` (#1047) orders this entry among the actor's own Spirit Magic spells.
     matrixSpells: new ArrayField(
       new SchemaField({
         spellRqidLink: rqidLinkSchemaField({ nullable: true }),

--- a/src/items/rqg-item-sheet-v2.ts
+++ b/src/items/rqg-item-sheet-v2.ts
@@ -542,7 +542,7 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
     const newEntry = {
       spellRqidLink: spellRqidLink,
       points: (droppedItem as unknown as SpiritMagicItem).system.points,
-      sort: await getNextSpiritMagicSort(this.document.actor as unknown as RqgActor | null),
+      sort: getNextSpiritMagicSort(this.document.actor as unknown as RqgActor | null),
     };
     await this.document.update({
       system: { matrixSpells: [...this.getMatrixSpells(), newEntry] },

--- a/src/items/rqg-item-sheet-v2.ts
+++ b/src/items/rqg-item-sheet-v2.ts
@@ -172,11 +172,8 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
           };
         }),
       );
-      // Displayed alphabetically (#1047) - matrixSpells is stored in enchant order, which has no
-      // meaning to a player/GM. `storageIndex` (set above, before sorting) is what
-      // _onRender's points-edit listener and _unlinkMatrixSpellAction key off - see
-      // item-common-physical.hbs's data-index - so reordering this array for display doesn't
-      // desync those from the real, unsorted system.matrixSpells array.
+      // Displayed alphabetically (#1047); storageIndex (set above) keeps edit/unlink actions
+      // pointed at the real, unsorted array index.
       system.matrixSpells.sort((a, b) =>
         (a.spellRqidLink?.name ?? "").localeCompare(b.spellRqidLink?.name ?? ""),
       );

--- a/src/items/rqg-item-sheet-v2.ts
+++ b/src/items/rqg-item-sheet-v2.ts
@@ -12,7 +12,11 @@ import type { RqgItem } from "./rqg-item";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { PhysicalItem } from "@item-model/item-types.ts";
 import { getBondRoleConflict, getBoundSpiritActors } from "../system/magic-point-source";
-import { resolveMatrixSpellItem } from "../system/spell-matrix";
+import {
+  getNextSpiritMagicSort,
+  resolveMatrixSpellItem,
+  type MatrixSpellStorageEntry,
+} from "../system/spell-matrix";
 import {
   extractDropInfo,
   extractDroppedActor,
@@ -32,9 +36,6 @@ import type { DeepPartial } from "fvtt-types/utils";
 /** Shorthand types for ApplicationV2 lifecycle method parameters. */
 export type AppV2RenderContext = DeepPartial<foundry.applications.api.ApplicationV2.RenderContext>;
 export type AppV2RenderOptions = DeepPartial<foundry.applications.api.ApplicationV2.RenderOptions>;
-
-/** One stored Matrix Spell entry (#959) as persisted on a physical item's `system.matrixSpells`. */
-type MatrixSpellStorageEntry = { spellRqidLink: RqidLink; points: number };
 
 const { HandlebarsApplicationMixin } = foundry.applications.api;
 const ItemSheetV2 = foundry.applications.sheets.ItemSheetV2;
@@ -145,7 +146,7 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
     // other item type - no type-narrowing needed here.
     const boundSpiritActors = getBoundSpiritActors(this.document as unknown as PhysicalItem);
     const system = foundry.utils.duplicate(this.document._source.system) as {
-      matrixSpells?: (MatrixSpellStorageEntry & { isVariable?: boolean })[];
+      matrixSpells?: (MatrixSpellStorageEntry & { isVariable?: boolean; storageIndex?: number })[];
     };
     if (system.matrixSpells) {
       // Only a variable spell's (e.g. Bladesharp 1-4) enchanted level is a per-matrix choice -
@@ -164,8 +165,20 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
             index,
             canonicalCache,
           );
-          return { ...entry, isVariable: resolved?.system.isVariable ?? false };
+          return {
+            ...entry,
+            isVariable: resolved?.system.isVariable ?? false,
+            storageIndex: index,
+          };
         }),
+      );
+      // Displayed alphabetically (#1047) - matrixSpells is stored in enchant order, which has no
+      // meaning to a player/GM. `storageIndex` (set above, before sorting) is what
+      // _onRender's points-edit listener and _unlinkMatrixSpellAction key off - see
+      // item-common-physical.hbs's data-index - so reordering this array for display doesn't
+      // desync those from the real, unsorted system.matrixSpells array.
+      system.matrixSpells.sort((a, b) =>
+        (a.spellRqidLink?.name ?? "").localeCompare(b.spellRqidLink?.name ?? ""),
       );
     }
     return {
@@ -529,6 +542,7 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
     const newEntry = {
       spellRqidLink: spellRqidLink,
       points: (droppedItem as unknown as SpiritMagicItem).system.points,
+      sort: await getNextSpiritMagicSort(this.document.actor as unknown as RqgActor | null),
     };
     await this.document.update({
       system: { matrixSpells: [...this.getMatrixSpells(), newEntry] },

--- a/src/items/rqg-item-sheet-v2.ts
+++ b/src/items/rqg-item-sheet-v2.ts
@@ -172,8 +172,8 @@ export class RqgItemSheetV2 extends RqgItemSheetV2Base {
           };
         }),
       );
-      // Displayed alphabetically (#1047); storageIndex (set above) keeps edit/unlink actions
-      // pointed at the real, unsorted array index.
+      // Displayed alphabetically; storageIndex keeps edit/unlink actions pointed at the real
+      // array index.
       system.matrixSpells.sort((a, b) =>
         (a.spellRqidLink?.name ?? "").localeCompare(b.spellRqidLink?.name ?? ""),
       );

--- a/src/items/sheet-parts/item-common-physical.hbs
+++ b/src/items/sheet-parts/item-common-physical.hbs
@@ -115,8 +115,8 @@
      above: an item can hold more than one enchanted spell (e.g. one 4-point and one 1-point
      spell), and the dropzone always appends another. Each spell's own mechanics are resolved live
      from spellRqidLink at cast time (resolveMatrixSpellItem, spell-matrix.ts); only the enchanted
-     level (points) is stored per entry here. Listed alphabetically (#1047) - use
-     `this.storageIndex`, not `@index`, for the real system.matrixSpells array position. --}}
+     level (points) is stored per entry here. Listed alphabetically - use `this.storageIndex`,
+     not `@index`, for the real array position. --}}
 <label for="matrix-spell-{{id}}">{{localize "RQG.Item.Gear.MatrixSpell"}}</label>
 <div id="matrix-spell-{{id}}"
      class="matrix-spell-dropzone"

--- a/src/items/sheet-parts/item-common-physical.hbs
+++ b/src/items/sheet-parts/item-common-physical.hbs
@@ -115,7 +115,9 @@
      above: an item can hold more than one enchanted spell (e.g. one 4-point and one 1-point
      spell), and the dropzone always appends another. Each spell's own mechanics are resolved live
      from spellRqidLink at cast time (resolveMatrixSpellItem, spell-matrix.ts); only the enchanted
-     level (points) is stored per entry here. --}}
+     level (points) is stored per entry here. Listed alphabetically (#1047, rqg-item-sheet-v2.ts) -
+     use `this.storageIndex`, not `@index`, wherever an index into the real system.matrixSpells
+     array is needed (points edit, unlink), since display order no longer matches storage order. --}}
 <label for="matrix-spell-{{id}}">{{localize "RQG.Item.Gear.MatrixSpell"}}</label>
 <div id="matrix-spell-{{id}}"
      class="matrix-spell-dropzone"
@@ -130,7 +132,7 @@
         {{#if this.isVariable}}
           <input type="number"
                  data-matrix-spell-points
-                 data-index="{{@index}}"
+                 data-index="{{this.storageIndex}}"
                  data-tooltip="{{localize "RQG.Item.Gear.MatrixSpellPoints"}}"
                  value="{{this.points}}"
                  min="0"
@@ -142,7 +144,7 @@
       {{/if}}
       {{#if ../isEditable}}
         <a data-action="unlinkMatrixSpell"
-           data-index="{{@index}}"
+           data-index="{{this.storageIndex}}"
            data-tooltip="{{localize "RQG.Item.Gear.UnlinkMatrixSpellTitle" spellName=this.spellRqidLink.name}}">
           <i class="fas fa-unlink"></i>
         </a>

--- a/src/items/sheet-parts/item-common-physical.hbs
+++ b/src/items/sheet-parts/item-common-physical.hbs
@@ -115,9 +115,8 @@
      above: an item can hold more than one enchanted spell (e.g. one 4-point and one 1-point
      spell), and the dropzone always appends another. Each spell's own mechanics are resolved live
      from spellRqidLink at cast time (resolveMatrixSpellItem, spell-matrix.ts); only the enchanted
-     level (points) is stored per entry here. Listed alphabetically (#1047, rqg-item-sheet-v2.ts) -
-     use `this.storageIndex`, not `@index`, wherever an index into the real system.matrixSpells
-     array is needed (points edit, unlink), since display order no longer matches storage order. --}}
+     level (points) is stored per entry here. Listed alphabetically (#1047) - use
+     `this.storageIndex`, not `@index`, for the real system.matrixSpells array position. --}}
 <label for="matrix-spell-{{id}}">{{localize "RQG.Item.Gear.MatrixSpell"}}</label>
 <div id="matrix-spell-{{id}}"
      class="matrix-spell-dropzone"

--- a/src/system/spell-matrix.test.ts
+++ b/src/system/spell-matrix.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ItemTypeEnum } from "@item-model/item-types.ts";
+import { Rqid } from "./api/rqid-api";
+import { getMatrixSpellRows, getNextSpiritMagicSort } from "./spell-matrix";
+
+/** A fake canonical Spirit Magic item, as returned by Rqid.fromRqid. */
+function fakeCanonicalSpell(rqid: string, name: string) {
+  return {
+    type: ItemTypeEnum.SpiritMagic,
+    toObject: () => ({ name, type: ItemTypeEnum.SpiritMagic, system: { points: 1 } }),
+  } as any;
+}
+
+/** A fake physical item carrying one or more Spell Matrix Enchantment entries (#959). */
+function fakeMatrixItem(
+  id: string,
+  matrixSpells: { rqid: string; name: string; points?: number; sort?: number }[],
+) {
+  return {
+    id,
+    type: "gear",
+    system: {
+      equippedStatus: "equipped",
+      matrixSpells: matrixSpells.map(({ rqid, name, points, sort }) => ({
+        spellRqidLink: { rqid, name },
+        points: points ?? 1,
+        sort: sort ?? 0,
+      })),
+    },
+  } as any;
+}
+
+function fakeActor(items: any[]) {
+  return { items } as any;
+}
+
+describe("getMatrixSpellRows", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("flattens every matrix item's entries, carrying each entry's own sort and entryIndex", async () => {
+    vi.spyOn(Rqid, "fromRqid").mockImplementation(async (rqid) => {
+      const byRqid: Record<string, any> = {
+        "spell.dullblade": fakeCanonicalSpell("spell.dullblade", "Dullblade"),
+        "spell.bladesharp": fakeCanonicalSpell("spell.bladesharp", "Bladesharp"),
+        "spell.heal": fakeCanonicalSpell("spell.heal", "Heal"),
+      };
+      return rqid ? byRqid[rqid] : undefined;
+    });
+    (globalThis as any).CONFIG.Item = {
+      documentClass: class FakeItem {
+        constructor(data: any) {
+          Object.assign(this, data);
+        }
+      },
+    };
+
+    const matrixItem1 = fakeMatrixItem("m1", [
+      { rqid: "spell.dullblade", name: "Dullblade", sort: 300000 },
+      { rqid: "spell.bladesharp", name: "Bladesharp", sort: 100000 },
+    ]);
+    const matrixItem2 = fakeMatrixItem("m2", [{ rqid: "spell.heal", name: "Heal", sort: 200000 }]);
+
+    const rows = await getMatrixSpellRows(fakeActor([matrixItem1, matrixItem2]));
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        sourceItem: matrixItem1,
+        entryIndex: 0,
+        sort: 300000,
+        item: expect.objectContaining({ name: "Dullblade" }),
+      }),
+      expect.objectContaining({
+        sourceItem: matrixItem1,
+        entryIndex: 1,
+        sort: 100000,
+        item: expect.objectContaining({ name: "Bladesharp" }),
+      }),
+      expect.objectContaining({
+        sourceItem: matrixItem2,
+        entryIndex: 0,
+        sort: 200000,
+        item: expect.objectContaining({ name: "Heal" }),
+      }),
+    ]);
+  });
+
+  it("omits an unequipped matrix item entirely", async () => {
+    const matrixItem = fakeMatrixItem("m1", [{ rqid: "spell.heal", name: "Heal" }]);
+    matrixItem.system.equippedStatus = "carried";
+
+    expect(await getMatrixSpellRows(fakeActor([matrixItem]))).toEqual([]);
+  });
+});
+
+describe("getNextSpiritMagicSort", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 0 when there's no actor to append after", async () => {
+    expect(await getNextSpiritMagicSort(null)).toBe(0);
+    expect(await getNextSpiritMagicSort(undefined)).toBe(0);
+  });
+
+  it("lands one density step past the highest sort among owned spells and matrix entries", async () => {
+    (globalThis as any).CONST = { SORT_INTEGER_DENSITY: 100000 };
+    vi.spyOn(Rqid, "fromRqid").mockResolvedValue(fakeCanonicalSpell("spell.heal", "Heal"));
+    (globalThis as any).CONFIG.Item = {
+      documentClass: class FakeItem {
+        constructor(data: any) {
+          Object.assign(this, data);
+        }
+      },
+    };
+
+    const ownedSpell = { id: "s1", type: ItemTypeEnum.SpiritMagic, sort: 150000 };
+    const matrixItem = fakeMatrixItem("m1", [{ rqid: "spell.heal", name: "Heal", sort: 250000 }]);
+
+    expect(await getNextSpiritMagicSort(fakeActor([ownedSpell, matrixItem]))).toBe(350000);
+  });
+});

--- a/src/system/spell-matrix.test.ts
+++ b/src/system/spell-matrix.test.ts
@@ -122,8 +122,7 @@ describe("getNextSpiritMagicSort", () => {
   });
 
   it("lands one density step past the highest sort among owned spells and matrix entries", () => {
-    // Reads sort straight off the stored matrixSpells entries (no Rqid.fromRqid resolution needed
-    // just to place a new entry), so this doesn't need to mock spell resolution at all.
+    // No spell resolution needed, so no Rqid mock either.
     (globalThis as any).CONST = { SORT_INTEGER_DENSITY: 100000 };
     const ownedSpell = { id: "s1", type: ItemTypeEnum.SpiritMagic, sort: 150000 };
     const matrixItem = fakeMatrixItem("m1", [{ rqid: "spell.heal", name: "Heal", sort: 250000 }]);

--- a/src/system/spell-matrix.test.ts
+++ b/src/system/spell-matrix.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ItemTypeEnum } from "@item-model/item-types.ts";
 import { Rqid } from "./api/rqid-api";
-import { getMatrixSpellRows, getNextSpiritMagicSort } from "./spell-matrix";
+import { getMatrixSpellRows, getMatrixSpellSlots, getNextSpiritMagicSort } from "./spell-matrix";
 
 /** A fake canonical Spirit Magic item, as returned by Rqid.fromRqid. */
 function fakeCanonicalSpell(rqid: string, name: string) {
@@ -94,30 +94,40 @@ describe("getMatrixSpellRows", () => {
   });
 });
 
+describe("getMatrixSpellSlots", () => {
+  it("reads sort and name straight off the stored entries, without resolving the canonical spell", () => {
+    const matrixItem = fakeMatrixItem("m1", [
+      { rqid: "spell.dullblade", name: "Dullblade", sort: 300000 },
+      { rqid: "spell.bladesharp", name: "Bladesharp", sort: 100000 },
+    ]);
+
+    expect(getMatrixSpellSlots(fakeActor([matrixItem]))).toEqual([
+      { sourceItem: matrixItem, entryIndex: 0, sort: 300000, name: "Dullblade" },
+      { sourceItem: matrixItem, entryIndex: 1, sort: 100000, name: "Bladesharp" },
+    ]);
+  });
+
+  it("omits an unequipped matrix item entirely", () => {
+    const matrixItem = fakeMatrixItem("m1", [{ rqid: "spell.heal", name: "Heal" }]);
+    matrixItem.system.equippedStatus = "carried";
+
+    expect(getMatrixSpellSlots(fakeActor([matrixItem]))).toEqual([]);
+  });
+});
+
 describe("getNextSpiritMagicSort", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
+  it("returns 0 when there's no actor to append after", () => {
+    expect(getNextSpiritMagicSort(null)).toBe(0);
+    expect(getNextSpiritMagicSort(undefined)).toBe(0);
   });
 
-  it("returns 0 when there's no actor to append after", async () => {
-    expect(await getNextSpiritMagicSort(null)).toBe(0);
-    expect(await getNextSpiritMagicSort(undefined)).toBe(0);
-  });
-
-  it("lands one density step past the highest sort among owned spells and matrix entries", async () => {
+  it("lands one density step past the highest sort among owned spells and matrix entries", () => {
+    // Reads sort straight off the stored matrixSpells entries (no Rqid.fromRqid resolution needed
+    // just to place a new entry), so this doesn't need to mock spell resolution at all.
     (globalThis as any).CONST = { SORT_INTEGER_DENSITY: 100000 };
-    vi.spyOn(Rqid, "fromRqid").mockResolvedValue(fakeCanonicalSpell("spell.heal", "Heal"));
-    (globalThis as any).CONFIG.Item = {
-      documentClass: class FakeItem {
-        constructor(data: any) {
-          Object.assign(this, data);
-        }
-      },
-    };
-
     const ownedSpell = { id: "s1", type: ItemTypeEnum.SpiritMagic, sort: 150000 };
     const matrixItem = fakeMatrixItem("m1", [{ rqid: "spell.heal", name: "Heal", sort: 250000 }]);
 
-    expect(await getNextSpiritMagicSort(fakeActor([ownedSpell, matrixItem]))).toBe(350000);
+    expect(getNextSpiritMagicSort(fakeActor([ownedSpell, matrixItem]))).toBe(350000);
   });
 });

--- a/src/system/spell-matrix.ts
+++ b/src/system/spell-matrix.ts
@@ -8,7 +8,7 @@ import { ItemTypeEnum } from "@item-model/item-types.ts";
 import { Rqid } from "./api/rqid-api";
 import { isDocumentSubType, localize } from "./util";
 
-/** One stored Spell Matrix entry (#959). `sort` orders it among the actor's own spells (#1047). */
+/** One stored Spell Matrix entry. `sort` orders it among the actor's own spells. */
 export type MatrixSpellStorageEntry = { spellRqidLink: RqidLink; points: number; sort: number };
 
 /**
@@ -68,7 +68,6 @@ export async function resolveMatrixSpellItem(
   return new CONFIG.Item.documentClass(data) as unknown as SpiritMagicItem;
 }
 
-/** Actor's equipped items holding at least one Spell Matrix entry (#959). */
 function getEquippedMatrixItems(actor: RqgActor): PhysicalItem[] {
   return actor.items.filter(
     (i) =>
@@ -79,7 +78,7 @@ function getEquippedMatrixItems(actor: RqgActor): PhysicalItem[] {
 }
 
 /** A matrix entry's sort/name, read directly off storage - no Rqid resolution. Use
- *  getMatrixSpellRows instead when the resolved SpiritMagicItem is actually needed (#1047). */
+ *  getMatrixSpellRows instead when the resolved SpiritMagicItem is actually needed. */
 export type MatrixSpellSlot = {
   sourceItem: PhysicalItem;
   entryIndex: number;
@@ -87,7 +86,6 @@ export type MatrixSpellSlot = {
   name: string;
 };
 
-/** Every Spell Matrix entry's sort/name, unresolved - see MatrixSpellSlot. */
 export function getMatrixSpellSlots(actor: RqgActor): MatrixSpellSlot[] {
   return getEquippedMatrixItems(actor).flatMap((sourceItem) =>
     (sourceItem.system.matrixSpells ?? []).map((entry, entryIndex) => ({
@@ -99,7 +97,7 @@ export function getMatrixSpellSlots(actor: RqgActor): MatrixSpellSlot[] {
   );
 }
 
-/** One Spell Matrix entry (#959), resolved to its live SpiritMagicItem. */
+/** One Spell Matrix entry, resolved to its live SpiritMagicItem. */
 export type MatrixSpellRow = {
   sourceItem: PhysicalItem;
   entryIndex: number;
@@ -107,8 +105,7 @@ export type MatrixSpellRow = {
   sort: number;
 };
 
-/** Every Spell Matrix spell across the actor's equipped items, resolved and flattened (#1047 -
- *  listed alongside owned spells, not grouped by item). */
+/** Flattened, not grouped by item. */
 export async function getMatrixSpellRows(actor: RqgActor): Promise<MatrixSpellRow[]> {
   const matrixItems = getEquippedMatrixItems(actor);
 
@@ -131,8 +128,7 @@ export async function getMatrixSpellRows(actor: RqgActor): Promise<MatrixSpellRo
   return rows.flat();
 }
 
-/** Sort value for a newly-enchanted matrix entry: past everything else, so it appends at the
- *  end (#1047). 0 when there's no actor yet. */
+/** Past everything else, so a newly-enchanted entry appends at the end. 0 with no actor yet. */
 export function getNextSpiritMagicSort(actor: RqgActor | null | undefined): number {
   if (!actor) {
     return 0;

--- a/src/system/spell-matrix.ts
+++ b/src/system/spell-matrix.ts
@@ -71,6 +71,44 @@ export async function resolveMatrixSpellItem(
   return new CONFIG.Item.documentClass(data) as unknown as SpiritMagicItem;
 }
 
+/** The actor's own physical items that currently offer a Spell Matrix spell (#959) - equipped
+ *  (mirroring the physical-contact requirement for bound spirits and POW crystals in
+ *  magic-point-source.ts) and holding at least one enchanted entry. Shared by every function below
+ *  that needs to enumerate matrix entries. */
+function getEquippedMatrixItems(actor: RqgActor): PhysicalItem[] {
+  return actor.items.filter(
+    (i) =>
+      isDocumentSubType<PhysicalItem>(i, physicalItemTypes) &&
+      (i.system.matrixSpells?.length ?? 0) > 0 &&
+      i.system.equippedStatus === "equipped",
+  ) as PhysicalItem[];
+}
+
+/** One Spell Matrix entry's identity, `sort`, and display name (#1047) - read directly off the
+ *  stored `matrixSpells` entry, no Rqid.fromRqid/compendium lookup. Cheap enough for the "sort
+ *  alphabetically" button and every drag/drop (RqgActorSheetV2's _getSpiritMagicSortSiblings) and
+ *  for placing a newly-enchanted entry (getNextSpiritMagicSort); use getMatrixSpellRows instead
+ *  when the full resolved SpiritMagicItem (icon, spell summary, ...) is actually needed to render
+ *  or cast it. */
+export type MatrixSpellSlot = {
+  sourceItem: PhysicalItem;
+  entryIndex: number;
+  sort: number;
+  name: string;
+};
+
+/** Every Spell Matrix entry's identity/sort/name (#1047) - see MatrixSpellSlot. */
+export function getMatrixSpellSlots(actor: RqgActor): MatrixSpellSlot[] {
+  return getEquippedMatrixItems(actor).flatMap((sourceItem) =>
+    (sourceItem.system.matrixSpells ?? []).map((entry, entryIndex) => ({
+      sourceItem,
+      entryIndex,
+      sort: entry.sort ?? 0,
+      name: entry.spellRqidLink?.name ?? "",
+    })),
+  );
+}
+
 /** One Spell Matrix entry (#959), resolved to its live SpiritMagicItem, alongside enough context
  *  (`sourceItem`, `entryIndex`) to cast it and to write a new `sort` back onto the right
  *  `matrixSpells` array entry when the actor sheet reorders it (RqgActorSheetV2's
@@ -95,12 +133,7 @@ export type MatrixSpellRow = {
  * (already warned about by resolveMatrixSpellItem) are omitted.
  */
 export async function getMatrixSpellRows(actor: RqgActor): Promise<MatrixSpellRow[]> {
-  const matrixItems = actor.items.filter(
-    (i) =>
-      isDocumentSubType<PhysicalItem>(i, physicalItemTypes) &&
-      (i.system.matrixSpells?.length ?? 0) > 0 &&
-      i.system.equippedStatus === "equipped",
-  ) as PhysicalItem[];
+  const matrixItems = getEquippedMatrixItems(actor);
 
   // Shared across every entry resolved below, so items/entries enchanted with the same spell
   // (e.g. two matrices both holding Bladesharp) only resolve that spell's canonical rqid once.
@@ -125,17 +158,17 @@ export async function getMatrixSpellRows(actor: RqgActor): Promise<MatrixSpellRo
  * The `sort` a newly-enchanted matrix spell entry (#1047, RqgItemSheetV2._onDropMatrixSpell)
  * should get: past everything the actor's Spirit Magic tab already shows (owned spells and other
  * matrix entries alike), so it appends at the end instead of colliding with an existing `sort` and
- * forcing an immediate reindex. `undefined` when the item isn't on an actor yet (e.g. a sidebar/
+ * forcing an immediate reindex. Returns 0 when the item isn't on an actor yet (e.g. a sidebar/
  * compendium template) - there's no existing order to append after, so the entry just gets the
  * schema's `initial: 0` until it's equipped onto someone.
  */
-export async function getNextSpiritMagicSort(actor: RqgActor | null | undefined): Promise<number> {
+export function getNextSpiritMagicSort(actor: RqgActor | null | undefined): number {
   if (!actor) {
     return 0;
   }
   const ownedSorts = actor.items
     .filter((i) => i.type === ItemTypeEnum.SpiritMagic)
     .map((i) => i.sort ?? 0);
-  const matrixSorts = (await getMatrixSpellRows(actor)).map((row) => row.sort);
+  const matrixSorts = getMatrixSpellSlots(actor).map((slot) => slot.sort);
   return Math.max(0, ...ownedSorts, ...matrixSorts) + CONST.SORT_INTEGER_DENSITY;
 }

--- a/src/system/spell-matrix.ts
+++ b/src/system/spell-matrix.ts
@@ -2,10 +2,17 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { PhysicalItem } from "@item-model/item-types.ts";
 import type { SpiritMagicItem } from "@item-model/spirit-magic-data-model.ts";
 import type { RqgItem } from "../items/rqg-item";
+import type { RqidLink } from "../data-model/shared/rqid-link";
 import { physicalItemTypes } from "@item-model/i-physical-item.ts";
 import { ItemTypeEnum } from "@item-model/item-types.ts";
 import { Rqid } from "./api/rqid-api";
 import { isDocumentSubType, localize } from "./util";
+
+/** One stored Matrix Spell entry (#959) as persisted on a physical item's `system.matrixSpells`
+ *  (physical-item-schema-fields.ts). `sort` (#1047) places it among the actor's own Spirit Magic
+ *  spells - see getNextSpiritMagicSort/getMatrixSpellRows and RqgActorSheetV2's
+ *  SpiritMagicSortSibling/_applySpiritMagicSortUpdates. */
+export type MatrixSpellStorageEntry = { spellRqidLink: RqidLink; points: number; sort: number };
 
 /**
  * Resolve one Spirit Magic spell stored in a Spell Matrix Enchantment (Core p.264-265, #959) into
@@ -27,7 +34,7 @@ import { isDocumentSubType, localize } from "./util";
  * for Reputation's PartialAbilityItem in ability-roll-dialog-v2.ts).
  *
  * Accepts an optional `canonicalCache`, shared across sibling calls (e.g. every entry resolved by
- * one getMatrixSpellSources call, or one item sheet render), so entries pointing at the same rqid
+ * one getMatrixSpellRows call, or one item sheet render), so entries pointing at the same rqid
  * - a common case, e.g. two matrices both enchanted with Bladesharp - only pay Rqid.fromRqid's
  * world/compendium lookup once instead of once per entry.
  */
@@ -64,34 +71,30 @@ export async function resolveMatrixSpellItem(
   return new CONFIG.Item.documentClass(data) as unknown as SpiritMagicItem;
 }
 
-/** One resolved Spell Matrix entry within a MatrixSpellSource group - `entryIndex` identifies
- *  which array entry on `sourceItem.system.matrixSpells` this resolved from (needed to cast the
- *  right one, since an item can hold more than one matrix spell). */
-export type MatrixSpellEntry = {
+/** One Spell Matrix entry (#959), resolved to its live SpiritMagicItem, alongside enough context
+ *  (`sourceItem`, `entryIndex`) to cast it and to write a new `sort` back onto the right
+ *  `matrixSpells` array entry when the actor sheet reorders it (RqgActorSheetV2's
+ *  _getSpiritMagicSortSiblings/_reorderSpiritMagic). Listed as an ordinary row alongside the
+ *  actor's own known spells (#1047) rather than grouped under its item - see
+ *  actor-sheet-v2-spirit-magic.hbs. `sort` is the entry's own persisted position (physical-item-
+ *  schema-fields.ts), shared numeric space with owned spiritMagic Items' `sort` field. */
+export type MatrixSpellRow = {
+  sourceItem: PhysicalItem;
   entryIndex: number;
   item: SpiritMagicItem;
-};
-
-/** One item's Spell Matrix Enchantment(s) (#959), resolved for display under its own
- *  "From {itemName}:" group in the Spirit Magic tab - see actor-sheet-v2-spirit-magic.hbs.
- *  Grouped by `sourceItem` the same way getBoundSpiritSpiritMagicItems groups by bound spirit
- *  (spell-source.ts), so an item holding more than one matrix spell gets one divider with all its
- *  entries listed underneath, not a repeated divider per entry. */
-export type MatrixSpellSource = {
-  sourceItem: PhysicalItem;
-  entries: MatrixSpellEntry[];
+  sort: number;
 };
 
 /**
- * Every enchanted Spell Matrix item among the actor's own physical items, one group per item, each
- * resolved to its entries' live SpiritMagicItems (see resolveMatrixSpellItem). Requires physical
- * contact with the item (mirroring the equipped requirement for bound spirits and POW crystals in
- * magic-point-source.ts), so only equipped matrices are included. For sheet display purposes this
- * only looks at the viewing actor's own items - items on other actors are out of scope here.
- * Entries whose spell can't be resolved (already warned about by resolveMatrixSpellItem) are
- * omitted; items left with no resolvable entries are omitted entirely.
+ * Every Spirit Magic spell enchanted into one of the actor's own, equipped Spell Matrix items
+ * (#959), flattened into one list (not grouped by item - #1047 lists them alongside the actor's
+ * own known spells, ordered by `sort` together with those). Requires physical contact with the
+ * item (mirroring the equipped requirement for bound spirits and POW crystals in
+ * magic-point-source.ts). For sheet display purposes this only looks at the viewing actor's own
+ * items - items on other actors are out of scope here. Entries whose spell can't be resolved
+ * (already warned about by resolveMatrixSpellItem) are omitted.
  */
-export async function getMatrixSpellSources(actor: RqgActor): Promise<MatrixSpellSource[]> {
+export async function getMatrixSpellRows(actor: RqgActor): Promise<MatrixSpellRow[]> {
   const matrixItems = actor.items.filter(
     (i) =>
       isDocumentSubType<PhysicalItem>(i, physicalItemTypes) &&
@@ -103,20 +106,36 @@ export async function getMatrixSpellSources(actor: RqgActor): Promise<MatrixSpel
   // (e.g. two matrices both holding Bladesharp) only resolve that spell's canonical rqid once.
   const canonicalCache = new Map<string, Promise<RqgItem | undefined>>();
 
-  const sources = await Promise.all(
+  const rows = await Promise.all(
     matrixItems.map(async (sourceItem) => {
       const spellEntries = sourceItem.system.matrixSpells ?? [];
       const resolved = await Promise.all(
-        spellEntries.map(async (_entry, entryIndex) => {
+        spellEntries.map(async (entry, entryIndex) => {
           const item = await resolveMatrixSpellItem(sourceItem, entryIndex, canonicalCache);
-          return item ? { entryIndex, item } : undefined;
+          return item ? { sourceItem, entryIndex, item, sort: entry.sort ?? 0 } : undefined;
         }),
       );
-      return {
-        sourceItem,
-        entries: resolved.filter((entry): entry is MatrixSpellEntry => entry != null),
-      };
+      return resolved.filter((row): row is MatrixSpellRow => row != null);
     }),
   );
-  return sources.filter((source) => source.entries.length > 0);
+  return rows.flat();
+}
+
+/**
+ * The `sort` a newly-enchanted matrix spell entry (#1047, RqgItemSheetV2._onDropMatrixSpell)
+ * should get: past everything the actor's Spirit Magic tab already shows (owned spells and other
+ * matrix entries alike), so it appends at the end instead of colliding with an existing `sort` and
+ * forcing an immediate reindex. `undefined` when the item isn't on an actor yet (e.g. a sidebar/
+ * compendium template) - there's no existing order to append after, so the entry just gets the
+ * schema's `initial: 0` until it's equipped onto someone.
+ */
+export async function getNextSpiritMagicSort(actor: RqgActor | null | undefined): Promise<number> {
+  if (!actor) {
+    return 0;
+  }
+  const ownedSorts = actor.items
+    .filter((i) => i.type === ItemTypeEnum.SpiritMagic)
+    .map((i) => i.sort ?? 0);
+  const matrixSorts = (await getMatrixSpellRows(actor)).map((row) => row.sort);
+  return Math.max(0, ...ownedSorts, ...matrixSorts) + CONST.SORT_INTEGER_DENSITY;
 }

--- a/src/system/spell-matrix.ts
+++ b/src/system/spell-matrix.ts
@@ -8,10 +8,7 @@ import { ItemTypeEnum } from "@item-model/item-types.ts";
 import { Rqid } from "./api/rqid-api";
 import { isDocumentSubType, localize } from "./util";
 
-/** One stored Matrix Spell entry (#959) as persisted on a physical item's `system.matrixSpells`
- *  (physical-item-schema-fields.ts). `sort` (#1047) places it among the actor's own Spirit Magic
- *  spells - see getNextSpiritMagicSort/getMatrixSpellRows and RqgActorSheetV2's
- *  SpiritMagicSortSibling/_applySpiritMagicSortUpdates. */
+/** One stored Spell Matrix entry (#959). `sort` orders it among the actor's own spells (#1047). */
 export type MatrixSpellStorageEntry = { spellRqidLink: RqidLink; points: number; sort: number };
 
 /**
@@ -71,10 +68,7 @@ export async function resolveMatrixSpellItem(
   return new CONFIG.Item.documentClass(data) as unknown as SpiritMagicItem;
 }
 
-/** The actor's own physical items that currently offer a Spell Matrix spell (#959) - equipped
- *  (mirroring the physical-contact requirement for bound spirits and POW crystals in
- *  magic-point-source.ts) and holding at least one enchanted entry. Shared by every function below
- *  that needs to enumerate matrix entries. */
+/** Actor's equipped items holding at least one Spell Matrix entry (#959). */
 function getEquippedMatrixItems(actor: RqgActor): PhysicalItem[] {
   return actor.items.filter(
     (i) =>
@@ -84,12 +78,8 @@ function getEquippedMatrixItems(actor: RqgActor): PhysicalItem[] {
   ) as PhysicalItem[];
 }
 
-/** One Spell Matrix entry's identity, `sort`, and display name (#1047) - read directly off the
- *  stored `matrixSpells` entry, no Rqid.fromRqid/compendium lookup. Cheap enough for the "sort
- *  alphabetically" button and every drag/drop (RqgActorSheetV2's _getSpiritMagicSortSiblings) and
- *  for placing a newly-enchanted entry (getNextSpiritMagicSort); use getMatrixSpellRows instead
- *  when the full resolved SpiritMagicItem (icon, spell summary, ...) is actually needed to render
- *  or cast it. */
+/** A matrix entry's sort/name, read directly off storage - no Rqid resolution. Use
+ *  getMatrixSpellRows instead when the resolved SpiritMagicItem is actually needed (#1047). */
 export type MatrixSpellSlot = {
   sourceItem: PhysicalItem;
   entryIndex: number;
@@ -97,7 +87,7 @@ export type MatrixSpellSlot = {
   name: string;
 };
 
-/** Every Spell Matrix entry's identity/sort/name (#1047) - see MatrixSpellSlot. */
+/** Every Spell Matrix entry's sort/name, unresolved - see MatrixSpellSlot. */
 export function getMatrixSpellSlots(actor: RqgActor): MatrixSpellSlot[] {
   return getEquippedMatrixItems(actor).flatMap((sourceItem) =>
     (sourceItem.system.matrixSpells ?? []).map((entry, entryIndex) => ({
@@ -109,13 +99,7 @@ export function getMatrixSpellSlots(actor: RqgActor): MatrixSpellSlot[] {
   );
 }
 
-/** One Spell Matrix entry (#959), resolved to its live SpiritMagicItem, alongside enough context
- *  (`sourceItem`, `entryIndex`) to cast it and to write a new `sort` back onto the right
- *  `matrixSpells` array entry when the actor sheet reorders it (RqgActorSheetV2's
- *  _getSpiritMagicSortSiblings/_reorderSpiritMagic). Listed as an ordinary row alongside the
- *  actor's own known spells (#1047) rather than grouped under its item - see
- *  actor-sheet-v2-spirit-magic.hbs. `sort` is the entry's own persisted position (physical-item-
- *  schema-fields.ts), shared numeric space with owned spiritMagic Items' `sort` field. */
+/** One Spell Matrix entry (#959), resolved to its live SpiritMagicItem. */
 export type MatrixSpellRow = {
   sourceItem: PhysicalItem;
   entryIndex: number;
@@ -123,15 +107,8 @@ export type MatrixSpellRow = {
   sort: number;
 };
 
-/**
- * Every Spirit Magic spell enchanted into one of the actor's own, equipped Spell Matrix items
- * (#959), flattened into one list (not grouped by item - #1047 lists them alongside the actor's
- * own known spells, ordered by `sort` together with those). Requires physical contact with the
- * item (mirroring the equipped requirement for bound spirits and POW crystals in
- * magic-point-source.ts). For sheet display purposes this only looks at the viewing actor's own
- * items - items on other actors are out of scope here. Entries whose spell can't be resolved
- * (already warned about by resolveMatrixSpellItem) are omitted.
- */
+/** Every Spell Matrix spell across the actor's equipped items, resolved and flattened (#1047 -
+ *  listed alongside owned spells, not grouped by item). */
 export async function getMatrixSpellRows(actor: RqgActor): Promise<MatrixSpellRow[]> {
   const matrixItems = getEquippedMatrixItems(actor);
 
@@ -154,14 +131,8 @@ export async function getMatrixSpellRows(actor: RqgActor): Promise<MatrixSpellRo
   return rows.flat();
 }
 
-/**
- * The `sort` a newly-enchanted matrix spell entry (#1047, RqgItemSheetV2._onDropMatrixSpell)
- * should get: past everything the actor's Spirit Magic tab already shows (owned spells and other
- * matrix entries alike), so it appends at the end instead of colliding with an existing `sort` and
- * forcing an immediate reindex. Returns 0 when the item isn't on an actor yet (e.g. a sidebar/
- * compendium template) - there's no existing order to append after, so the entry just gets the
- * schema's `initial: 0` until it's equipped onto someone.
- */
+/** Sort value for a newly-enchanted matrix entry: past everything else, so it appends at the
+ *  end (#1047). 0 when there's no actor yet. */
 export function getNextSpiritMagicSort(actor: RqgActor | null | undefined): number {
   if (!actor) {
     return 0;

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -454,7 +454,7 @@
         "Concentration": "Concentration",
         "AlliedSpiritFromLabel": "Allied Spirit",
         "BoundSpiritFromLabel": "Bound Spirit",
-        "MatrixFromLabel": "Matrix",
+        "MatrixSourceTooltip": "Matrix: {itemName}",
         "InLabel": "in"
       }
     },


### PR DESCRIPTION
## Summary
- Spell Matrix entries (#959) now carry their own `sort` field, sharing the same numeric space as owned Items' `sort`
- Matrix spells (any count, not just single-spell ones) are listed as ordinary rows in the actor's own Spirit Magic list, interleaved by `sort`, with a small source-item badge marking them as matrix-derived - no more "Matrix: ..." divider grouping
- Both kinds are drag-reorderable together (`foundry.utils.performIntegerSort` fed a mixed owned-Item/matrix-entry sibling list)
- "Sort Items alphabetically" now alphabetizes owned spells and matrix entries together in one pass

## Test plan
- [x] `getMatrixSpellRows`/`getNextSpiritMagicSort` covered by unit tests
- [x] `pnpm typecheck`, `pnpm lint`, full test suite, i18n audit all pass
- [x] Verified live against a dev-world character with a single-spell and a multi-spell matrix: alphabetical ordering, badge/no-divider rendering, and drag-reorder in both directions (owned↔matrix) all confirmed working
- [x] Manual re-check by @wake42 on a real character

Fixes #1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)