### PR TITLE
fix: restore isCreature checkbox on v2 actor sheet

### DIFF
--- a/src/actors/sheet-parts-v2/actor-sheet-v2-header.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-header.hbs
@@ -132,6 +132,12 @@
             {{/if}}
           </label>
         {{/if}}
+        {{#edit-mode system.editMode "gm"}}
+          <label data-tooltip="{{localize 'RQG.Actor.Attributes.CreatureExplanation'}}">
+            <input type="checkbox" name="system.attributes.isCreature" {{checked system.attributes.isCreature}}>
+            {{localize "RQG.Actor.Attributes.CreatureQ"}}
+          </label>
+        {{/edit-mode}}
       </div>
 
       <div class="mov-enc">


### PR DESCRIPTION
## Summary
- Restores the GM-only "is creature" checkbox that existed on the v1 actor sheet but was dropped in the v2 conversion.
- Only visible to the GM in edit mode; hidden entirely in play mode (no checkbox, no "Creature" label).

Fixes #1061

## Test plan
- [x] `tsc -noEmit`, i18n audit, and full test suite pass (789 tests)
- [x] Manually verify in Foundry: GM edit mode shows the checkbox and toggling it persists `system.attributes.isCreature`; play mode shows nothing for GM and players