### PR TITLE
Let any owner drag-reorder Spirit/Rune Magic spells, not just the GM

### DIFF
--- a/src/actors/sheet-parts-v2/actor-sheet-v2-rune-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-rune-magic.hbs
@@ -99,7 +99,7 @@
                 <div class="rune-magic contextmenu item"
                      data-item-id="{{id}}"
                      {{#if system.descriptionRqidLink.rqid}}data-rqid-link="{{system.descriptionRqidLink.rqid}}"{{/if}}>
-                  {{#if @root.isGM}}<span class="item-drag-handle item draggable" data-item-drag-handle data-item-id="{{id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{img}}">
+                  {{#if @root.isEditable}}<span class="item-drag-handle item draggable" data-item-drag-handle data-item-id="{{id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{img}}">
                 </div>
                 <div class="rune-magic contextmenu item"
                      data-item-id="{{id}}"

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-spirit-magic.hbs
@@ -35,7 +35,7 @@
        <div class="spirit-magic contextmenu item"
          data-item-id="{{id}}"
          {{#if system.descriptionRqidLink.rqid}}data-rqid-link="{{system.descriptionRqidLink.rqid}}"{{/if}}>
-         {{#if @root.isGM}}<span class="item-drag-handle item draggable" data-item-drag-handle data-item-id="{{id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{img}}">
+         {{#if @root.isEditable}}<span class="item-drag-handle item draggable" data-item-drag-handle data-item-id="{{id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{img}}">
       </div>
       <div class="spirit-magic contextmenu item"
            data-item-id="{{id}}"


### PR DESCRIPTION
## Summary
- The Spirit Magic and Rune Magic tabs' spell drag handle only rendered for the GM (`{{#if @root.isGM}}`)
- The underlying drag permission check (`_canDragStart`, inherited from Foundry's base sheet class) only requires owner/observer access, not GM - so this was purely a template display bug, not an actual permission restriction
- Swapped to `{{#if @root.isEditable}}`, matching the pattern already used correctly on the Gear tab, so a player who owns the character can reorder their own known spells too

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, full test suite, i18n audit all pass
- [x] Verified live (as GM) that both tabs still render their drag handles correctly after the change
- [x] Manual check by @wake42 as a non-GM player

Fixes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)