### PR TITLE
fix: Combat tab items unable to be dragged to the hotbar

### DIFF
--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -165,9 +165,9 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
   // Runtime override of ActorSheetV2 _dragDrop; current fvtt-types do not expose this member.
   protected get _dragDrop(): foundry.applications.ux.DragDrop.Implementation {
     this._rqgDragDrop ??= new foundry.applications.ux.DragDrop.implementation({
-      // Also matches Spell Matrix drag handles (not real Items).
+      // Also matches Spell Matrix and weapon-row drag handles (separate attributes).
       dragSelector:
-        "[data-item-drag-handle][data-item-id], [data-matrix-spell-drag-handle][data-item-id]",
+        "[data-item-drag-handle][data-item-id], [data-matrix-spell-drag-handle][data-item-id], [data-weapon-drag-handle][data-item-id]",
       // Include a non-root content drop target for generic Foundry handling.
       // Do not include the root selector here: if html.matches(dropSelector),
       // Foundry binds only the root and skips descendant dropzones.

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
@@ -397,7 +397,7 @@
             <div data-item-id="{{dodgeSkillData.id}}" data-item-roll data-tooltip="{{localize "RQG.Game.RollTitle"}}"
                 class="skill contextmenu"
                 {{#if dodgeSkillData.system.descriptionRqidLink.rqid}}data-rqid-link="{{dodgeSkillData.system.descriptionRqidLink.rqid}}"{{/if}}>
-              <img class="row-icon" src="{{dodgeSkillData.img}}">
+              {{#if @root.isEditable}}<span class="weapon-drag-handle item draggable" data-weapon-drag-handle data-item-id="{{dodgeSkillData.id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{dodgeSkillData.img}}">
             </div>
             <div data-item-id="{{dodgeSkillData.id}}" data-item-roll data-tooltip="{{localize "RQG.Game.RollTitle"}}" class="skill contextmenu">{{localize "RQG.Actor.Combat.Dodge"}}</div>
             <div data-item-id="{{dodgeSkillData.id}}" data-item-roll data-tooltip="{{localize "RQG.Game.RollTitle"}}" class="skill contextmenu"></div>
@@ -422,7 +422,7 @@
             <div data-item-id="{{spiritCombatSkillData.id}}"
                 class="skill contextmenu"
                 {{#if spiritCombatSkillData.system.descriptionRqidLink.rqid}}data-rqid-link="{{spiritCombatSkillData.system.descriptionRqidLink.rqid}}"{{/if}}>
-              <img class="row-icon" src="{{spiritCombatSkillData.img}}">
+              {{#if @root.isEditable}}<span class="weapon-drag-handle item draggable" data-weapon-drag-handle data-item-id="{{spiritCombatSkillData.id}}"><span class="grip-icon"></span></span>{{/if}}<img class="row-icon" src="{{spiritCombatSkillData.img}}">
             </div>
             <div data-item-id="{{spiritCombatSkillData.id}}"
                 class="skill contextmenu"


### PR DESCRIPTION
## Summary
- The `DragDrop` `dragSelector` only matched `[data-item-drag-handle]`, but Combat-tab weapon rows use a separate `[data-weapon-drag-handle]` attribute — Foundry's `DragDrop.bind()` only makes elements matching `dragSelector` draggable, so weapon rows never became drag sources at all (the drop-side handler already understood the attribute, it just never fired).
- The Dodge and Spirit Combat rows had no drag handle markup whatsoever.
- Adds `[data-weapon-drag-handle][data-item-id]` to the selector, and gives Dodge/Spirit Combat the same handle as weapon rows (gated on `isEditable`, matching the rest of the tab).

Closes #1059.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Full test suite passes (via pre-push hook)
- [x] Verified live in a running world: before the fix, weapon/Dodge/Spirit-Combat drag handles had no `draggable` attribute and no bound `dragstart`; after the fix all three render `draggable="true"` with a bound handler, and a synthetic `dragstart` correctly populates `dataTransfer` with the item's UUID
- [ ] Manually drag a weapon, Dodge, and Spirit Combat from the Combat tab onto the hotbar and confirm each creates a working macro

🤖 Generated with [Claude Code](https://claude.com/claude-code)