### PR TITLE
Add comment-brevity rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ VS Code Copilot also auto-loads this file via [`.github/copilot-instructions.md`
 11. Naming convention: use **kebab-case** for new folders and non-type files (especially under `src/applications/**`); keep PascalCase for TypeScript symbol names (classes/types/interfaces). Treat legacy mixed-case paths as stable unless a task explicitly includes path normalization.
 12. For i18n keys/messages, prefer translator-friendly strings: use one key with explicit placeholders where feasible, and avoid source phrasing that depends on dynamic-name grammar (article/gender/plural/case) so translations can reorder placeholders naturally.
 13. Prefer Foundry core implementation patterns and APIs over custom abstraction layers; introduce extra layers only when there is a clear, documented reason (for example compatibility gaps, safety, or substantial duplication reduction).
+14. Keep comments minimal: only for a hidden constraint, workaround, or non-obvious invariant — never restating what the code or its name already says. Design rationale and issue/task context belong in the commit message, not the code.
 
 ## Foundry + fvtt-types Guidance
 


### PR DESCRIPTION
## Summary
- Comments drifted long during recent feature work: multi-sentence doc comments restating design rationale, cross-referencing several other methods, and using issue numbers as the explanation itself instead of a pointer.
- Adds rule 14 to the "Default Engineering Rules" list: keep comments to only a hidden constraint, workaround, or non-obvious invariant - never a restatement of the code/name, and put design rationale in the commit message instead.

Applies to all AI agents per this file's stated scope (Claude Code, Codex, Aider, Cursor, Copilot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)