### PR TITLE
fix: prevent Rqid batch editor progress bar from spamming notifications

### DIFF
--- a/src/applications/rqid-batch-editor/rqid-batch-editor.ts
+++ b/src/applications/rqid-batch-editor/rqid-batch-editor.ts
@@ -998,9 +998,10 @@ export class RqidBatchEditor extends HandlebarsApplicationMixin(
       RqidBatchEditor.logger.info(`${message} ${pct}`);
     }
 
-    if (!RqidBatchEditor.updateProgressBar?.active) {
+    if (!RqidBatchEditor.updateProgressBar) {
       RqidBatchEditor.updateProgressBar = ui.notifications?.info(message, {
         progress: true,
+        permanent: true,
         console: false,
       });
     }

--- a/src/system/migrations/apply-migrations.ts
+++ b/src/system/migrations/apply-migrations.ts
@@ -1488,7 +1488,10 @@ function updateProgressBar(
   const message = `${prefix} ${index} / ${totalCount}`;
 
   if (!progressState.progressBar) {
-    progressState.progressBar = ui.notifications?.info(message, { progress: true });
+    progressState.progressBar = ui.notifications?.info(message, {
+      progress: true,
+      permanent: true,
+    });
   }
 
   progressState.progressBar?.update?.({ message, pct });


### PR DESCRIPTION
## Summary
- `RqidBatchEditor.updateProgress` created its scan progress notification without `permanent: true`, so Foundry auto-expired it after `LIFETIME_MS` (5s) during long scans (thousands of world actors/items/compendium entries).
- The creation guard checked `notification.active`, so once the bar expired mid-scan a brand-new notification was spawned instead of reusing the existing one — stacking up dozens of stale "Find Rqids from World Actors N / 2114" notifications, as reported in #1052.
- Found the same missing `permanent: true` in `apply-migrations.ts`'s own progress-bar fallback, used when `applyMigrations()`/`applyDefaultWorldMigrations()` is called without a pre-built notification (e.g. via `game.system.api.migration.applyWorldMigrations` from a macro). That path doesn't respawn duplicates (its guard checks existence, not `.active`), but the bar would still go inactive/stale mid-run on a long migration triggered that way.
- Fix: mark both notifications `permanent: true`, and for the Rqid batch editor also guard creation on existence instead of `.active`, so a single bar is reused and updated for the whole scan (matching the pattern already used for the top-level world-migration notification).

Closes #1052

## Test plan
- [x] `tsc --noEmit` passes
- [x] Full test suite passes (765 tests)
- [x] Manually verify: run the Rqid batch editor scan against a world with many actors/items and confirm only one progress notification appears and updates in place instead of stacking

🤖 Generated with [Claude Code](https://claude.com/claude-code)