### PR TITLE
fix: dropping a weapon/spell on the hotbar creates an action macro

### DIFF
--- a/src/foundry-ui/rqg-hotbar.ts
+++ b/src/foundry-ui/rqg-hotbar.ts
@@ -7,7 +7,8 @@ import Document = foundry.abstract.Document;
 /**
  * The kind of macros that can be created by dropping a document onto the Hotbar.
  */
-type MacroAction = "abilityRoll" | "rollTable" | "toggleSheet";
+type MacroAction =
+  "abilityRoll" | "attack" | "spiritMagicRoll" | "runeMagicRoll" | "rollTable" | "toggleSheet";
 
 export class RqgHotbar extends Hotbar {
   static init() {
@@ -19,8 +20,27 @@ export class RqgHotbar extends Hotbar {
    */
   static macroActions = new Map<MacroAction, (doc: Document.Any) => string>([
     ["abilityRoll", (doc) => `const item = await fromUuid("${doc.uuid}"); item.abilityRoll();`],
+    ["attack", (doc) => `const item = await fromUuid("${doc.uuid}"); item.attack();`],
+    [
+      "spiritMagicRoll",
+      (doc) => `const item = await fromUuid("${doc.uuid}"); item.spiritMagicRoll();`,
+    ],
+    ["runeMagicRoll", (doc) => `const item = await fromUuid("${doc.uuid}"); item.runeMagicRoll();`],
     ["rollTable", (doc) => `(await fromUuid("${doc.uuid}")).draw()`],
     ["toggleSheet", (doc) => `Hotbar.toggleDocumentSheet("${doc.uuid}")`],
+  ]);
+
+  /**
+   * Item types that have a dedicated action to perform (roll, cast, attack) instead of just
+   * toggling the item sheet when dropped onto the Hotbar.
+   */
+  static itemActions = new Map<Item.SubType, MacroAction>([
+    [ItemTypeEnum.Weapon, "attack"],
+    [ItemTypeEnum.SpiritMagic, "spiritMagicRoll"],
+    [ItemTypeEnum.RuneMagic, "runeMagicRoll"],
+    [ItemTypeEnum.Passion, "abilityRoll"],
+    [ItemTypeEnum.Rune, "abilityRoll"],
+    [ItemTypeEnum.Skill, "abilityRoll"],
   ]);
 
   /**
@@ -44,36 +64,18 @@ export class RqgHotbar extends Hotbar {
   }
 
   getMacroCommandAndName(doc: Document.Any): { command: string | undefined; name: string } {
-    // Item that can be sent to chat
-    // if (
-    //   doc.documentName === "Item" &&
-    //   [
-    //     ItemTypeEnum.RuneMagic,
-    //     ItemTypeEnum.ShamanicAbility,
-    //     ItemTypeEnum.SorceryMagic,
-    //     ItemTypeEnum.SpiritMagic,
-    //     ItemTypeEnum.Weapon,
-    //   ].includes(doc.type)
-    // ) {
-    //   const actorName = doc?.parent?.prototypeToken?.name;
-    //   const translationKey = actorName
-    //     ? "RQG.Hotbar.MacroName.ToChatEmbedded"
-    //     : "RQG.Hotbar.MacroName.ToChat";
-    //   const name = localize(translationKey, { name: doc.name, actor: actorName });
-    //   return { command: RqgHotbar.macroActions.get("toChat")?.(doc), name: name };
-    // }
+    const actorName = (doc.parent as Actor | null)?.prototypeToken?.name;
 
-    // Items that can show an AbilityRollDialog
-    if (
-      doc.documentName === "Item" &&
-      [ItemTypeEnum.Passion, ItemTypeEnum.Rune, ItemTypeEnum.Skill].includes((doc as Item).type)
-    ) {
-      const actorName = (doc.parent as Actor | null)?.prototypeToken?.name;
-      const translationKey = actorName
-        ? "RQG.Hotbar.MacroName.ToChatEmbedded"
-        : "RQG.Hotbar.MacroName.ToChat";
-      const name = localize(translationKey, { name: doc.name ?? "", actor: actorName ?? "" });
-      return { command: RqgHotbar.macroActions.get("abilityRoll")?.(doc), name: name };
+    // Items with a dedicated action (roll, cast spell, attack) instead of the item sheet
+    if (doc.documentName === "Item") {
+      const macroAction = RqgHotbar.itemActions.get((doc as Item).type);
+      if (macroAction) {
+        const translationKey = actorName
+          ? "RQG.Hotbar.MacroName.ToChatEmbedded"
+          : "RQG.Hotbar.MacroName.ToChat";
+        const name = localize(translationKey, { name: doc.name ?? "", actor: actorName ?? "" });
+        return { command: RqgHotbar.macroActions.get(macroAction)?.(doc), name: name };
+      }
     }
 
     // Roll table (draw a result and send to chat)
@@ -85,7 +87,6 @@ export class RqgHotbar extends Hotbar {
     }
 
     // Default - toggle the display of the document sheet
-    const actorName = (doc.parent as Actor | null)?.prototypeToken?.name;
     const translationKey = actorName
       ? "RQG.Hotbar.MacroName.ToggleSheetEmbedded"
       : "RQG.Hotbar.MacroName.ToggleSheet";

--- a/src/foundry-ui/rqg-hotbar.ts
+++ b/src/foundry-ui/rqg-hotbar.ts
@@ -17,7 +17,8 @@ type MacroAction =
   | "runeMagicRoll"
   | "rollTable"
   | "toggleSheet"
-  | "openJournalPage";
+  | "openJournalPage"
+  | "viewScene";
 
 export class RqgHotbar extends Hotbar {
   static init() {
@@ -82,6 +83,7 @@ export class RqgHotbar extends Hotbar {
       (doc) =>
         `const page = await fromUuid("${doc.uuid}"); page.parent.sheet.render(true, { pageId: page.id });`,
     ],
+    ["viewScene", (doc) => `const scene = await fromUuid("${doc.uuid}"); scene.view();`],
   ]);
 
   /**
@@ -176,6 +178,14 @@ export class RqgHotbar extends Hotbar {
       return {
         command: RqgHotbar.macroActions.get("openJournalPage")?.(doc),
         name: localize("RQG.Hotbar.MacroName.OpenJournalPage", { name: doc.name ?? "" }),
+      };
+    }
+
+    // Scene - view it on the canvas, instead of opening its configuration sheet.
+    if (doc.documentName === "Scene") {
+      return {
+        command: RqgHotbar.macroActions.get("viewScene")?.(doc),
+        name: localize("RQG.Hotbar.MacroName.ViewScene", { name: doc.name ?? "" }),
       };
     }
 

--- a/src/foundry-ui/rqg-hotbar.ts
+++ b/src/foundry-ui/rqg-hotbar.ts
@@ -1,4 +1,4 @@
-import { localize } from "../system/util";
+import { isDocumentSubType, localize } from "../system/util";
 import { ItemTypeEnum } from "@item-model/item-types.ts";
 import type { WeaponItem } from "@item-model/weapon-data-model.ts";
 import { weaponUsageTypes } from "../data-model/shared/weapon-usage-choices";
@@ -52,10 +52,10 @@ export class RqgHotbar extends Hotbar {
    * e.g. plain ammunition like arrows - a javelin still gets a macro since it can be thrown itself.
    */
   override async _createDocumentSheetToggle(doc: Document.Any): Promise<Macro.Implementation> {
-    if (doc.documentName === "Item" && (doc as Item).type === ItemTypeEnum.Weapon) {
-      const weapon = doc as unknown as WeaponItem;
+    const item = doc.documentName === "Item" ? (doc as Item) : undefined;
+    if (isDocumentSubType<WeaponItem>(item, ItemTypeEnum.Weapon)) {
       const isAttackable = weaponUsageTypes.some((usageType) =>
-        hasLinkedSkillReference(weapon, usageType),
+        hasLinkedSkillReference(item, usageType),
       );
       if (!isAttackable) {
         ui.notifications?.warn(

--- a/src/foundry-ui/rqg-hotbar.ts
+++ b/src/foundry-ui/rqg-hotbar.ts
@@ -1,5 +1,8 @@
 import { localize } from "../system/util";
 import { ItemTypeEnum } from "@item-model/item-types.ts";
+import type { WeaponItem } from "@item-model/weapon-data-model.ts";
+import { weaponUsageTypes } from "../data-model/shared/weapon-usage-choices";
+import { hasLinkedSkillReference } from "../items/weapon-item/weapon-skill-links";
 
 import Hotbar = foundry.applications.ui.Hotbar;
 import Document = foundry.abstract.Document;
@@ -45,9 +48,25 @@ export class RqgHotbar extends Hotbar {
 
   /**
    * Create a Macro document that with a macroAction depending on what document is dropped.
-   *
+   * Returns undefined (adding nothing to the Hotbar) for weapons with no attackable usage type,
+   * e.g. plain ammunition like arrows - a javelin still gets a macro since it can be thrown itself.
    */
   override async _createDocumentSheetToggle(doc: Document.Any): Promise<Macro.Implementation> {
+    if (doc.documentName === "Item" && (doc as Item).type === ItemTypeEnum.Weapon) {
+      const weapon = doc as unknown as WeaponItem;
+      const isAttackable = weaponUsageTypes.some((usageType) =>
+        hasLinkedSkillReference(weapon, usageType),
+      );
+      if (!isAttackable) {
+        ui.notifications?.warn(
+          localize("RQG.Hotbar.Warning.NotAddableToMacroBar", { name: doc.name ?? "" }),
+        );
+        // @ts-expect-error Returning undefined intentionally skips adding a macro to the Hotbar,
+        // which is what the Foundry core caller already does when this returns a falsy value.
+        return undefined;
+      }
+    }
+
     const { command, name } = this.getMacroCommandAndName(doc);
 
     // @ts-expect-error create

--- a/src/foundry-ui/rqg-hotbar.ts
+++ b/src/foundry-ui/rqg-hotbar.ts
@@ -16,6 +16,46 @@ type MacroAction =
 export class RqgHotbar extends Hotbar {
   static init() {
     CONFIG.ui.hotbar = RqgHotbar;
+    Hooks.on("hotbarDrop", RqgHotbar.onHotbarDrop);
+  }
+
+  /**
+   * Foundry doesn't resolve a dropped Compendium pack to a Document - there's no "Compendium"
+   * document type - so the core Hotbar silently does nothing when one is dropped. Create a macro
+   * that opens the compendium here instead, and cancel the (otherwise no-op) default handling.
+   *
+   * Must return synchronously: Hooks.call checks `=== false` on the direct return value, so an
+   * async function (which always returns a Promise) could never cancel the default handling.
+   */
+  static onHotbarDrop(
+    _hotbar: foundry.applications.ui.Hotbar.Any,
+    data: Macro.DropData,
+    slot: number,
+  ): boolean | void {
+    const dropData = data as unknown as { type?: string; collection?: string };
+    if (dropData.type !== "Compendium" || !dropData.collection) {
+      return;
+    }
+
+    void RqgHotbar.createCompendiumOpenMacro(dropData.collection, slot);
+    return false;
+  }
+
+  private static async createCompendiumOpenMacro(collection: string, slot: number): Promise<void> {
+    const pack = game.packs?.get(collection);
+    if (!pack) {
+      return;
+    }
+
+    const macro = await Macro.implementation.create({
+      name: localize("RQG.Hotbar.MacroName.OpenCompendium", { name: pack.title }),
+      type: CONST.MACRO_TYPES.SCRIPT,
+      img: "icons/svg/book.svg",
+      command: `game.packs.get("${collection}")?.render(true);`,
+    });
+    if (macro) {
+      await game.user?.assignHotbarMacro(macro, slot);
+    }
   }
 
   /**
@@ -48,22 +88,23 @@ export class RqgHotbar extends Hotbar {
 
   /**
    * Create a Macro document that with a macroAction depending on what document is dropped.
-   * Returns undefined (adding nothing to the Hotbar) for weapons with no attackable usage type,
-   * e.g. plain ammunition like arrows - a javelin still gets a macro since it can be thrown itself.
+   * Returns undefined (adding nothing to the Hotbar) for documents with no reasonable hotbar
+   * action: a Folder (dropping one just toggled a not-very-useful sheet), and a weapon with no
+   * attackable usage type, e.g. plain ammunition like arrows - a javelin still gets a macro
+   * since it can be thrown itself.
    */
   override async _createDocumentSheetToggle(doc: Document.Any): Promise<Macro.Implementation> {
+    if (doc.documentName === "Folder") {
+      return this.notAddableToMacroBar(doc);
+    }
+
     const item = doc.documentName === "Item" ? (doc as Item) : undefined;
     if (isDocumentSubType<WeaponItem>(item, ItemTypeEnum.Weapon)) {
       const isAttackable = weaponUsageTypes.some((usageType) =>
         hasLinkedSkillReference(item, usageType),
       );
       if (!isAttackable) {
-        ui.notifications?.warn(
-          localize("RQG.Hotbar.Warning.NotAddableToMacroBar", { name: doc.name ?? "" }),
-        );
-        // @ts-expect-error Returning undefined intentionally skips adding a macro to the Hotbar,
-        // which is what the Foundry core caller already does when this returns a falsy value.
-        return undefined;
+        return this.notAddableToMacroBar(doc);
       }
     }
 
@@ -76,6 +117,19 @@ export class RqgHotbar extends Hotbar {
       img: this.getMacroImg(doc),
       command: command,
     });
+  }
+
+  /**
+   * Warn instead of creating a Macro for a document that has no reasonable standalone hotbar
+   * action. Returning undefined skips adding anything to the Hotbar, which is what the Foundry
+   * core caller already does when this returns a falsy value.
+   */
+  notAddableToMacroBar(doc: Document.Any): Macro.Implementation {
+    ui.notifications?.warn(
+      localize("RQG.Hotbar.Warning.NotAddableToMacroBar", { name: doc.name ?? "" }),
+    );
+    // @ts-expect-error Intentionally undefined - see the method doc comment above.
+    return undefined;
   }
 
   getMacroImg(doc: Document.Any): string | undefined {

--- a/src/foundry-ui/rqg-hotbar.ts
+++ b/src/foundry-ui/rqg-hotbar.ts
@@ -11,7 +11,13 @@ import Document = foundry.abstract.Document;
  * The kind of macros that can be created by dropping a document onto the Hotbar.
  */
 type MacroAction =
-  "abilityRoll" | "attack" | "spiritMagicRoll" | "runeMagicRoll" | "rollTable" | "toggleSheet";
+  | "abilityRoll"
+  | "attack"
+  | "spiritMagicRoll"
+  | "runeMagicRoll"
+  | "rollTable"
+  | "toggleSheet"
+  | "openJournalPage";
 
 export class RqgHotbar extends Hotbar {
   static init() {
@@ -71,6 +77,11 @@ export class RqgHotbar extends Hotbar {
     ["runeMagicRoll", (doc) => `const item = await fromUuid("${doc.uuid}"); item.runeMagicRoll();`],
     ["rollTable", (doc) => `(await fromUuid("${doc.uuid}")).draw()`],
     ["toggleSheet", (doc) => `Hotbar.toggleDocumentSheet("${doc.uuid}")`],
+    [
+      "openJournalPage",
+      (doc) =>
+        `const page = await fromUuid("${doc.uuid}"); page.parent.sheet.render(true, { pageId: page.id });`,
+    ],
   ]);
 
   /**
@@ -156,6 +167,15 @@ export class RqgHotbar extends Hotbar {
       return {
         command: RqgHotbar.macroActions.get("rollTable")?.(doc),
         name: localize("RQG.Hotbar.MacroName.RollTable", { name: doc.name ?? "" }),
+      };
+    }
+
+    // Journal Entry Page - open the parent Journal Entry sheet with this page selected,
+    // instead of the page's own standalone editor.
+    if (doc.documentName === "JournalEntryPage") {
+      return {
+        command: RqgHotbar.macroActions.get("openJournalPage")?.(doc),
+        name: localize("RQG.Hotbar.MacroName.OpenJournalPage", { name: doc.name ?? "" }),
       };
     }
 

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -1258,7 +1258,8 @@
         "ToggleSheet": "Display Sheet {name}",
         "ToggleSheetEmbedded": "Display Sheet {name} ({actor})",
         "OpenCompendium": "Open Compendium {name}",
-        "OpenJournalPage": "Open {name}"
+        "OpenJournalPage": "Open {name}",
+        "ViewScene": "View {name}"
       },
       "Warning": {
         "NotAddableToMacroBar": "{name} can't be added to the macro bar - there's no action to perform with it on its own"

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -1256,7 +1256,8 @@
         "ToChatEmbedded": "Use {name} ({actor})",
         "RollTable": "Roll table {name}",
         "ToggleSheet": "Display Sheet {name}",
-        "ToggleSheetEmbedded": "Display Sheet {name} ({actor})"
+        "ToggleSheetEmbedded": "Display Sheet {name} ({actor})",
+        "OpenCompendium": "Open Compendium {name}"
       },
       "Warning": {
         "NotAddableToMacroBar": "{name} can't be added to the macro bar - there's no action to perform with it on its own"

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -1257,7 +1257,8 @@
         "RollTable": "Roll table {name}",
         "ToggleSheet": "Display Sheet {name}",
         "ToggleSheetEmbedded": "Display Sheet {name} ({actor})",
-        "OpenCompendium": "Open Compendium {name}"
+        "OpenCompendium": "Open Compendium {name}",
+        "OpenJournalPage": "Open {name}"
       },
       "Warning": {
         "NotAddableToMacroBar": "{name} can't be added to the macro bar - there's no action to perform with it on its own"

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -1257,6 +1257,9 @@
         "RollTable": "Roll table {name}",
         "ToggleSheet": "Display Sheet {name}",
         "ToggleSheetEmbedded": "Display Sheet {name} ({actor})"
+      },
+      "Warning": {
+        "NotAddableToMacroBar": "{name} can't be added to the macro bar - there's no action to perform with it on its own"
       }
     },
     "Foundry": {


### PR DESCRIPTION
## Summary

- Dragging a **Weapon** item onto the hotbar now creates a macro that opens the attack dialog (`item.attack()`), instead of just toggling the weapon sheet.
- Dragging a **Spirit Magic** or **Rune Magic** item onto the hotbar now creates a macro that opens the cast dialog (`item.spiritMagicRoll()` / `item.runeMagicRoll()`).
- This matches how Skill, Rune and Passion items already behave (`item.abilityRoll()`), finishing the half-implemented (commented-out) attempt at this that was already in the code.
- Refactored the per-item-type branches in `getMacroCommandAndName` into a single `itemActions` lookup map to avoid repeating the name/translation-key logic four times.
- Dragging a weapon with no attackable usage type (pure ammunition like arrows) onto the hotbar now shows a warning notification and adds nothing to the bar, instead of creating a macro that errors when run. A weapon that's both ammunition and independently attackable (e.g. a javelin) still gets a working attack macro.
- Dragging a **Compendium** pack onto the hotbar now creates a macro that opens it (`game.packs.get(...).render(true)`). Foundry core has no "Compendium" document type, so its default hotbar-drop handling silently did nothing for this case - handled here via the `hotbarDrop` hook, which core checks before its own (no-op) handling.
- Dragging a **Folder** onto the hotbar now shows the same "can't be added" warning as unusable weapons, instead of creating a not-very-useful "toggle sheet" macro.
- Dragging a **Journal Entry Page** onto the hotbar now opens the parent Journal Entry with that page selected (`parent.sheet.render(true, {pageId})`), matching how clicking a page content link already behaves, instead of opening the page's own standalone editor sheet.
- Dragging a **Scene** onto the hotbar now views it (`scene.view()`), matching the sidebar's "View" context menu action, instead of opening its SceneConfig sheet.

Closes #874. Related to #402 - discussed the remaining follow-ups from that issue:
- Token actors: confirmed as a Foundry engine limitation, not something we can fix (canvas tokens use PIXI pointer-drag, not native HTML5 drag/drop, so they can't be dropped on the hotbar at all).
- Dragging a weapon skill: already works fine (any Skill item, including weapon skills, drags correctly).
- Projectile weapons: handled in this PR via the warning notification above.
- Dragging an item's image: already fixed elsewhere by adding a drag handle.
- Dragging "Dodge" from the combat tab: split out into a broader issue, #1059 (drag-and-drop from the Combat tab appears generally broken), targeted at 6.2.0.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — no new errors
- [x] `pnpm test` — full vitest suite passes (789/789)
- [ ] Manual: drag a Weapon/Spirit Magic/Rune Magic item to the hotbar in Foundry and confirm the created macro opens the right dialog (not exercised — no running Foundry instance in this environment)
- [ ] Manual: drag a pure-ammunition weapon (e.g. arrows) to the hotbar and confirm a warning notification appears and nothing is added to the bar
- [ ] Manual: drag a Compendium pack to the hotbar and confirm the created macro opens that compendium
- [ ] Manual: drag a Folder to the hotbar and confirm a warning notification appears and nothing is added to the bar
- [ ] Manual: drag a Journal Entry Page to the hotbar and confirm the created macro opens the parent journal with that page selected, not the page's standalone editor
- [ ] Manual: drag a Scene to the hotbar and confirm the created macro views that scene, not its config sheet