### PR TITLE
Add template picker to Create Actor dialog

### DIFF
--- a/src/actors/rqg-actor-create-dialog-content.hbs
+++ b/src/actors/rqg-actor-create-dialog-content.hbs
@@ -1,0 +1,9 @@
+<div class="form-group">
+  <label>{{localize "RQG.Dialog.ActorCreate.StartFrom"}}</label>
+  <div class="form-fields">
+    <select name="startFrom">
+      <option value="blank">{{localize "RQG.Dialog.ActorCreate.Blank"}}</option>
+      <option value="template">{{localize "RQG.Dialog.ActorCreate.ChooseTemplate"}}</option>
+    </select>
+  </div>
+</div>

--- a/src/actors/rqg-actor.ts
+++ b/src/actors/rqg-actor.ts
@@ -57,6 +57,7 @@ import {
 } from "@items/item-lifecycle-strategy.ts";
 import { ActorTemplatePicker } from "../applications/actor-template-picker/actor-template-picker";
 import { templatePaths } from "../system/load-handlebars-templates";
+import { tagsFlag } from "../data-model/shared/rqg-document-flags";
 
 import Actor = foundry.documents.Actor;
 
@@ -144,7 +145,11 @@ export class RqgActor extends Actor {
       {
         context: { content },
         ok: {
-          callback: async (event: Event, button: HTMLButtonElement) => {
+          callback: async (
+            event: Event,
+            button: HTMLButtonElement,
+            dialog: foundry.applications.api.DialogV2.Any,
+          ) => {
             const fd = new foundry.applications.ux.FormDataExtended(button.form as HTMLFormElement);
             const startFrom = (fd.object as { startFrom?: string }).startFrom;
 
@@ -152,9 +157,11 @@ export class RqgActor extends Actor {
               return createBlank(event, button);
             }
 
+            void dialog.close();
             const templateUuid = await ActorTemplatePicker.pick();
             if (!templateUuid) {
-              return createBlank(event, button);
+              // The create dialog is already closed - canceling the picker aborts creation entirely.
+              return undefined;
             }
             const templateActor = await getDocumentFromUuid<RqgActor>(templateUuid);
             if (!templateActor) {
@@ -191,6 +198,19 @@ export class RqgActor extends Actor {
                 keepId: false,
               })) as RqgActor | undefined;
             }
+            // A clone is a specific actor, not a new template - drop the picker's gate tag.
+            const clonedTags = cloned?.getFlag(systemId, tagsFlag) as string[] | undefined;
+            if (clonedTags?.includes(RQG_CONFIG.actorTemplateGateTag)) {
+              const remainingTags = clonedTags.filter(
+                (tag) => tag !== RQG_CONFIG.actorTemplateGateTag,
+              );
+              if (remainingTags.length) {
+                await cloned?.setFlag(systemId, tagsFlag, remainingTags);
+              } else {
+                await cloned?.unsetFlag(systemId, tagsFlag);
+              }
+            }
+
             void cloned?.sheet?.render(true);
             return cloned;
           },

--- a/src/actors/rqg-actor.ts
+++ b/src/actors/rqg-actor.ts
@@ -6,6 +6,7 @@ import { DamageCalculations } from "../items/hit-location-item/hit-location-dama
 import { HealingCalculations } from "../items/hit-location-item/hit-location-healing-calculations";
 import {
   assertDocumentSubType,
+  getDocumentFromUuid,
   getSpeakerDisplayName,
   getTokenFromActor,
   isDocumentSubType,
@@ -54,6 +55,8 @@ import {
   handleActorPrepareDerivedData,
   handleActorPrepareEmbeddedDocuments,
 } from "@items/item-lifecycle-strategy.ts";
+import { ActorTemplatePicker } from "../applications/actor-template-picker/actor-template-picker";
+import { templatePaths } from "../system/load-handlebars-templates";
 
 import Actor = foundry.documents.Actor;
 
@@ -70,6 +73,9 @@ export class RqgActor extends Actor {
   static init() {
     CONFIG.Actor.documentClass = RqgActor;
     CONFIG.Actor.dataModels["character"] = CharacterDataModel;
+
+    // So the template picker (#778/#636) can find flagged actors via the index alone.
+    CONFIG.Actor.compendiumIndexFields.push("flags.rqg.tags");
 
     const Actors = foundry.documents.collections.Actors;
 
@@ -88,6 +94,112 @@ export class RqgActor extends Actor {
       label: "RQG.SheetName.Actor.CharacterV2",
       makeDefault: true,
     });
+  }
+
+  /** Adds a "Start from: Blank / Template" field to the native Create Actor dialog (#778/#636). */
+  static override async createDialog<
+    Options extends Actor.CreateDialogOptions | undefined = undefined,
+  >(
+    data?: Actor.CreateDialogData,
+    createOptions?: Actor.Database.CreateDocumentsOperation,
+    options?: Options,
+  ): Promise<Actor.CreateDialogReturn<Options>> {
+    const content = await foundry.applications.handlebars.renderTemplate(
+      templatePaths.actorCreateDialogContent,
+      {},
+    );
+
+    const createBlank = async (
+      _event: Event,
+      button: HTMLButtonElement,
+    ): Promise<RqgActor | undefined> => {
+      const fd = new foundry.applications.ux.FormDataExtended(button.form as HTMLFormElement);
+      const submitted = foundry.utils.mergeObject(data ?? {}, fd.object, { inplace: false }) as {
+        name?: string;
+        type?: string;
+        folder?: string;
+        startFrom?: string;
+      };
+      delete submitted.startFrom;
+      if (!submitted.folder) {
+        delete submitted.folder;
+      }
+      if (!submitted.name?.trim()) {
+        submitted.name = this.defaultName({
+          type: submitted.type as any,
+          parent: createOptions?.parent,
+          pack: createOptions?.pack,
+        });
+      }
+      const doc = (await this.create(submitted as Actor.CreateData, {
+        renderSheet: false,
+        ...createOptions,
+      })) as RqgActor | undefined;
+      void doc?.sheet?.render(true);
+      return doc;
+    };
+
+    const mergedOptions = foundry.utils.mergeObject(
+      options ?? {},
+      {
+        context: { content },
+        ok: {
+          callback: async (event: Event, button: HTMLButtonElement) => {
+            const fd = new foundry.applications.ux.FormDataExtended(button.form as HTMLFormElement);
+            const startFrom = (fd.object as { startFrom?: string }).startFrom;
+
+            if (startFrom !== "template") {
+              return createBlank(event, button);
+            }
+
+            const templateUuid = await ActorTemplatePicker.pick();
+            if (!templateUuid) {
+              return createBlank(event, button);
+            }
+            const templateActor = await getDocumentFromUuid<RqgActor>(templateUuid);
+            if (!templateActor) {
+              const msg = `RQG | Couldn't find the chosen template actor [${templateUuid}]`;
+              ui.notifications?.error(msg, { console: false });
+              console.error(msg);
+              return createBlank(event, button);
+            }
+
+            const nameField = button.form?.elements.namedItem("name") as
+              HTMLInputElement | undefined;
+            const folderField = button.form?.elements.namedItem("folder") as
+              HTMLSelectElement | undefined;
+            const updateData = {
+              name: nameField?.value?.trim() || templateActor.name,
+              folder: folderField?.value || undefined,
+            };
+
+            // clone() would otherwise recreate a compendium-sourced template into its own pack.
+            let cloned: RqgActor | undefined;
+            if (templateActor.pack) {
+              requireValue(templateActor.id, "Template actor has no id");
+              cloned = (await game.actors?.importFromCompendium(
+                game.packs.get(
+                  templateActor.pack,
+                ) as foundry.documents.collections.CompendiumCollection<"Actor">,
+                templateActor.id,
+                updateData,
+                { renderSheet: false },
+              )) as RqgActor | undefined;
+            } else {
+              cloned = (await templateActor.clone(updateData, {
+                save: true,
+                keepId: false,
+              })) as RqgActor | undefined;
+            }
+            void cloned?.sheet?.render(true);
+            return cloned;
+          },
+        },
+      },
+      { inplace: false },
+    ) as unknown as Options;
+
+    return super.createDialog(data, createOptions, mergedOptions);
   }
 
   /**

--- a/src/actors/rqg-actor.ts
+++ b/src/actors/rqg-actor.ts
@@ -57,7 +57,7 @@ import {
 } from "@items/item-lifecycle-strategy.ts";
 import { ActorTemplatePicker } from "../applications/actor-template-picker/actor-template-picker";
 import { templatePaths } from "../system/load-handlebars-templates";
-import { tagsFlag } from "../data-model/shared/rqg-document-flags";
+import { cloneActorFromTemplate } from "../system/api/actor-template-api";
 
 import Actor = foundry.documents.Actor;
 
@@ -151,9 +151,9 @@ export class RqgActor extends Actor {
             dialog: foundry.applications.api.DialogV2.Any,
           ) => {
             const fd = new foundry.applications.ux.FormDataExtended(button.form as HTMLFormElement);
-            const startFrom = (fd.object as { startFrom?: string }).startFrom;
+            const submitted = fd.object as { name?: string; folder?: string; startFrom?: string };
 
-            if (startFrom !== "template") {
+            if (submitted.startFrom !== "template") {
               return createBlank(event, button);
             }
 
@@ -171,46 +171,10 @@ export class RqgActor extends Actor {
               return createBlank(event, button);
             }
 
-            const nameField = button.form?.elements.namedItem("name") as
-              HTMLInputElement | undefined;
-            const folderField = button.form?.elements.namedItem("folder") as
-              HTMLSelectElement | undefined;
-            const updateData = {
-              name: nameField?.value?.trim() || templateActor.name,
-              folder: folderField?.value || undefined,
-            };
-
-            // clone() would otherwise recreate a compendium-sourced template into its own pack.
-            let cloned: RqgActor | undefined;
-            if (templateActor.pack) {
-              requireValue(templateActor.id, "Template actor has no id");
-              cloned = (await game.actors?.importFromCompendium(
-                game.packs.get(
-                  templateActor.pack,
-                ) as foundry.documents.collections.CompendiumCollection<"Actor">,
-                templateActor.id,
-                updateData,
-                { renderSheet: false },
-              )) as RqgActor | undefined;
-            } else {
-              cloned = (await templateActor.clone(updateData, {
-                save: true,
-                keepId: false,
-              })) as RqgActor | undefined;
-            }
-            // A clone is a specific actor, not a new template - drop the picker's gate tag.
-            const clonedTags = cloned?.getFlag(systemId, tagsFlag) as string[] | undefined;
-            if (clonedTags?.includes(RQG_CONFIG.actorTemplateGateTag)) {
-              const remainingTags = clonedTags.filter(
-                (tag) => tag !== RQG_CONFIG.actorTemplateGateTag,
-              );
-              if (remainingTags.length) {
-                await cloned?.setFlag(systemId, tagsFlag, remainingTags);
-              } else {
-                await cloned?.unsetFlag(systemId, tagsFlag);
-              }
-            }
-
+            const cloned = await cloneActorFromTemplate(templateActor, {
+              name: submitted.name?.trim() || templateActor.name,
+              folder: submitted.folder || undefined,
+            });
             void cloned?.sheet?.render(true);
             return cloned;
           },

--- a/src/actors/rqg-actor.ts
+++ b/src/actors/rqg-actor.ts
@@ -151,7 +151,9 @@ export class RqgActor extends Actor {
             dialog: foundry.applications.api.DialogV2.Any,
           ) => {
             const fd = new foundry.applications.ux.FormDataExtended(button.form as HTMLFormElement);
-            const submitted = fd.object as { name?: string; folder?: string; startFrom?: string };
+            const submitted = foundry.utils.mergeObject(data ?? {}, fd.object, {
+              inplace: false,
+            }) as { name?: string; folder?: string; startFrom?: string };
 
             if (submitted.startFrom !== "template") {
               return createBlank(event, button);

--- a/src/applications/actor-template-picker/actor-template-picker.css
+++ b/src/applications/actor-template-picker/actor-template-picker.css
@@ -9,6 +9,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.4rem;
+    margin-top: 0.4rem;
 
     & select {
       flex: 0 0 auto;

--- a/src/applications/actor-template-picker/actor-template-picker.css
+++ b/src/applications/actor-template-picker/actor-template-picker.css
@@ -1,0 +1,121 @@
+.actor-template-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  height: 100%;
+  min-height: 0;
+
+  & .actor-template-picker-facets {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+
+    & select {
+      flex: 0 0 auto;
+      width: auto;
+      font-size: var(--font-size-13, 0.8125rem);
+    }
+  }
+
+  & input[type="search"] {
+    font-size: var(--font-size-14, 0.875rem);
+    line-height: 1.8rem;
+  }
+
+  & .actor-template-picker-list {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  /* Not a <button> - Foundry's fixed button height clips multi-line content. */
+  & .actor-template-picker-entry {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.5rem;
+    cursor: var(--cursor-pointer, pointer);
+    border-bottom: 1px solid var(--color-cool-4, #444);
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &:hover {
+      background: var(--color-cool-3, rgb(255 255 255 / 8%));
+    }
+
+    &[hidden] {
+      display: none;
+    }
+
+    & img {
+      flex: 0 0 auto;
+      width: 2.5rem;
+      height: 2.5rem;
+      object-fit: cover;
+      border: none;
+      margin-top: 0.1rem;
+    }
+  }
+
+  & .actor-template-picker-text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    min-width: 0;
+  }
+
+  & .actor-template-picker-headline {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  & .actor-template-picker-name {
+    flex: 0 0 auto;
+    max-width: 65%;
+    font-size: var(--font-size-16, 1rem);
+    font-weight: bold;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  & .actor-template-picker-source {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: var(--font-size-12, 0.75rem);
+    opacity: 0.7;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: right;
+  }
+
+  & .actor-template-picker-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.1rem;
+  }
+
+  & .actor-template-picker-pill {
+    flex: 0 0 auto;
+    line-height: 1.2rem;
+    padding: 0 0.5rem;
+    border: 1px solid var(--color-cool-4, #666);
+    border-radius: 999px;
+    font-size: var(--font-size-11, 0.6875rem);
+    opacity: 0.8;
+  }
+
+  & .actor-template-picker-empty {
+    text-align: center;
+    opacity: 0.7;
+  }
+}

--- a/src/applications/actor-template-picker/actor-template-picker.hbs
+++ b/src/applications/actor-template-picker/actor-template-picker.hbs
@@ -1,0 +1,41 @@
+<section class="actor-template-picker">
+  <input type="search" name="search" placeholder="{{localize 'RQG.Dialog.ActorTemplatePicker.SearchPlaceholder'}}" autofocus>
+
+  {{#if facets.length}}
+    <div class="actor-template-picker-facets">
+      {{#each facets}}
+        <select data-facet="{{key}}">
+          <option value="">{{key}}: {{localize 'RQG.Dialog.ActorTemplatePicker.Any'}}</option>
+          {{selectOptions options localize=false}}
+        </select>
+      {{/each}}
+    </div>
+  {{/if}}
+
+  <ol class="actor-template-picker-list">
+    {{#each templates}}
+      <li class="actor-template-picker-entry" data-action="selectTemplate" data-uuid="{{uuid}}" data-name="{{name}}" data-tags="{{tagsAttr}}">
+        {{#if img}}
+          <img src="{{img}}" alt="">
+        {{/if}}
+        <div class="actor-template-picker-text">
+          <div class="actor-template-picker-headline">
+            <span class="actor-template-picker-name">{{name}}</span>
+            <span class="actor-template-picker-source" title="{{sourceDisplay}}">{{sourceDisplay}}</span>
+          </div>
+          {{#if tags.length}}
+            <div class="actor-template-picker-pills">
+              {{#each tags}}
+                <span class="actor-template-picker-pill">{{this}}</span>
+              {{/each}}
+            </div>
+          {{/if}}
+        </div>
+      </li>
+    {{/each}}
+  </ol>
+
+  {{#unless hasTemplates}}
+    <p class="actor-template-picker-empty">{{localize 'RQG.Dialog.ActorTemplatePicker.Empty'}}</p>
+  {{/unless}}
+</section>

--- a/src/applications/actor-template-picker/actor-template-picker.hbs
+++ b/src/applications/actor-template-picker/actor-template-picker.hbs
@@ -14,7 +14,7 @@
 
   <ol class="actor-template-picker-list">
     {{#each templates}}
-      <li class="actor-template-picker-entry" data-action="selectTemplate" data-uuid="{{uuid}}" data-name="{{name}}" data-tags="{{tagsAttr}}">
+      <li class="actor-template-picker-entry" data-action="selectTemplate" data-uuid="{{uuid}}">
         {{#if img}}
           <img src="{{img}}" alt="">
         {{/if}}

--- a/src/applications/actor-template-picker/actor-template-picker.test.ts
+++ b/src/applications/actor-template-picker/actor-template-picker.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { ActorTemplateEntry } from "../../system/api/actor-template-api";
+import { buildFacets, computeAvailableFacetValues } from "./actor-template-picker";
+
+function entry(...tags: string[]): ActorTemplateEntry {
+  return { uuid: `Actor.${tags.join(",")}`, name: "Test", tags, source: "World" };
+}
+
+describe("buildFacets", () => {
+  it("gives a colon-hierarchical tag a selectable row for every ancestor level", () => {
+    const facets = buildFacets([entry("species:uz:dark-troll")]);
+    const species = facets.find((f) => f.key === "species");
+    expect(species?.options.map((o) => o.value)).toEqual(["species:uz", "species:uz:dark-troll"]);
+  });
+
+  it("does not duplicate an ancestor row already shared by multiple leaves", () => {
+    const facets = buildFacets([entry("species:uz:dark-troll"), entry("species:uz:great-troll")]);
+    const species = facets.find((f) => f.key === "species");
+    expect(species?.options.map((o) => o.value)).toEqual([
+      "species:uz",
+      "species:uz:dark-troll",
+      "species:uz:great-troll",
+    ]);
+  });
+
+  it("indents a row's label by its depth, using only its own leaf segment", () => {
+    const facets = buildFacets([entry("species:uz:dark-troll")]);
+    const species = facets.find((f) => f.key === "species");
+    expect(species?.options.map((o) => o.label)).toEqual(["uz", "  dark-troll"]);
+  });
+
+  it("leaves a flat (non-hierarchical) tag as a single row", () => {
+    const facets = buildFacets([entry("species:human")]);
+    const species = facets.find((f) => f.key === "species");
+    expect(species?.options.map((o) => o.value)).toEqual(["species:human"]);
+  });
+
+  it("groups facets by namespace independently", () => {
+    const facets = buildFacets([entry("role:adventurer", "species:uz:dark-troll")]);
+    expect(facets.map((f) => f.key)).toEqual(["role", "species"]);
+  });
+});
+
+describe("computeAvailableFacetValues", () => {
+  const templates = [
+    entry("role:adventurer", "species:uz:dark-troll"),
+    entry("role:adventurer", "species:human"),
+    entry("class:animal", "species:wolf"),
+  ];
+
+  it("excludes species only reachable through templates the other active filters rule out", () => {
+    const available = computeAvailableFacetValues(templates, ["role:adventurer"], "species");
+    expect(available).toEqual(new Set(["species:uz", "species:uz:dark-troll", "species:human"]));
+    expect(available.has("species:wolf")).toBe(false);
+  });
+
+  it("ignores the facet's own active filter so it doesn't collapse to just the current selection", () => {
+    const available = computeAvailableFacetValues(templates, ["species:human"], "species");
+    expect(available).toEqual(
+      new Set(["species:uz", "species:uz:dark-troll", "species:human", "species:wolf"]),
+    );
+  });
+
+  it("with no active filters, every facet value across all templates is available", () => {
+    const available = computeAvailableFacetValues(templates, [], "class");
+    expect(available).toEqual(new Set(["class:animal"]));
+  });
+});

--- a/src/applications/actor-template-picker/actor-template-picker.ts
+++ b/src/applications/actor-template-picker/actor-template-picker.ts
@@ -36,6 +36,14 @@ interface ActorTemplatePickerContext extends foundry.applications.api.Applicatio
 
 const INDENT = "\u00A0\u00A0"; // non-breaking - a leading regular space can get collapsed in <option> text
 
+/** Adds every ancestor-depth path of a colon-separated tag value (e.g. "uz:dark-troll" -> "uz", "uz:dark-troll") into `paths`. */
+function addAncestorPaths(paths: Set<string>, value: string): void {
+  const segments = value.split(":");
+  for (let depth = 1; depth <= segments.length; depth++) {
+    paths.add(segments.slice(0, depth).join(":"));
+  }
+}
+
 /** Colon-path segments (with every ancestor depth) for one facet's tags across `templates`. */
 function collectFacetPaths(templates: ActorTemplateEntry[], facetKey: string): Set<string> {
   const paths = new Set<string>();
@@ -45,10 +53,7 @@ function collectFacetPaths(templates: ActorTemplateEntry[], facetKey: string): S
       if (separatorIndex === -1 || tag.slice(0, separatorIndex) !== facetKey) {
         continue;
       }
-      const segments = tag.slice(separatorIndex + 1).split(":");
-      for (let depth = 1; depth <= segments.length; depth++) {
-        paths.add(segments.slice(0, depth).join(":"));
-      }
+      addAncestorPaths(paths, tag.slice(separatorIndex + 1));
     }
   }
   return paths;
@@ -69,10 +74,7 @@ export function buildFacets(templates: ActorTemplateEntry[]): TemplateFacet[] {
         paths = new Set();
         pathsByFacet.set(key, paths);
       }
-      const segments = tag.slice(separatorIndex + 1).split(":");
-      for (let depth = 1; depth <= segments.length; depth++) {
-        paths.add(segments.slice(0, depth).join(":"));
-      }
+      addAncestorPaths(paths, tag.slice(separatorIndex + 1));
     }
   }
   return [...pathsByFacet.entries()]

--- a/src/applications/actor-template-picker/actor-template-picker.ts
+++ b/src/applications/actor-template-picker/actor-template-picker.ts
@@ -10,7 +10,6 @@ import { templatePaths } from "../../system/load-handlebars-templates";
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 interface ActorTemplatePickerRow extends ActorTemplateEntry {
-  tagsAttr: string;
   /** `source` plus rqid lang/priority. */
   sourceDisplay: string;
 }
@@ -57,25 +56,37 @@ function collectFacetPaths(templates: ActorTemplateEntry[], facetKey: string): S
 
 /** One filter facet per tag namespace, with a selectable row for every ancestor level too. */
 export function buildFacets(templates: ActorTemplateEntry[]): TemplateFacet[] {
-  const facetKeys = new Set<string>();
+  const pathsByFacet = new Map<string, Set<string>>();
   for (const template of templates) {
     for (const tag of template.tags) {
       const separatorIndex = tag.indexOf(":");
-      if (separatorIndex !== -1) {
-        facetKeys.add(tag.slice(0, separatorIndex));
+      if (separatorIndex === -1) {
+        continue;
+      }
+      const key = tag.slice(0, separatorIndex);
+      let paths = pathsByFacet.get(key);
+      if (!paths) {
+        paths = new Set();
+        pathsByFacet.set(key, paths);
+      }
+      const segments = tag.slice(separatorIndex + 1).split(":");
+      for (let depth = 1; depth <= segments.length; depth++) {
+        paths.add(segments.slice(0, depth).join(":"));
       }
     }
   }
-  return [...facetKeys].sort().map((key) => ({
-    key,
-    options: [...collectFacetPaths(templates, key)].sort().map((path) => {
-      const segments = path.split(":");
-      return {
-        value: `${key}:${path}`,
-        label: `${INDENT.repeat(segments.length - 1)}${segments[segments.length - 1]}`,
-      };
-    }),
-  }));
+  return [...pathsByFacet.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, paths]) => ({
+      key,
+      options: [...paths].sort().map((path) => {
+        const segments = path.split(":");
+        return {
+          value: `${key}:${path}`,
+          label: `${INDENT.repeat(segments.length - 1)}${segments[segments.length - 1]}`,
+        };
+      }),
+    }));
 }
 
 /** Facet option values (`"<key>:<path>"`) still reachable given every *other* active facet filter. */
@@ -98,6 +109,7 @@ export class ActorTemplatePicker extends HandlebarsApplicationMixin(
   private readonly resolvePick: (uuid: string | undefined) => void;
   private resolved = false;
   private templates: ActorTemplateEntry[] = [];
+  private templatesByUuid = new Map<string, ActorTemplateEntry>();
   private searchFilter?: foundry.applications.ux.SearchFilter;
 
   private constructor(resolvePick: (uuid: string | undefined) => void) {
@@ -140,10 +152,10 @@ export class ActorTemplatePicker extends HandlebarsApplicationMixin(
   override async _prepareContext(): Promise<ActorTemplatePickerContext> {
     if (!this.templates.length) {
       this.templates = await getActorTemplates();
+      this.templatesByUuid = new Map(this.templates.map((template) => [template.uuid, template]));
     }
     const rows: ActorTemplatePickerRow[] = this.templates.map((template) => ({
       ...template,
-      tagsAttr: template.tags.join("|"),
       sourceDisplay: buildSourceDisplay(template),
     }));
     return {
@@ -187,11 +199,13 @@ export class ActorTemplatePicker extends HandlebarsApplicationMixin(
       .map((select) => select.value)
       .filter((value) => value !== "");
     for (const row of html.querySelectorAll<HTMLElement>("[data-uuid]")) {
-      const name = row.dataset["name"] ?? "";
-      const tags = (row.dataset["tags"] ?? "").split("|").filter(Boolean);
-      const matchesQuery = foundry.applications.ux.SearchFilter.testQuery(rgx, name);
+      const template = this.templatesByUuid.get(row.dataset["uuid"] ?? "");
+      const matchesQuery = foundry.applications.ux.SearchFilter.testQuery(
+        rgx,
+        template?.name ?? "",
+      );
       const matchesFacets = facetFilters.every((filterTag) =>
-        actorTagsMatchFilter(tags, filterTag),
+        actorTagsMatchFilter(template?.tags, filterTag),
       );
       row.hidden = !(matchesQuery && matchesFacets);
     }

--- a/src/applications/actor-template-picker/actor-template-picker.ts
+++ b/src/applications/actor-template-picker/actor-template-picker.ts
@@ -1,0 +1,196 @@
+import type { DeepPartial } from "fvtt-types/utils";
+import {
+  actorTagsMatchFilter,
+  getActorTemplates,
+  type ActorTemplateEntry,
+} from "../../system/api/actor-template-api";
+import { systemId } from "../../system/config";
+import { templatePaths } from "../../system/load-handlebars-templates";
+
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+interface ActorTemplatePickerRow extends ActorTemplateEntry {
+  tagsAttr: string;
+  /** `source` plus rqid lang/priority. */
+  sourceDisplay: string;
+}
+
+function buildSourceDisplay(template: ActorTemplateEntry): string {
+  if (!template.rqid?.lang) {
+    return template.source;
+  }
+  const priority = template.rqid.priority;
+  const detail = priority ? `${template.rqid.lang}, priority: ${priority}` : template.rqid.lang;
+  return `${template.source} (${detail})`;
+}
+
+interface TemplateFacet {
+  key: string;
+  options: SelectOptionData<string>[];
+}
+
+interface ActorTemplatePickerContext extends foundry.applications.api.ApplicationV2.RenderContext {
+  templates: ActorTemplatePickerRow[];
+  hasTemplates: boolean;
+  facets: TemplateFacet[];
+}
+
+/** Groups every distinct tag by its colon-hierarchical namespace into one filter facet each. */
+function buildFacets(templates: ActorTemplateEntry[]): TemplateFacet[] {
+  const valuesByFacet = new Map<string, Set<string>>();
+  for (const template of templates) {
+    for (const tag of template.tags) {
+      const separatorIndex = tag.indexOf(":");
+      if (separatorIndex === -1) {
+        continue;
+      }
+      const key = tag.slice(0, separatorIndex);
+      const value = tag.slice(separatorIndex + 1);
+      if (!valuesByFacet.has(key)) {
+        valuesByFacet.set(key, new Set());
+      }
+      valuesByFacet.get(key)?.add(value);
+    }
+  }
+  return [...valuesByFacet.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, values]) => ({
+      key,
+      options: [...values].sort().map((value) => ({ value: `${key}:${value}`, label: value })),
+    }));
+}
+
+/** Searchable/tag-filterable picker for choosing a template actor to clone (#778/#636). */
+export class ActorTemplatePicker extends HandlebarsApplicationMixin(
+  ApplicationV2<ActorTemplatePickerContext>,
+) {
+  private readonly resolvePick: (uuid: string | undefined) => void;
+  private resolved = false;
+  private templates: ActorTemplateEntry[] = [];
+  private searchFilter?: foundry.applications.ux.SearchFilter;
+
+  private constructor(resolvePick: (uuid: string | undefined) => void) {
+    super({});
+    this.resolvePick = resolvePick;
+  }
+
+  static async pick(): Promise<string | undefined> {
+    return new Promise((resolve) => {
+      const app = new ActorTemplatePicker(resolve);
+      void app.render({ force: true });
+    });
+  }
+
+  static override DEFAULT_OPTIONS = {
+    id: "actor-template-picker",
+    classes: [systemId, "actor-template-picker"],
+    window: {
+      title: "RQG.Dialog.ActorTemplatePicker.Title",
+      icon: "fas fa-address-card",
+      resizable: true,
+    },
+    actions: {
+      selectTemplate: ActorTemplatePicker._selectTemplateAction,
+    },
+    position: {
+      width: 560,
+      height: 680,
+    },
+  } satisfies foundry.applications.api.ApplicationV2.DefaultOptions;
+
+  static override PARTS = {
+    body: {
+      template: templatePaths.actorTemplatePicker,
+      scrollable: [".actor-template-picker-list"],
+      root: true,
+    },
+  };
+
+  override async _prepareContext(): Promise<ActorTemplatePickerContext> {
+    if (!this.templates.length) {
+      this.templates = await getActorTemplates();
+    }
+    const rows: ActorTemplatePickerRow[] = this.templates.map((template) => ({
+      ...template,
+      tagsAttr: template.tags.join("|"),
+      sourceDisplay: buildSourceDisplay(template),
+    }));
+    return {
+      templates: rows,
+      hasTemplates: this.templates.length > 0,
+      facets: buildFacets(this.templates),
+    };
+  }
+
+  override async _onRender(
+    context: foundry.applications.api.HandlebarsApplicationMixin.RenderContext,
+    options: DeepPartial<foundry.applications.api.ApplicationV2.RenderOptions>,
+  ): Promise<void> {
+    await super._onRender(context, options);
+
+    this.searchFilter ??= new foundry.applications.ux.SearchFilter({
+      inputSelector: '[name="search"]',
+      contentSelector: ".actor-template-picker-list",
+      callback: this._onSearchFilter.bind(this),
+    });
+    this.searchFilter.bind(this.element);
+
+    for (const select of this.element.querySelectorAll<HTMLSelectElement>("select[data-facet]")) {
+      select.addEventListener("change", () => {
+        // SearchFilter#filter tolerates a null event at runtime despite its type declaration.
+        this.searchFilter?.filter(null as unknown as KeyboardEvent, this.searchFilter.query);
+      });
+    }
+  }
+
+  private _onSearchFilter(
+    _event: KeyboardEvent | null,
+    _query: string,
+    rgx: RegExp,
+    html: HTMLElement | null,
+  ): void {
+    if (!html) {
+      return;
+    }
+    const facetFilters = [...this.element.querySelectorAll<HTMLSelectElement>("select[data-facet]")]
+      .map((select) => select.value)
+      .filter((value) => value !== "");
+    for (const row of html.querySelectorAll<HTMLElement>("[data-uuid]")) {
+      const name = row.dataset["name"] ?? "";
+      const tags = (row.dataset["tags"] ?? "").split("|").filter(Boolean);
+      const matchesQuery = foundry.applications.ux.SearchFilter.testQuery(rgx, name);
+      const matchesFacets = facetFilters.every((filterTag) =>
+        actorTagsMatchFilter(tags, filterTag),
+      );
+      row.hidden = !(matchesQuery && matchesFacets);
+    }
+  }
+
+  private static _selectTemplateAction(
+    this: ActorTemplatePicker,
+    _event: PointerEvent,
+    target: HTMLElement,
+  ): void {
+    const uuid = target.closest<HTMLElement>("[data-uuid]")?.dataset["uuid"];
+    if (!uuid) {
+      return;
+    }
+    this.resolveOnce(uuid);
+    void this.close();
+  }
+
+  private resolveOnce(uuid: string | undefined): void {
+    if (this.resolved) {
+      return;
+    }
+    this.resolved = true;
+    this.resolvePick(uuid);
+  }
+
+  override async close(
+    options?: foundry.applications.api.ApplicationV2.ClosingOptions,
+  ): Promise<this | void> {
+    this.resolveOnce(undefined);
+    return await super.close(options);
+  }
+}

--- a/src/applications/actor-template-picker/actor-template-picker.ts
+++ b/src/applications/actor-template-picker/actor-template-picker.ts
@@ -35,29 +35,60 @@ interface ActorTemplatePickerContext extends foundry.applications.api.Applicatio
   facets: TemplateFacet[];
 }
 
-/** Groups every distinct tag by its colon-hierarchical namespace into one filter facet each. */
-function buildFacets(templates: ActorTemplateEntry[]): TemplateFacet[] {
-  const valuesByFacet = new Map<string, Set<string>>();
+const INDENT = "\u00A0\u00A0"; // non-breaking - a leading regular space can get collapsed in <option> text
+
+/** Colon-path segments (with every ancestor depth) for one facet's tags across `templates`. */
+function collectFacetPaths(templates: ActorTemplateEntry[], facetKey: string): Set<string> {
+  const paths = new Set<string>();
   for (const template of templates) {
     for (const tag of template.tags) {
       const separatorIndex = tag.indexOf(":");
-      if (separatorIndex === -1) {
+      if (separatorIndex === -1 || tag.slice(0, separatorIndex) !== facetKey) {
         continue;
       }
-      const key = tag.slice(0, separatorIndex);
-      const value = tag.slice(separatorIndex + 1);
-      if (!valuesByFacet.has(key)) {
-        valuesByFacet.set(key, new Set());
+      const segments = tag.slice(separatorIndex + 1).split(":");
+      for (let depth = 1; depth <= segments.length; depth++) {
+        paths.add(segments.slice(0, depth).join(":"));
       }
-      valuesByFacet.get(key)?.add(value);
     }
   }
-  return [...valuesByFacet.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, values]) => ({
-      key,
-      options: [...values].sort().map((value) => ({ value: `${key}:${value}`, label: value })),
-    }));
+  return paths;
+}
+
+/** One filter facet per tag namespace, with a selectable row for every ancestor level too. */
+export function buildFacets(templates: ActorTemplateEntry[]): TemplateFacet[] {
+  const facetKeys = new Set<string>();
+  for (const template of templates) {
+    for (const tag of template.tags) {
+      const separatorIndex = tag.indexOf(":");
+      if (separatorIndex !== -1) {
+        facetKeys.add(tag.slice(0, separatorIndex));
+      }
+    }
+  }
+  return [...facetKeys].sort().map((key) => ({
+    key,
+    options: [...collectFacetPaths(templates, key)].sort().map((path) => {
+      const segments = path.split(":");
+      return {
+        value: `${key}:${path}`,
+        label: `${INDENT.repeat(segments.length - 1)}${segments[segments.length - 1]}`,
+      };
+    }),
+  }));
+}
+
+/** Facet option values (`"<key>:<path>"`) still reachable given every *other* active facet filter. */
+export function computeAvailableFacetValues(
+  templates: ActorTemplateEntry[],
+  activeFilters: string[],
+  facetKey: string,
+): Set<string> {
+  const otherFilters = activeFilters.filter((filter) => !filter.startsWith(`${facetKey}:`));
+  const reachable = templates.filter((template) =>
+    otherFilters.every((filter) => actorTagsMatchFilter(template.tags, filter)),
+  );
+  return new Set([...collectFacetPaths(reachable, facetKey)].map((path) => `${facetKey}:${path}`));
 }
 
 /** Searchable/tag-filterable picker for choosing a template actor to clone (#778/#636). */
@@ -163,6 +194,30 @@ export class ActorTemplatePicker extends HandlebarsApplicationMixin(
         actorTagsMatchFilter(tags, filterTag),
       );
       row.hidden = !(matchesQuery && matchesFacets);
+    }
+    this._updateFacetAvailability(facetFilters);
+  }
+
+  /**
+   * Hides options that no other active filter's result set could still contain, so the list stays
+   * scannable. The current selection is kept visible (disabled, not hidden) rather than yanked out
+   * from under the user - that would silently jump the select to a different value.
+   */
+  private _updateFacetAvailability(activeFilters: string[]): void {
+    for (const select of this.element.querySelectorAll<HTMLSelectElement>("select[data-facet]")) {
+      const facetKey = select.dataset["facet"];
+      if (!facetKey) {
+        continue;
+      }
+      const available = computeAvailableFacetValues(this.templates, activeFilters, facetKey);
+      for (const option of select.options) {
+        if (option.value === "") {
+          continue;
+        }
+        const isAvailable = available.has(option.value);
+        option.disabled = !isAvailable;
+        option.hidden = !isAvailable && option.value !== select.value;
+      }
     }
   }
 

--- a/src/data-model/shared/rqg-document-flags.ts
+++ b/src/data-model/shared/rqg-document-flags.ts
@@ -1,5 +1,6 @@
 export const documentRqidFlags = "documentRqidFlags" as const;
 export const actorWizardFlags = "actorWizardFlags" as const;
+export const tagsFlag = "tags" as const;
 export const magicPointStorageOrderFlag = "magicPointStorageOrder" as const;
 
 import type { RqidString } from "../../system/api/rqid-api";
@@ -45,6 +46,8 @@ export interface RqgActorFlags {
     isActorTemplate?: boolean;
     wizardChoices?: string;
   };
+  /** General-purpose colon-hierarchical tags, e.g. "role:adventurer". Write additively. */
+  [tagsFlag]?: string[];
   /** Full Magic Point draw order for the "auto" source: storage item ids plus the literal
    *  "self", interleaved by priority and drag-reorderable from the Magic Point Sources popout
    *  (#956). Entries not listed here fall back to their natural order, self last. */

--- a/src/rqg.css
+++ b/src/rqg.css
@@ -5,6 +5,7 @@
 @import url("./rolls/improvement-roll/improvement-roll.css");
 @import url("./applications/rqid-editor/rqid-editor.css");
 @import url("./applications/rqid-batch-editor/rqid-batch-editor.css");
+@import url("./applications/actor-template-picker/actor-template-picker.css");
 @import url("./applications/experience-roll-session/experience-roll-session.css");
 @import url("./items/itemsheets.css");
 @import url("./items/itemsheets-v2.css");

--- a/src/system/api/actor-template-api.test.ts
+++ b/src/system/api/actor-template-api.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { RQG_CONFIG } from "../config";
+import {
+  actorTagsMatchFilter,
+  compareTemplates,
+  isActorTemplate,
+  tagMatchesFilter,
+  type ActorTemplateEntry,
+} from "./actor-template-api";
+
+const { actorTemplateGateTag } = RQG_CONFIG;
+
+function entry(
+  name: string,
+  source: string,
+  rqid?: ActorTemplateEntry["rqid"],
+): ActorTemplateEntry {
+  return { uuid: `Actor.${name}`, name, tags: [], source, rqid };
+}
+
+describe("tagMatchesFilter", () => {
+  it("matches an exact tag", () => {
+    expect(tagMatchesFilter("role:adventurer", "role:adventurer")).toBe(true);
+  });
+
+  it("matches a colon-hierarchical child of the filter tag", () => {
+    expect(tagMatchesFilter("class:elder-race:troll", "class:elder-race")).toBe(true);
+  });
+
+  it("does not match an unrelated tag", () => {
+    expect(tagMatchesFilter("role:mount", "class:elder-race")).toBe(false);
+  });
+
+  it("does not match a tag that merely shares a prefix without the colon boundary", () => {
+    expect(tagMatchesFilter("class:elder-racehorse", "class:elder-race")).toBe(false);
+  });
+});
+
+describe("actorTagsMatchFilter", () => {
+  it("matches if any tag equals or is a child of the filter", () => {
+    expect(actorTagsMatchFilter(["role:mount", "class:elder-race:troll"], "class:elder-race")).toBe(
+      true,
+    );
+  });
+
+  it("is false when no tag matches", () => {
+    expect(actorTagsMatchFilter(["role:mount"], "class:elder-race")).toBe(false);
+  });
+
+  it("is false for undefined tags", () => {
+    expect(actorTagsMatchFilter(undefined, "class:elder-race")).toBe(false);
+  });
+});
+
+describe("isActorTemplate", () => {
+  it("requires the reserved gate tag", () => {
+    expect(isActorTemplate([actorTemplateGateTag, "class:elder-race:troll"])).toBe(true);
+  });
+
+  it("is false when only descriptive tags are present", () => {
+    expect(isActorTemplate(["class:elder-race:troll", "role:adventurer"])).toBe(false);
+  });
+
+  it("is false for undefined or empty tags", () => {
+    expect(isActorTemplate(undefined)).toBe(false);
+    expect(isActorTemplate([])).toBe(false);
+  });
+});
+
+describe("compareTemplates", () => {
+  const sort = (templates: ActorTemplateEntry[], worldLanguage = "en") =>
+    [...templates].sort((a, b) => compareTemplates(a, b, worldLanguage));
+
+  it("prefers entries matching the world language over others, regardless of name", () => {
+    const templates = [
+      entry("Zorro", "World", { lang: "en" }),
+      entry("Arimaxilus", "World", { lang: "es" }),
+    ];
+    expect(sort(templates, "es").map((t) => t.name)).toEqual(["Arimaxilus", "Zorro"]);
+  });
+
+  it("treats an actor with no rqid as not matching any world language", () => {
+    const templates = [entry("Zorro", "World"), entry("Arimaxilus", "World", { lang: "es" })];
+    expect(sort(templates, "es").map((t) => t.name)).toEqual(["Arimaxilus", "Zorro"]);
+  });
+
+  it("breaks a language tie by rqid priority, higher first", () => {
+    const templates = [
+      entry("Human (Base)", "World", { lang: "en", priority: 0 }),
+      entry("Human (Base)", "wiki-en-rqg — Bestiary", { lang: "en", priority: 5 }),
+    ];
+    expect(sort(templates).map((t) => t.source)).toEqual(["wiki-en-rqg — Bestiary", "World"]);
+  });
+
+  it("treats a missing priority as lower than an explicit priority of 0", () => {
+    const templates = [
+      entry("Human (Base)", "No priority", { lang: "en" }),
+      entry("Human (Base)", "Priority zero", { lang: "en", priority: 0 }),
+    ];
+    expect(sort(templates).map((t) => t.source)).toEqual(["Priority zero", "No priority"]);
+  });
+
+  it("falls back to name when language and priority tie", () => {
+    const templates = [entry("Vasana", "World"), entry("Arimaxilus", "World")];
+    expect(sort(templates).map((t) => t.name)).toEqual(["Arimaxilus", "Vasana"]);
+  });
+
+  it("falls back to source as the final tiebreak", () => {
+    const templates = [entry("Human (Base)", "B source"), entry("Human (Base)", "A source")];
+    expect(sort(templates).map((t) => t.source)).toEqual(["A source", "B source"]);
+  });
+});

--- a/src/system/api/actor-template-api.ts
+++ b/src/system/api/actor-template-api.ts
@@ -1,10 +1,11 @@
+import type { RqgActor } from "../../actors/rqg-actor";
 import {
   documentRqidFlags,
   tagsFlag,
   type DocumentRqidFlags,
 } from "../../data-model/shared/rqg-document-flags";
 import { RQG_CONFIG, systemId } from "../config";
-import { localize } from "../util";
+import { localize, requireValue } from "../util";
 
 /** True if `tag` is `filterTag` itself, or a colon-hierarchical child of it. */
 export function tagMatchesFilter(tag: string, filterTag: string): boolean {
@@ -15,7 +16,7 @@ export function actorTagsMatchFilter(tags: string[] | undefined, filterTag: stri
   return (tags ?? []).some((tag) => tagMatchesFilter(tag, filterTag));
 }
 
-export function isActorTemplate(tags: string[] | undefined): boolean {
+export function isActorTemplate(tags: string[] | undefined): tags is string[] {
   return (tags ?? []).includes(RQG_CONFIG.actorTemplateGateTag);
 }
 
@@ -40,21 +41,21 @@ type ActorTemplateIndexEntry = {
   flags?: { rqg?: { tags?: string[]; documentRqidFlags?: DocumentRqidFlags } };
 };
 
-function toEntry(
-  uuid: string,
-  name: string,
-  img: string | null | undefined,
-  tags: string[],
-  source: string,
-  rqid: DocumentRqidFlags | undefined,
-): ActorTemplateEntry {
+function toEntry(params: {
+  uuid: string;
+  name: string;
+  img: string | null | undefined;
+  tags: string[];
+  source: string;
+  rqid: DocumentRqidFlags | undefined;
+}): ActorTemplateEntry {
   return {
-    uuid,
-    name,
-    img,
-    tags: tags.filter((tag) => tag !== RQG_CONFIG.actorTemplateGateTag),
-    source,
-    rqid,
+    uuid: params.uuid,
+    name: params.name,
+    img: params.img,
+    tags: params.tags.filter((tag) => tag !== RQG_CONFIG.actorTemplateGateTag),
+    source: params.source,
+    rqid: params.rqid,
   };
 }
 
@@ -117,17 +118,19 @@ export async function getActorTemplates(): Promise<ActorTemplateEntry[]> {
       const folderPath = getFolderPath(actor.folder);
       const source = folderPath ? `${worldLabel} — ${folderPath}` : worldLabel;
       const rqid = actor.getFlag(systemId, documentRqidFlags);
-      results.push(toEntry(actor.uuid, actor.name, actor.img, tags ?? [], source, rqid));
+      results.push(
+        toEntry({ uuid: actor.uuid, name: actor.name, img: actor.img, tags, source, rqid }),
+      );
     }
   }
 
-  for (const pack of game.packs ?? []) {
-    if (pack.documentClass?.documentName !== "Actor") {
-      continue;
-    }
-    if (!pack.indexed) {
-      await pack.getIndex();
-    }
+  const actorPacks = [...(game.packs ?? [])].filter(
+    (pack) => pack.documentClass?.documentName === "Actor",
+  );
+  // Load every un-indexed pack's index concurrently rather than one at a time.
+  await Promise.all(actorPacks.filter((pack) => !pack.indexed).map((pack) => pack.getIndex()));
+
+  for (const pack of actorPacks) {
     const packSource = `${getPackSourceLabel(pack)} — ${pack.title}`;
     const indexEntries = [...pack.index.values()] as ActorTemplateIndexEntry[];
     for (const entry of indexEntries) {
@@ -136,7 +139,9 @@ export async function getActorTemplates(): Promise<ActorTemplateEntry[]> {
         const folderPath = entry.folder ? getFolderPath(pack.folders.get(entry.folder)) : "";
         const source = folderPath ? `${packSource} / ${folderPath}` : packSource;
         const rqid = entry.flags?.rqg?.documentRqidFlags;
-        results.push(toEntry(entry.uuid, entry.name, entry.img, tags ?? [], source, rqid));
+        results.push(
+          toEntry({ uuid: entry.uuid, name: entry.name, img: entry.img, tags, source, rqid }),
+        );
       }
     }
   }
@@ -144,4 +149,46 @@ export async function getActorTemplates(): Promise<ActorTemplateEntry[]> {
   const worldLanguage: string =
     game.settings?.get(systemId, "worldLanguage") ?? CONFIG.RQG.fallbackLanguage;
   return results.sort((a, b) => compareTemplates(a, b, worldLanguage));
+}
+
+/**
+ * Clones `templateActor` into a new world actor and drops the picker's gate tag from the clone -
+ * a template instance is a specific actor, not itself a new template.
+ */
+export async function cloneActorFromTemplate(
+  templateActor: RqgActor,
+  updateData: { name?: string; folder?: string },
+): Promise<RqgActor | undefined> {
+  // clone() would otherwise recreate a compendium-sourced template into its own pack.
+  let cloned: RqgActor | undefined;
+  if (templateActor.pack) {
+    requireValue(templateActor.id, "Template actor has no id");
+    cloned = (await game.actors?.importFromCompendium(
+      game.packs.get(
+        templateActor.pack,
+      ) as foundry.documents.collections.CompendiumCollection<"Actor">,
+      templateActor.id,
+      updateData,
+      { renderSheet: false },
+    )) as RqgActor | undefined;
+  } else {
+    cloned = (await templateActor.clone(updateData, {
+      save: true,
+      keepId: false,
+    })) as RqgActor | undefined;
+  }
+  if (!cloned) {
+    return undefined;
+  }
+
+  const tags = cloned.getFlag(systemId, tagsFlag) as string[] | undefined;
+  if (isActorTemplate(tags)) {
+    const remainingTags = tags.filter((tag) => tag !== RQG_CONFIG.actorTemplateGateTag);
+    if (remainingTags.length) {
+      await cloned.setFlag(systemId, tagsFlag, remainingTags);
+    } else {
+      await cloned.unsetFlag(systemId, tagsFlag);
+    }
+  }
+  return cloned;
 }

--- a/src/system/api/actor-template-api.ts
+++ b/src/system/api/actor-template-api.ts
@@ -1,0 +1,147 @@
+import {
+  documentRqidFlags,
+  tagsFlag,
+  type DocumentRqidFlags,
+} from "../../data-model/shared/rqg-document-flags";
+import { RQG_CONFIG, systemId } from "../config";
+import { localize } from "../util";
+
+/** True if `tag` is `filterTag` itself, or a colon-hierarchical child of it. */
+export function tagMatchesFilter(tag: string, filterTag: string): boolean {
+  return tag === filterTag || tag.startsWith(`${filterTag}:`);
+}
+
+export function actorTagsMatchFilter(tags: string[] | undefined, filterTag: string): boolean {
+  return (tags ?? []).some((tag) => tagMatchesFilter(tag, filterTag));
+}
+
+export function isActorTemplate(tags: string[] | undefined): boolean {
+  return (tags ?? []).includes(RQG_CONFIG.actorTemplateGateTag);
+}
+
+export interface ActorTemplateEntry {
+  uuid: string;
+  name: string;
+  img?: string | null;
+  /** All tags except RQG_CONFIG.actorTemplateGateTag. */
+  tags: string[];
+  /** e.g. "World" or "<module title> — <pack title>". */
+  source: string;
+  rqid?: DocumentRqidFlags;
+}
+
+/** Minimal shape of a compendium index entry with actor-template flags. */
+type ActorTemplateIndexEntry = {
+  _id: string;
+  uuid: string;
+  name?: string;
+  img?: string | null;
+  folder?: string;
+  flags?: { rqg?: { tags?: string[]; documentRqidFlags?: DocumentRqidFlags } };
+};
+
+function toEntry(
+  uuid: string,
+  name: string,
+  img: string | null | undefined,
+  tags: string[],
+  source: string,
+  rqid: DocumentRqidFlags | undefined,
+): ActorTemplateEntry {
+  return {
+    uuid,
+    name,
+    img,
+    tags: tags.filter((tag) => tag !== RQG_CONFIG.actorTemplateGateTag),
+    source,
+    rqid,
+  };
+}
+
+/** World language preferred, then rqid priority (like Rqid.compareRqidPrio), then name. */
+export function compareTemplates(
+  a: ActorTemplateEntry,
+  b: ActorTemplateEntry,
+  worldLanguage: string,
+): number {
+  const aMatchesLang = a.rqid?.lang === worldLanguage;
+  const bMatchesLang = b.rqid?.lang === worldLanguage;
+  if (aMatchesLang !== bMatchesLang) {
+    return aMatchesLang ? -1 : 1;
+  }
+
+  // Finite, not Infinity: `-Infinity - -Infinity` is NaN.
+  const NO_PRIORITY = Number.MIN_SAFE_INTEGER;
+  const byPriority = (b.rqid?.priority ?? NO_PRIORITY) - (a.rqid?.priority ?? NO_PRIORITY);
+  if (byPriority !== 0) {
+    return byPriority;
+  }
+
+  const byName = a.name.localeCompare(b.name);
+  if (byName !== 0) {
+    return byName;
+  }
+  return a.source.localeCompare(b.source);
+}
+
+/** The owning module's (or system's) title, falling back to the raw package id. */
+function getPackSourceLabel(pack: CompendiumCollection.Any): string {
+  const packageName = pack.metadata.packageName;
+  if (packageName === game.system?.id) {
+    return game.system?.title ?? packageName;
+  }
+  return game.modules?.get(packageName)?.title ?? packageName;
+}
+
+/** Full "Grandparent / Parent / Folder" path, root first. */
+function getFolderPath(folder: Folder.Stored | null | undefined): string {
+  if (!folder) {
+    return "";
+  }
+  return [...folder.ancestors]
+    .reverse()
+    .concat(folder)
+    .map((f) => f.name)
+    .filter(Boolean)
+    .join(" / ");
+}
+
+/** Scans world Actors and all Actor compendium packs for RQG_CONFIG.actorTemplateGateTag. */
+export async function getActorTemplates(): Promise<ActorTemplateEntry[]> {
+  const results: ActorTemplateEntry[] = [];
+
+  const worldLabel = localize("RQG.Dialog.ActorTemplatePicker.SourceWorld");
+  for (const actor of game.actors ?? []) {
+    const tags = actor.getFlag(systemId, tagsFlag);
+    if (isActorTemplate(tags) && actor.uuid && actor.name) {
+      const folderPath = getFolderPath(actor.folder);
+      const source = folderPath ? `${worldLabel} — ${folderPath}` : worldLabel;
+      const rqid = actor.getFlag(systemId, documentRqidFlags);
+      results.push(toEntry(actor.uuid, actor.name, actor.img, tags ?? [], source, rqid));
+    }
+  }
+
+  for (const pack of game.packs ?? []) {
+    if (pack.documentClass?.documentName !== "Actor") {
+      continue;
+    }
+    if (!pack.indexed) {
+      await pack.getIndex();
+    }
+    const packSource = `${getPackSourceLabel(pack)} — ${pack.title}`;
+    const indexEntries = [...pack.index.values()] as ActorTemplateIndexEntry[];
+    for (const entry of indexEntries) {
+      const tags = entry.flags?.rqg?.tags;
+      if (isActorTemplate(tags) && entry.name) {
+        const folderPath = entry.folder ? getFolderPath(pack.folders.get(entry.folder)) : "";
+        const source = folderPath ? `${packSource} / ${folderPath}` : packSource;
+        const rqid = entry.flags?.rqg?.documentRqidFlags;
+        results.push(toEntry(entry.uuid, entry.name, entry.img, tags ?? [], source, rqid));
+      }
+    }
+  }
+
+  const worldLanguage: string =
+    game.settings?.get(systemId, "worldLanguage") ?? CONFIG.RQG.fallbackLanguage;
+  return results.sort((a, b) => compareTemplates(a, b, worldLanguage));
+}

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -19,6 +19,9 @@ export const RQG_CONFIG = {
     magic: "i.rune.magic-condition" as RqidString,
   },
 
+  // Tag that gates an actor's visibility in the Create Actor template picker
+  actorTemplateGateTag: "role:template",
+
   bodytypes: {
     humanoid: [
       "i.hit-location.head" as RqidString,

--- a/src/system/load-handlebars-templates.ts
+++ b/src/system/load-handlebars-templates.ts
@@ -102,6 +102,10 @@ export const templatePaths = {
   // Actor Wizard
   actorWizardApplication: "systems/rqg/applications/actor-wizard-application.hbs",
 
+  // Create Actor dialog template picker (#778/#636)
+  actorTemplatePicker: "systems/rqg/applications/actor-template-picker/actor-template-picker.hbs",
+  actorCreateDialogContent: "systems/rqg/actors/rqg-actor-create-dialog-content.hbs",
+
   // Experience Roll Session
   experienceRollSessionHeader:
     "systems/rqg/applications/experience-roll-session/experience-roll-session-header.hbs",

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -620,6 +620,18 @@
         "SummaryRuneMagic": "The RQG System uses a System ID (Rqid). This allows the system to identify FoundryVTT documents for example skills. This page will allow you to set the id for existing rune magic documents that do not yet have a Rqid. The Rqid should use the English translation of the name to support localization across all languages.<br><br><b>Currently only the common rune magic spells need a Rqid (Command Cult Spirit, Divination, Sanctify, Summon Cult Spirit, Dismiss Magic, Extension, Multispell, Find Enemy, Heal Wound, Soul Sight, Spirit Block, and Warding)</b>",
         "ButtonUpdate": "Update"
       },
+      "ActorCreate": {
+        "StartFrom": "Start from",
+        "Blank": "Blank",
+        "ChooseTemplate": "Choose template..."
+      },
+      "ActorTemplatePicker": {
+        "Title": "Choose a Template",
+        "SearchPlaceholder": "Search templates...",
+        "Empty": "No template actors were found. Templates are actors flagged for this picker by a compendium module.",
+        "SourceWorld": "World",
+        "Any": "Any"
+      },
       "Common": {
         "yes": "yes",
         "no": "no",

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -628,7 +628,7 @@
       "ActorTemplatePicker": {
         "Title": "Create Actor from Template",
         "SearchPlaceholder": "Search templates...",
-        "Empty": "No template actors were found. Templates are actors flagged for this picker by a compendium module.",
+        "Empty": "No template actors were found. Update your RQG wiki module to version 2.1.0 or later - it tags its bestiary and adventurer actors so they show up here automatically.",
         "SourceWorld": "World",
         "Any": "Any"
       },

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -626,7 +626,7 @@
         "ChooseTemplate": "Choose template..."
       },
       "ActorTemplatePicker": {
-        "Title": "Choose a Template",
+        "Title": "Create Actor from Template",
         "SearchPlaceholder": "Search templates...",
         "Empty": "No template actors were found. Templates are actors flagged for this picker by a compendium module.",
         "SourceWorld": "World",


### PR DESCRIPTION
## Summary
- Extends Foundry's native "Create Actor" dialog with a "Start from" field: **Blank** (unchanged default) or **Choose template...**, which opens a searchable/faceted picker of template actors to clone.
- Templates are discovered by a reserved `role:template` tag (`RQG_CONFIG.actorTemplateGateTag`) scanned across world Actors and every Actor compendium pack - no hardcoded pack names, so a future bestiary module is picked up the same way the wiki module is.
- Descriptive tags (`role:adventurer`, `species:human`, ...) are colon-hierarchical strings, matching both Foundry's own (twice-proposed) native Document Tags format and the community `document-tagger` module's format.
- The picker groups tags into one filter dropdown per namespace, shows each result's source (world/pack + folder path) and rqid language, and ranks results by world-language match then rqid priority then name - mirroring how `Rqid` resolution itself prefers matches, without using rqid id as a ranking input.
- Selecting a template clones it (`clone()` for a world-sourced template, `importFromCompendium()` for a pack-sourced one, to avoid `clone()`'s default of recreating the copy back into the source pack) rather than reimplementing selective item-copy logic.
- Independent of the dormant #101/#634 character-creation-wizard epic; only the "template actor" idea is reused, via its own flag namespace.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (781 tests), `pnpm i18n:audit:en`, `pnpm build:system` all pass
- [x] Manual smoke test in a live world: Create Actor → Blank still behaves exactly as before
- [x] Manual smoke test: Create Actor → Choose template... → search/facet filters narrow the list → selecting one clones it with items intact
- [x] Manual smoke test: cancelling the picker falls back to blank creation without error
- [x] Wiki module content needs `role:template` (+ descriptive tags) added to actors meant to appear here - picker's empty state handles the meantime gracefully

Closes #1055