### PR TITLE
feat: resistance table rolls, requests, and a spell POW-vs-POW hook

### DIFF
--- a/buildScripts/i18n-dynamic-key-map.ts
+++ b/buildScripts/i18n-dynamic-key-map.ts
@@ -34,6 +34,7 @@ import {
   SpellRangeEnum,
   SpellDurationEnum,
   SpellConcentrationEnum,
+  SpellResistanceCheckEnum,
 } from "../src/data-model/item-data/spell";
 import { AbilitySuccessLevelEnum } from "../src/rolls/ability-roll/ability-roll.defs";
 
@@ -146,6 +147,7 @@ export const dynamicKeyMap: Record<string, readonly string[]> = {
     "undefined",
   ],
   "RQG.Item.Spell.RangeEnum.": [...Object.values(SpellRangeEnum).filter(Boolean), "undefined"],
+  "RQG.Item.Spell.ResistanceCheckEnum.": [...Object.values(SpellResistanceCheckEnum)],
 
   // Item - Weapon
   "RQG.Item.Weapon.combatManeuver.": [...combatManeuverNames],

--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -1480,6 +1480,16 @@
         display: flex;
         justify-content: space-between;
         align-items: baseline;
+
+        & button[data-request-resistance-roll] {
+          width: 1.7rem;
+          height: 1.7rem;
+          padding: 0;
+          align-self: center;
+          border-style: outset;
+          background-color: var(--rqg-color-sr-button-bg);
+          border-radius: var(--rqg-radius-md);
+        }
       }
 
       & .health-state {

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -770,6 +770,15 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       });
     });
 
+    // GM-only: request a resistance-table check from this actor's owner (Combat tab)
+    this.element.querySelectorAll<HTMLElement>("[data-request-resistance-roll]").forEach((el) => {
+      el.addEventListener("click", async () => {
+        const { openResistanceRequest } =
+          await import("../applications/resistance-roll-dialog/open-resistance-request");
+        await openResistanceRequest(this.document.token?.uuid || this.actor.uuid || "");
+      });
+    });
+
     // Handle in-grid editing of runes
     this.element.querySelectorAll<HTMLElement>("[data-rune-grid-edit]").forEach((el) => {
       el.addEventListener("change", async (event) => {

--- a/src/actors/rqg-actor.ts
+++ b/src/actors/rqg-actor.ts
@@ -592,12 +592,14 @@ export class RqgActor extends Actor {
   public async checkExperience(
     characteristicName: string,
     result: AbilitySuccessLevelEnum | undefined,
+    chance?: number,
   ): Promise<void> {
     assertDocumentSubType<CharacterActor>(this, ActorTypeEnum.Character);
     if (
       result != null &&
       result <= AbilitySuccessLevelEnum.Success &&
-      characteristicName === "power"
+      characteristicName === "power" &&
+      (chance == null || chance < 95) // a roll made at 95%+ is too easy to count as stress
     ) {
       ui.notifications?.info(localize("RQG.Actor.AwardExperience.PowExperienceInfo"), {
         permanent: true,

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
@@ -173,7 +173,7 @@
       <h2 class="section-heading">
         <span>{{localize "RQG.Actor.Nav.Combat"}}</span>
         {{#if @root.isGM}}
-          <button type="button" class="ui-control icon fa-solid fa-comment-dots" data-request-resistance-roll
+          <button type="button" class="ui-control icon fa-solid fa-scale-unbalanced" data-request-resistance-roll
                   data-tooltip="{{localize 'RQG.Game.RequestResistanceRoll'}}"
                   aria-label="{{localize 'RQG.Game.RequestResistanceRoll'}}"></button>
         {{/if}}

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
@@ -170,7 +170,14 @@
   {{!-- Combat Section --}}
   {{#if showUiSection.combat}}
     <div class="combat-section">
-      <h2 class="section-heading">{{localize "RQG.Actor.Nav.Combat"}}</h2>
+      <h2 class="section-heading">
+        <span>{{localize "RQG.Actor.Nav.Combat"}}</span>
+        {{#if @root.isGM}}
+          <button type="button" class="ui-control icon fa-solid fa-comment-dots" data-request-resistance-roll
+                  data-tooltip="{{localize 'RQG.Game.RequestResistanceRoll'}}"
+                  aria-label="{{localize 'RQG.Game.RequestResistanceRoll'}}"></button>
+        {{/if}}
+      </h2>
 
       {{!-- SR Buttons (only visible when in combat) --}}
       {{#if isInCombat}}

--- a/src/applications/app-parts/augment-meditate-options.ts
+++ b/src/applications/app-parts/augment-meditate-options.ts
@@ -1,0 +1,19 @@
+// Shared Augment/Meditate modifier options for any roll dialog that lets a player augment their
+// roll (RAW allows this for characteristic rolls, resistance rolls, etc. - core rulebook p.146).
+export const augmentOptions: SelectOptionData<number>[] = [
+  { value: 0, label: "RQG.Dialog.Common.AugmentOptions.None" },
+  { value: 50, label: "RQG.Dialog.Common.AugmentOptions.CriticalSuccess" },
+  { value: 30, label: "RQG.Dialog.Common.AugmentOptions.SpecialSuccess" },
+  { value: 20, label: "RQG.Dialog.Common.AugmentOptions.Success" },
+  { value: -20, label: "RQG.Dialog.Common.AugmentOptions.Failure" },
+  { value: -50, label: "RQG.Dialog.Common.AugmentOptions.Fumble" },
+];
+
+export const meditateOptions: SelectOptionData<number>[] = [
+  { value: 0, label: "RQG.Dialog.Common.MeditateOptions.None" },
+  { value: 5, label: "RQG.Dialog.Common.MeditateOptions.1mr" },
+  { value: 10, label: "RQG.Dialog.Common.MeditateOptions.2mr" },
+  { value: 15, label: "RQG.Dialog.Common.MeditateOptions.5mr" },
+  { value: 20, label: "RQG.Dialog.Common.MeditateOptions.25mr" },
+  { value: 25, label: "RQG.Dialog.Common.MeditateOptions.50mr" },
+];

--- a/src/applications/app-parts/augment-meditate-options.ts
+++ b/src/applications/app-parts/augment-meditate-options.ts
@@ -1,5 +1,4 @@
-// Shared Augment/Meditate modifier options for any roll dialog that lets a player augment their
-// roll (RAW allows this for characteristic rolls, resistance rolls, etc. - core rulebook p.146).
+// Augment/Meditate modifier options shared by every roll dialog.
 export const augmentOptions: SelectOptionData<number>[] = [
   { value: 0, label: "RQG.Dialog.Common.AugmentOptions.None" },
   { value: 50, label: "RQG.Dialog.Common.AugmentOptions.CriticalSuccess" },

--- a/src/applications/app-parts/roll-footer.hbs
+++ b/src/applications/app-parts/roll-footer.hbs
@@ -17,5 +17,5 @@
       </button>
     {{/each}}
   </div>
-  <button data-ability-roll>{{localize "RQG.Game.Roll"}}</button>
+  <button data-ability-roll {{#if disableRoll}}disabled{{/if}}>{{localize "RQG.Game.Roll"}}</button>
 </footer>

--- a/src/applications/app-parts/roll-footer.hbs
+++ b/src/applications/app-parts/roll-footer.hbs
@@ -5,17 +5,19 @@
     <i class="fa-solid fa-bullseye"></i><br>
     <span data-total-chance>{{totalChance}}%</span>
   </div>
-  <div data-roll-mode-parent class="split-button flex-none">
-    {{#each rollModes as |mode|}}
-      <button type="button"
-              class="ui-control icon {{mode.icon}}"
-              data-action="rollMode"
-              data-roll-mode="{{mode.id}}"
-              aria-pressed="{{#if (eq ../rollMode mode.id)}}true{{else}}false{{/if}}"
-              data-tooltip="{{localize mode.label}}"
-              aria-label="{{localize mode.label}}">
-      </button>
-    {{/each}}
-  </div>
+  {{#if rollModes.length}}
+    <div data-roll-mode-parent class="split-button flex-none">
+      {{#each rollModes as |mode|}}
+        <button type="button"
+                class="ui-control icon {{mode.icon}}"
+                data-action="rollMode"
+                data-roll-mode="{{mode.id}}"
+                aria-pressed="{{#if (eq ../rollMode mode.id)}}true{{else}}false{{/if}}"
+                data-tooltip="{{localize mode.label}}"
+                aria-label="{{localize mode.label}}">
+        </button>
+      {{/each}}
+    </div>
+  {{/if}}
   <button data-ability-roll {{#if disableRoll}}disabled{{/if}}>{{localize "RQG.Game.Roll"}}</button>
 </footer>

--- a/src/applications/app-parts/roll-footer.types.ts
+++ b/src/applications/app-parts/roll-footer.types.ts
@@ -9,6 +9,6 @@ export type RollFooterData = {
   totalChanceTooltip?: string;
   rollMode: foundry.dice.Roll.Mode; // read in onSubmit by checking aria-pressed state
   rollModes: RollModeOption[];
-  /** Set by dialogs that validate before rolling - greys out the Roll button while invalid. */
+  /** Greys out the Roll button while invalid. */
   disableRoll?: boolean;
 };

--- a/src/applications/app-parts/roll-footer.types.ts
+++ b/src/applications/app-parts/roll-footer.types.ts
@@ -9,4 +9,6 @@ export type RollFooterData = {
   totalChanceTooltip?: string;
   rollMode: foundry.dice.Roll.Mode; // read in onSubmit by checking aria-pressed state
   rollModes: RollModeOption[];
+  /** Set by dialogs that validate before rolling - greys out the Roll button while invalid. */
+  disableRoll?: boolean;
 };

--- a/src/applications/app-parts/roll-mode.ts
+++ b/src/applications/app-parts/roll-mode.ts
@@ -90,10 +90,7 @@ export function getSelectedRollModeFromClickEvent(event: MouseEvent): RollMode |
   return getSelectedRollMode(elementWithRollMode?.dataset["rollMode"]);
 }
 
-/**
- * Read whichever roll-mode toggle button is pressed on a roll-dialog form at submit time,
- * falling back to the configured default.
- */
+/** The pressed roll-mode toggle on a dialog form, or the configured default. */
 export function resolveRollModeFromForm(form: HTMLFormElement | undefined | null): RollMode {
   return (
     getSelectedRollMode(

--- a/src/applications/app-parts/roll-mode.ts
+++ b/src/applications/app-parts/roll-mode.ts
@@ -26,7 +26,7 @@ export function getConfiguredRollModes(): RollMode[] {
   return [...new Set(resolved)];
 }
 
-export function getConfiguredRollModeOptions(): RollModeOption[] {
+export function getConfiguredRollModeOptions(allowed?: readonly string[]): RollModeOption[] {
   const chatMessageConfig = CONFIG.ChatMessage as unknown as {
     modes?: Record<string, { label?: string; icon?: string }>;
   };
@@ -38,7 +38,7 @@ export function getConfiguredRollModeOptions(): RollModeOption[] {
   const options: RollModeOption[] = [];
   for (const [modeKey, modeConfig] of Object.entries(modes)) {
     const id = resolveRollMode(modeKey);
-    if (!id) {
+    if (!id || (allowed && !allowed.includes(id))) {
       continue;
     }
 

--- a/src/applications/app-parts/roll-mode.ts
+++ b/src/applications/app-parts/roll-mode.ts
@@ -89,3 +89,16 @@ export function getSelectedRollModeFromClickEvent(event: MouseEvent): RollMode |
   const elementWithRollMode = target.closest<HTMLElement>("[data-roll-mode]");
   return getSelectedRollMode(elementWithRollMode?.dataset["rollMode"]);
 }
+
+/**
+ * Read whichever roll-mode toggle button is pressed on a roll-dialog form at submit time,
+ * falling back to the configured default.
+ */
+export function resolveRollModeFromForm(form: HTMLFormElement | undefined | null): RollMode {
+  return (
+    getSelectedRollMode(
+      form?.querySelector<HTMLButtonElement>('button[data-action="rollMode"][aria-pressed="true"]')
+        ?.dataset["rollMode"],
+    ) ?? getDefaultRollMode()
+  );
+}

--- a/src/applications/app-parts/rqg-interactive-roll-application-base.ts
+++ b/src/applications/app-parts/rqg-interactive-roll-application-base.ts
@@ -79,6 +79,18 @@ export abstract class RqgInteractiveRollApplicationBase extends HandlebarsApplic
     this.getLivePreviewFormBehaviorConfig().updateLivePreview();
   }
 
+  /**
+   * Write a freshly computed target% into the footer's `[data-total-chance]` element in place,
+   * without a full re-render. Shared DOM-plumbing for subclasses whose `updateLivePreview()`
+   * only needs to update that one number.
+   */
+  protected updateTotalChanceDisplay(totalChance: number): void {
+    const totalChanceElement = this.element.querySelector<HTMLElement>("[data-total-chance]");
+    if (totalChanceElement) {
+      totalChanceElement.textContent = `${totalChance}%`;
+    }
+  }
+
   override get element(): HTMLFormElement {
     return super.element as HTMLFormElement;
   }

--- a/src/applications/app-parts/rqg-interactive-roll-application-base.ts
+++ b/src/applications/app-parts/rqg-interactive-roll-application-base.ts
@@ -79,11 +79,7 @@ export abstract class RqgInteractiveRollApplicationBase extends HandlebarsApplic
     this.getLivePreviewFormBehaviorConfig().updateLivePreview();
   }
 
-  /**
-   * Write a freshly computed target% into the footer's `[data-total-chance]` element in place,
-   * without a full re-render. Shared DOM-plumbing for subclasses whose `updateLivePreview()`
-   * only needs to update that one number.
-   */
+  /** Update the footer target% in place, without a re-render. */
   protected updateTotalChanceDisplay(totalChance: number): void {
     const totalChanceElement = this.element.querySelector<HTMLElement>("[data-total-chance]");
     if (totalChanceElement) {

--- a/src/applications/characteristic-roll-dialog/characteristic-roll-dialog-v2.ts
+++ b/src/applications/characteristic-roll-dialog/characteristic-roll-dialog-v2.ts
@@ -23,6 +23,7 @@ import {
   getDefaultRollMode,
   getSelectedRollMode,
 } from "../app-parts/roll-mode";
+import { augmentOptions, meditateOptions } from "../app-parts/augment-meditate-options";
 import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
 import { getSpeakerCompat } from "../../system/fvtt-type-compat";
 
@@ -45,24 +46,6 @@ export class CharacteristicRollDialogV2 extends RqgInteractiveRollApplicationBas
       Number(formData.otherModifier ?? 0)
     );
   }
-
-  private static augmentOptions: SelectOptionData<number>[] = [
-    { value: 0, label: "RQG.Dialog.Common.AugmentOptions.None" },
-    { value: 50, label: "RQG.Dialog.Common.AugmentOptions.CriticalSuccess" },
-    { value: 30, label: "RQG.Dialog.Common.AugmentOptions.SpecialSuccess" },
-    { value: 20, label: "RQG.Dialog.Common.AugmentOptions.Success" },
-    { value: -20, label: "RQG.Dialog.Common.AugmentOptions.Failure" },
-    { value: -50, label: "RQG.Dialog.Common.AugmentOptions.Fumble" },
-  ];
-
-  private static meditateOptions: SelectOptionData<number>[] = [
-    { value: 0, label: "RQG.Dialog.Common.MeditateOptions.None" },
-    { value: 5, label: "RQG.Dialog.Common.MeditateOptions.1mr" },
-    { value: 10, label: "RQG.Dialog.Common.MeditateOptions.2mr" },
-    { value: 15, label: "RQG.Dialog.Common.MeditateOptions.5mr" },
-    { value: 20, label: "RQG.Dialog.Common.MeditateOptions.25mr" },
-    { value: 25, label: "RQG.Dialog.Common.MeditateOptions.50mr" },
-  ];
 
   private static difficultyOptions: SelectOptionData<number>[] = [
     { value: 0, label: "RQG.Dialog.CharacteristicRoll.RollDifficultyLevel.0" },
@@ -143,8 +126,8 @@ export class CharacteristicRollDialogV2 extends RqgInteractiveRollApplicationBas
       formData: formData,
 
       speakerName: getSpeakerDisplayName(speaker),
-      augmentOptions: CharacteristicRollDialogV2.augmentOptions,
-      meditateOptions: CharacteristicRollDialogV2.meditateOptions,
+      augmentOptions: augmentOptions,
+      meditateOptions: meditateOptions,
       difficultyOptions: CharacteristicRollDialogV2.difficultyOptions,
 
       // RollHeader

--- a/src/applications/resistance-roll-dialog/open-resistance-request.ts
+++ b/src/applications/resistance-roll-dialog/open-resistance-request.ts
@@ -1,18 +1,21 @@
 import { localize } from "../../system/util";
 import { resolveActorFromUuid } from "./resistance-roll-shared.ts";
 import type { ResistanceRequestSeed } from "./resistance-request-dialog-data.types.ts";
+import type { ResistanceRollSeed } from "./resistance-roll-dialog-data.types.ts";
 
 /**
- * Single GM entry point for opening the resistance-request dialog, shared by every UI surface
- * that offers it (actor sheet Combat tab, token HUD, combat tracker, Actors sidebar).
+ * Single GM entry point for the resistance-table flow, shared by every UI surface that offers it
+ * (actor sheet Combat tab, token HUD, combat tracker, Actors sidebar).
  *
- * Seeds the dialog from canvas state so the GM rarely has to pick sides by hand:
- * - invoked on a player-owned token/actor -> that's the active (rolling) side; the GM's current
- *   single target, if any, becomes the passive side;
- * - invoked on an NPC/monster -> that's the passive threat; a player-owned target becomes the
- *   active side;
- * - invoked with no context (e.g. a keybinding) -> only the active side is seeded, and only if
- *   the current target is player-owned.
+ * Picks the dialog from canvas state:
+ * - a player-owned actor is on one side -> {@link ResistanceRequestDialogV2}: post a roll-request
+ *   card to that player (invoked player = active; an invoked NPC with a player-owned target =
+ *   that player acting against the NPC);
+ * - neither side is player-owned -> {@link ResistanceRollDialogV2}: nobody to hand a card to
+ *   (its Roll button is owner-gated), so the GM rolls it directly - an NPC's POW-vs-POW, a
+ *   poison's POT-vs-CON, an improvised STR contest.
+ *
+ * Either way the current single target fills the side the invocation didn't.
  */
 export async function openResistanceRequest(invokedTokenOrActorUuid?: string): Promise<void> {
   if (!game.user?.isGM) {
@@ -28,16 +31,27 @@ export async function openResistanceRequest(invokedTokenOrActorUuid?: string): P
     !!invokedTokenOrActorUuid && !!resolveActorFromUuid(invokedTokenOrActorUuid)?.hasPlayerOwner;
   const targetIsPlayerOwned = !!targetUuid && !!resolveActorFromUuid(targetUuid)?.hasPlayerOwner;
 
+  // No player on either side: a request card would only ever be actionable by the GM, so open
+  // the direct roll dialog for the GM to roll instead.
+  if (!invokedIsPlayerOwned && !targetIsPlayerOwned) {
+    const seed: ResistanceRollSeed = invokedTokenOrActorUuid
+      ? { activeUuid: invokedTokenOrActorUuid, passiveUuid: targetUuid }
+      : { passiveUuid: targetUuid };
+    const { ResistanceRollDialogV2 } = await import("./resistance-roll-dialog-v2.ts");
+    await ResistanceRollDialogV2.openForGm(seed);
+    return;
+  }
+
   let seed: ResistanceRequestSeed;
-  if (invokedTokenOrActorUuid && invokedIsPlayerOwned) {
+  if (invokedIsPlayerOwned) {
+    // The invoked player is the one asked to roll; the target, if any, is what they resist.
     seed = { activeUuid: invokedTokenOrActorUuid, passiveUuid: targetUuid };
   } else if (invokedTokenOrActorUuid) {
-    seed = {
-      passiveUuid: invokedTokenOrActorUuid,
-      activeUuid: targetIsPlayerOwned ? targetUuid : undefined,
-    };
+    // Invoked on an NPC while a player is targeted: that player acts against the NPC.
+    seed = { passiveUuid: invokedTokenOrActorUuid, activeUuid: targetUuid };
   } else {
-    seed = { activeUuid: targetIsPlayerOwned ? targetUuid : undefined };
+    // No invocation context (e.g. a keybinding), only a player-owned target.
+    seed = { activeUuid: targetUuid };
   }
 
   const { ResistanceRequestDialogV2 } = await import("./resistance-request-dialog-v2.ts");

--- a/src/applications/resistance-roll-dialog/open-resistance-request.ts
+++ b/src/applications/resistance-roll-dialog/open-resistance-request.ts
@@ -1,0 +1,45 @@
+import { localize } from "../../system/util";
+import { resolveActorFromUuid } from "./resistance-roll-shared.ts";
+import type { ResistanceRequestSeed } from "./resistance-request-dialog-data.types.ts";
+
+/**
+ * Single GM entry point for opening the resistance-request dialog, shared by every UI surface
+ * that offers it (actor sheet Combat tab, token HUD, combat tracker, Actors sidebar).
+ *
+ * Seeds the dialog from canvas state so the GM rarely has to pick sides by hand:
+ * - invoked on a player-owned token/actor -> that's the active (rolling) side; the GM's current
+ *   single target, if any, becomes the passive side;
+ * - invoked on an NPC/monster -> that's the passive threat; a player-owned target becomes the
+ *   active side;
+ * - invoked with no context (e.g. a keybinding) -> only the active side is seeded, and only if
+ *   the current target is player-owned.
+ */
+export async function openResistanceRequest(invokedTokenOrActorUuid?: string): Promise<void> {
+  if (!game.user?.isGM) {
+    ui.notifications?.warn(localize("RQG.Notification.Error.GMOnlyOperation"));
+    return;
+  }
+
+  const targetUuid =
+    game.user.targets.size === 1
+      ? (game.user.targets.first()?.document?.uuid ?? undefined)
+      : undefined;
+  const invokedIsPlayerOwned =
+    !!invokedTokenOrActorUuid && !!resolveActorFromUuid(invokedTokenOrActorUuid)?.hasPlayerOwner;
+  const targetIsPlayerOwned = !!targetUuid && !!resolveActorFromUuid(targetUuid)?.hasPlayerOwner;
+
+  let seed: ResistanceRequestSeed;
+  if (invokedTokenOrActorUuid && invokedIsPlayerOwned) {
+    seed = { activeUuid: invokedTokenOrActorUuid, passiveUuid: targetUuid };
+  } else if (invokedTokenOrActorUuid) {
+    seed = {
+      passiveUuid: invokedTokenOrActorUuid,
+      activeUuid: targetIsPlayerOwned ? targetUuid : undefined,
+    };
+  } else {
+    seed = { activeUuid: targetIsPlayerOwned ? targetUuid : undefined };
+  }
+
+  const { ResistanceRequestDialogV2 } = await import("./resistance-request-dialog-v2.ts");
+  await new ResistanceRequestDialogV2(seed).render({ force: true });
+}

--- a/src/applications/resistance-roll-dialog/open-resistance-request.ts
+++ b/src/applications/resistance-roll-dialog/open-resistance-request.ts
@@ -4,18 +4,9 @@ import type { ResistanceRequestSeed } from "./resistance-request-dialog-data.typ
 import type { ResistanceRollSeed } from "./resistance-roll-dialog-data.types.ts";
 
 /**
- * Single GM entry point for the resistance-table flow, shared by every UI surface that offers it
- * (actor sheet Combat tab, token HUD, combat tracker, Actors sidebar).
- *
- * Picks the dialog from canvas state:
- * - a player-owned actor is on one side -> {@link ResistanceRequestDialogV2}: post a roll-request
- *   card to that player (invoked player = active; an invoked NPC with a player-owned target =
- *   that player acting against the NPC);
- * - neither side is player-owned -> {@link ResistanceRollDialogV2}: nobody to hand a card to
- *   (its Roll button is owner-gated), so the GM rolls it directly - an NPC's POW-vs-POW, a
- *   poison's POT-vs-CON, an improvised STR contest.
- *
- * Either way the current single target fills the side the invocation didn't.
+ * GM entry point for the resistance-table flow (actor sheet, token HUD, combat tracker, Actors
+ * sidebar). Delegates to a player via {@link ResistanceRequestDialogV2} when one is involved,
+ * otherwise opens {@link ResistanceRollDialogV2} for the GM to roll directly.
  */
 export async function openResistanceRequest(invokedTokenOrActorUuid?: string): Promise<void> {
   if (!game.user?.isGM) {
@@ -31,8 +22,7 @@ export async function openResistanceRequest(invokedTokenOrActorUuid?: string): P
     !!invokedTokenOrActorUuid && !!resolveActorFromUuid(invokedTokenOrActorUuid)?.hasPlayerOwner;
   const targetIsPlayerOwned = !!targetUuid && !!resolveActorFromUuid(targetUuid)?.hasPlayerOwner;
 
-  // No player on either side: a request card would only ever be actionable by the GM, so open
-  // the direct roll dialog for the GM to roll instead.
+  // Nobody to delegate to - the GM rolls it directly.
   if (!invokedIsPlayerOwned && !targetIsPlayerOwned) {
     const seed: ResistanceRollSeed = invokedTokenOrActorUuid
       ? { activeUuid: invokedTokenOrActorUuid, passiveUuid: targetUuid }
@@ -44,13 +34,11 @@ export async function openResistanceRequest(invokedTokenOrActorUuid?: string): P
 
   let seed: ResistanceRequestSeed;
   if (invokedIsPlayerOwned) {
-    // The invoked player is the one asked to roll; the target, if any, is what they resist.
     seed = { activeUuid: invokedTokenOrActorUuid, passiveUuid: targetUuid };
   } else if (invokedTokenOrActorUuid) {
-    // Invoked on an NPC while a player is targeted: that player acts against the NPC.
+    // NPC invoked, player targeted: the player acts against the NPC.
     seed = { passiveUuid: invokedTokenOrActorUuid, activeUuid: targetUuid };
   } else {
-    // No invocation context (e.g. a keybinding), only a player-owned target.
     seed = { activeUuid: targetUuid };
   }
 

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
@@ -8,13 +8,11 @@ export type ResistanceRequestSeed = {
 };
 
 export type ResistanceRequestDialogContext = RollHeaderData &
-  Pick<RollFooterData, "rollMode" | "rollModes"> & {
+  Pick<RollFooterData, "rollMode" | "rollModes" | "totalChance" | "totalChanceTooltip"> & {
     formData: ResistanceRequestDialogFormData;
     activeTokenOrActorOptions: SelectOptionData<string>[];
     passiveTokenOrActorOptions: SelectOptionData<string>[];
     characteristicOptions: SelectOptionData<string>[];
-    totalChance: number;
-    totalChanceTooltip?: string;
     /** Disables the Send button while a side is unresolved. */
     canSendRequest: boolean;
   };

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
@@ -1,10 +1,6 @@
 import type { RollHeaderData } from "../app-parts/roll-header.types.ts";
 
-/**
- * Pre-fill for {@link ResistanceRequestDialogV2}, produced by `openResistanceRequest` from the
- * invoking UI surface + the GM's current target. `activeUuid` is always a player-owned
- * token/actor (whoever the request card is addressed to); `passiveUuid` may be any token/actor.
- */
+/** Canvas-derived seed for {@link ResistanceRequestDialogV2}: `activeUuid` is always player-owned. */
 export type ResistanceRequestSeed = {
   activeUuid?: string | undefined;
   passiveUuid?: string | undefined;
@@ -16,14 +12,14 @@ export type ResistanceRequestDialogContext = RollHeaderData & {
   passiveTokenOrActorOptions: SelectOptionData<string>[];
   characteristicOptions: SelectOptionData<string>[];
   totalChance: number;
-  /** False while the active or passive side is still unresolved - disables the Send button. */
+  /** Disables the Send button while a side is unresolved. */
   canSendRequest: boolean;
 };
 
 export type ResistanceRequestDialogFormData = {
-  /** The actor/token who will be asked to roll - always a real actor, never manual. */
+  /** Who is asked to roll - always a real actor, never manual. */
   targetTokenOrActorUuid: string;
-  /** One characteristic name, or two joined by "+" (e.g. "strength+size") - what they roll. */
+  /** One characteristic name, or two joined by "+" (e.g. "strength+size"). */
   activeCharacteristics: string;
 
   /** A token/actor uuid, or the MANUAL_SOURCE_VALUE sentinel. */
@@ -34,7 +30,7 @@ export type ResistanceRequestDialogFormData = {
   passiveManualLabel: string;
   passiveManualValue: number;
 
-  // GM's situational modifier for the contest - sent as the roller's starting Other modifier.
+  // GM's situational modifier; seeds the roller's Other modifier.
   otherModifier: string;
   otherModifierDescription: string;
 };

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
@@ -16,6 +16,8 @@ export type ResistanceRequestDialogContext = RollHeaderData & {
   passiveTokenOrActorOptions: SelectOptionData<string>[];
   characteristicOptions: SelectOptionData<string>[];
   totalChance: number;
+  /** False while the active or passive side is still unresolved - disables the Send button. */
+  canSendRequest: boolean;
 };
 
 export type ResistanceRequestDialogFormData = {

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
@@ -1,4 +1,5 @@
 import type { RollHeaderData } from "../app-parts/roll-header.types.ts";
+import type { RollFooterData } from "../app-parts/roll-footer.types.ts";
 
 /** Canvas-derived seed for {@link ResistanceRequestDialogV2}: `activeUuid` is always player-owned. */
 export type ResistanceRequestSeed = {
@@ -6,16 +7,17 @@ export type ResistanceRequestSeed = {
   passiveUuid?: string | undefined;
 };
 
-export type ResistanceRequestDialogContext = RollHeaderData & {
-  formData: ResistanceRequestDialogFormData;
-  activeTokenOrActorOptions: SelectOptionData<string>[];
-  passiveTokenOrActorOptions: SelectOptionData<string>[];
-  characteristicOptions: SelectOptionData<string>[];
-  totalChance: number;
-  totalChanceTooltip?: string;
-  /** Disables the Send button while a side is unresolved. */
-  canSendRequest: boolean;
-};
+export type ResistanceRequestDialogContext = RollHeaderData &
+  Pick<RollFooterData, "rollMode" | "rollModes"> & {
+    formData: ResistanceRequestDialogFormData;
+    activeTokenOrActorOptions: SelectOptionData<string>[];
+    passiveTokenOrActorOptions: SelectOptionData<string>[];
+    characteristicOptions: SelectOptionData<string>[];
+    totalChance: number;
+    totalChanceTooltip?: string;
+    /** Disables the Send button while a side is unresolved. */
+    canSendRequest: boolean;
+  };
 
 export type ResistanceRequestDialogFormData = {
   /** Who is asked to roll - always a real actor, never manual. */

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
@@ -15,8 +15,6 @@ export type ResistanceRequestDialogContext = RollHeaderData & {
   activeTokenOrActorOptions: SelectOptionData<string>[];
   passiveTokenOrActorOptions: SelectOptionData<string>[];
   characteristicOptions: SelectOptionData<string>[];
-  augmentOptions: SelectOptionData<number>[];
-  meditateOptions: SelectOptionData<number>[];
   totalChance: number;
 };
 
@@ -34,9 +32,7 @@ export type ResistanceRequestDialogFormData = {
   passiveManualLabel: string;
   passiveManualValue: number;
 
-  // Prefilled defaults for the recipient's modifiers - they can still change them before rolling.
-  augmentModifier: string;
-  meditateModifier: string;
+  // GM's situational modifier for the contest - sent as the roller's starting Other modifier.
   otherModifier: string;
   otherModifierDescription: string;
 };

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
@@ -1,0 +1,42 @@
+import type { RollHeaderData } from "../app-parts/roll-header.types.ts";
+
+/**
+ * Pre-fill for {@link ResistanceRequestDialogV2}, produced by `openResistanceRequest` from the
+ * invoking UI surface + the GM's current target. `activeUuid` is always a player-owned
+ * token/actor (whoever the request card is addressed to); `passiveUuid` may be any token/actor.
+ */
+export type ResistanceRequestSeed = {
+  activeUuid?: string | undefined;
+  passiveUuid?: string | undefined;
+};
+
+export type ResistanceRequestDialogContext = RollHeaderData & {
+  formData: ResistanceRequestDialogFormData;
+  activeTokenOrActorOptions: SelectOptionData<string>[];
+  passiveTokenOrActorOptions: SelectOptionData<string>[];
+  characteristicOptions: SelectOptionData<string>[];
+  augmentOptions: SelectOptionData<number>[];
+  meditateOptions: SelectOptionData<number>[];
+  totalChance: number;
+};
+
+export type ResistanceRequestDialogFormData = {
+  /** The actor/token who will be asked to roll - always a real actor, never manual. */
+  targetTokenOrActorUuid: string;
+  /** One characteristic name, or two joined by "+" (e.g. "strength+size") - what they roll. */
+  activeCharacteristics: string;
+
+  /** A token/actor uuid, or the MANUAL_SOURCE_VALUE sentinel. */
+  passiveTokenOrActorUuid: string;
+  passiveCharacteristics: string;
+  /** Only used for a Manual passive - names the obstacle/disease, e.g. "Noxious Gas". */
+  passiveManualName: string;
+  passiveManualLabel: string;
+  passiveManualValue: number;
+
+  // Prefilled defaults for the recipient's modifiers - they can still change them before rolling.
+  augmentModifier: string;
+  meditateModifier: string;
+  otherModifier: string;
+  otherModifierDescription: string;
+};

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
@@ -12,6 +12,7 @@ export type ResistanceRequestDialogContext = RollHeaderData & {
   passiveTokenOrActorOptions: SelectOptionData<string>[];
   characteristicOptions: SelectOptionData<string>[];
   totalChance: number;
+  totalChanceTooltip?: string;
   /** Disables the Send button while a side is unresolved. */
   canSendRequest: boolean;
 };

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
@@ -47,22 +47,13 @@
   </datalist>
 
   <fieldset>
-    <legend>{{localize "RQG.Dialog.ResistanceRequest.ModifierDefaults"}}</legend>
+    <legend>{{localize "RQG.Dialog.ResistanceRequest.SituationalModifier"}}</legend>
     <div class="key-value-grid p-0">
-      <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
-      <select name="augmentModifier">
-        {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
-      </select>
-
-      <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
-      <select name="meditateModifier">
-        {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
-      </select>
-
       <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
       <div>
         <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
       </div>
     </div>
+    <p class="hint">{{localize "RQG.Dialog.ResistanceRequest.SituationalModifierHint"}}</p>
   </fieldset>
 </div>

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
@@ -29,21 +29,27 @@
         </select>
       {{else}}
         <label>{{localize "RQG.Dialog.ResistanceRoll.ManualName"}}</label>
-        <input type="text" value="{{formData.passiveManualName}}" name="passiveManualName">
+        <input type="text" value="{{formData.passiveManualName}}" name="passiveManualName"
+               placeholder="{{localize 'RQG.Dialog.ResistanceRoll.ManualNamePlaceholder'}}">
 
         <label>{{localize "RQG.Dialog.ResistanceRoll.ManualLabel"}}</label>
-        <input type="text" value="{{formData.passiveManualLabel}}" name="passiveManualLabel" list="resistance-manual-label-suggestions">
+        <input type="text" value="{{formData.passiveManualLabel}}" name="passiveManualLabel" list="resistance-manual-label-suggestions"
+               placeholder="{{localize 'RQG.Dialog.ResistanceRoll.ManualLabelPlaceholder'}}">
 
         <label>{{localize "RQG.Dialog.ResistanceRoll.ManualValue"}}</label>
         <input type="number" value="{{formData.passiveManualValue}}" name="passiveManualValue">
       {{/unless}}
     </div>
+    {{#if (eq formData.passiveTokenOrActorUuid "manual")}}
+      <p class="hint">{{localize "RQG.Dialog.ResistanceRoll.ManualHint"}}</p>
+    {{/if}}
   </fieldset>
 
   <datalist id="resistance-manual-label-suggestions">
-    <option value="POT">
+    <option value="{{localize 'RQG.Dialog.ResistanceRoll.Potency'}}">
     <option value="{{localize 'RQG.Actor.Characteristics.strength'}}">
     <option value="{{localize 'RQG.Actor.Characteristics.size'}}">
+    <option value="{{localize 'RQG.Actor.Characteristics.power'}}">
   </datalist>
 
   <fieldset>

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
@@ -1,0 +1,68 @@
+<div class="scrollable">
+  <fieldset>
+    <legend>{{localize "RQG.Dialog.ResistanceRoll.Active"}}</legend>
+    <div class="key-value-grid p-0">
+      <label>{{localize "RQG.Dialog.ResistanceRoll.TokenOrActor"}}</label>
+      <select name="targetTokenOrActorUuid">
+        {{selectOptions activeTokenOrActorOptions selected=formData.targetTokenOrActorUuid localize=false}}
+      </select>
+
+      <label>{{localize "RQG.Dialog.ResistanceRoll.Characteristic"}}</label>
+      <select name="activeCharacteristics">
+        {{selectOptions characteristicOptions selected=formData.activeCharacteristics localize=false}}
+      </select>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>{{localize "RQG.Dialog.ResistanceRoll.Passive"}}</legend>
+    <div class="key-value-grid p-0">
+      <label>{{localize "RQG.Dialog.ResistanceRoll.TokenOrActor"}}</label>
+      <select name="passiveTokenOrActorUuid">
+        {{selectOptions passiveTokenOrActorOptions selected=formData.passiveTokenOrActorUuid localize=false}}
+      </select>
+
+      {{#unless (eq formData.passiveTokenOrActorUuid "manual")}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.Characteristic"}}</label>
+        <select name="passiveCharacteristics">
+          {{selectOptions characteristicOptions selected=formData.passiveCharacteristics localize=false}}
+        </select>
+      {{else}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualName"}}</label>
+        <input type="text" value="{{formData.passiveManualName}}" name="passiveManualName">
+
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualLabel"}}</label>
+        <input type="text" value="{{formData.passiveManualLabel}}" name="passiveManualLabel" list="resistance-manual-label-suggestions">
+
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualValue"}}</label>
+        <input type="number" value="{{formData.passiveManualValue}}" name="passiveManualValue">
+      {{/unless}}
+    </div>
+  </fieldset>
+
+  <datalist id="resistance-manual-label-suggestions">
+    <option value="POT">
+    <option value="{{localize 'RQG.Actor.Characteristics.strength'}}">
+    <option value="{{localize 'RQG.Actor.Characteristics.size'}}">
+  </datalist>
+
+  <fieldset>
+    <legend>{{localize "RQG.Dialog.ResistanceRequest.ModifierDefaults"}}</legend>
+    <div class="key-value-grid p-0">
+      <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
+      <select name="augmentModifier">
+        {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
+      </select>
+
+      <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
+      <select name="meditateModifier">
+        {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
+      </select>
+
+      <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
+      <div>
+        <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
@@ -11,7 +11,13 @@
       <select name="activeCharacteristics">
         {{selectOptions characteristicOptions selected=formData.activeCharacteristics localize=false}}
       </select>
+
+      <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
+      <div>
+        <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
+      </div>
     </div>
+    <p class="hint">{{localize "RQG.Dialog.ResistanceRequest.SituationalModifierHint"}}</p>
   </fieldset>
 
   <fieldset>
@@ -51,15 +57,4 @@
     <option value="{{localize 'RQG.Actor.Characteristics.size'}}">
     <option value="{{localize 'RQG.Actor.Characteristics.power'}}">
   </datalist>
-
-  <fieldset>
-    <legend>{{localize "RQG.Dialog.ResistanceRequest.SituationalModifier"}}</legend>
-    <div class="key-value-grid p-0">
-      <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
-      <div>
-        <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
-      </div>
-    </div>
-    <p class="hint">{{localize "RQG.Dialog.ResistanceRequest.SituationalModifierHint"}}</p>
-  </fieldset>
 </div>

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
@@ -9,12 +9,10 @@ import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
 import { activateChatTab, localize } from "../../system/util";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import {
-  augmentOptions,
   filterToPlayerOwnedOptions,
   getBaseTokenOrActorOptions,
   getCharacteristicOptions,
   getTokenOrActorOptions,
-  meditateOptions,
   resolveActorFromUuid,
   resolveCharacteristicSide,
 } from "./resistance-roll-shared.ts";
@@ -133,8 +131,6 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
     formData.passiveManualLabel ??= "";
     formData.passiveManualValue ??= 0;
 
-    formData.augmentModifier ??= "0";
-    formData.meditateModifier ??= "0";
     formData.otherModifier ??= "0";
     formData.otherModifierDescription ??= localize("RQG.Dialog.Common.OtherModifier");
 
@@ -160,8 +156,6 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       activeTokenOrActorOptions: activeTokenOrActorOptions,
       passiveTokenOrActorOptions: passiveTokenOrActorOptions,
       characteristicOptions: getCharacteristicOptions(),
-      augmentOptions: augmentOptions,
-      meditateOptions: meditateOptions,
 
       // RollHeader
       rollType: localize("RQG.Dialog.ResistanceRequest.Title"),
@@ -188,8 +182,6 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       "",
     );
     return computeResistanceTargetChance(active.value, passive.value, [
-      Number(formData.augmentModifier),
-      Number(formData.meditateModifier),
       Number(formData.otherModifier),
     ]);
   }
@@ -239,8 +231,6 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       passiveValue: passive.value,
       passiveLabel: passive.label,
       passiveActorName: passive.actorName,
-      augmentModifier: Number(formDataObject.augmentModifier) || 0,
-      meditateModifier: Number(formDataObject.meditateModifier) || 0,
       otherModifier: Number(formDataObject.otherModifier) || 0,
       otherModifierDescription: formDataObject.otherModifierDescription || undefined,
       resistanceRoll: undefined,

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
@@ -9,6 +9,7 @@ import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
 import { activateChatTab, localize } from "../../system/util";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import {
+  defaultCharacteristic,
   filterToPlayerOwnedOptions,
   getBaseTokenOrActorOptions,
   getCharacteristicOptions,
@@ -123,10 +124,10 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
     );
 
     formData.targetTokenOrActorUuid ??= initialTargetHasPlayerOwner ? initialTargetUuid : "";
-    formData.activeCharacteristics ??= "";
+    formData.activeCharacteristics ??= defaultCharacteristic;
 
     formData.passiveTokenOrActorUuid ??= this.seed.passiveUuid || MANUAL_SOURCE_VALUE;
-    formData.passiveCharacteristics ??= "";
+    formData.passiveCharacteristics ??= defaultCharacteristic;
     formData.passiveManualName ??= "";
     formData.passiveManualLabel ??= "";
     formData.passiveManualValue ??= 0;
@@ -163,7 +164,35 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       baseChance: "",
 
       totalChance: totalChance,
+      canSendRequest: ResistanceRequestDialogV2.canSendRequest(formData),
     };
+  }
+
+  /**
+   * Both sides resolved to a usable value/label - the active token/actor is picked and its
+   * characteristic(s) sum to something, and the passive side is either a real actor or a manual
+   * entry with a label. Gates the Send button so a bad request can never be posted.
+   */
+  private static canSendRequest(formData: ResistanceRequestDialogFormData): boolean {
+    if (!formData.targetTokenOrActorUuid) {
+      return false;
+    }
+    const active = resolveCharacteristicSide(
+      formData.targetTokenOrActorUuid,
+      formData.activeCharacteristics,
+      "",
+      0,
+      "",
+    );
+    const passive = resolveCharacteristicSide(
+      formData.passiveTokenOrActorUuid,
+      formData.passiveCharacteristics,
+      formData.passiveManualLabel,
+      formData.passiveManualValue,
+      "",
+      formData.passiveManualName,
+    );
+    return !!active.label && !!passive.label;
   }
 
   private static computeTotalChance(formData: ResistanceRequestDialogFormData): number {
@@ -190,6 +219,13 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
     const formData = new foundry.applications.ux.FormDataExtended(this.element, {})
       .object as ResistanceRequestDialogFormData;
     this.updateTotalChanceDisplay(ResistanceRequestDialogV2.computeTotalChance(formData));
+
+    const sendButton = this.element.querySelector<HTMLButtonElement>(
+      "button[data-send-resistance-request]",
+    );
+    if (sendButton) {
+      sendButton.disabled = !ResistanceRequestDialogV2.canSendRequest(formData);
+    }
   }
 
   private static async onSubmit(
@@ -215,12 +251,9 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       formDataObject.passiveManualName,
     );
 
-    if (!formDataObject.targetTokenOrActorUuid || !active.label) {
-      ui.notifications?.error("Pick who should roll and which characteristic(s) they roll with.");
-      return;
-    }
-    if (!passive.label) {
-      ui.notifications?.error("Pick or enter what the roll resists.");
+    // The Send button is disabled until this passes, so reaching here invalid needs an odd path
+    // (e.g. a stale submit) - bail silently rather than surfacing an error the UI already prevents.
+    if (!ResistanceRequestDialogV2.canSendRequest(formDataObject)) {
       return;
     }
 

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
@@ -9,6 +9,8 @@ import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
 import { activateChatTab, localize } from "../../system/util";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import {
+  buildResistanceChanceBreakdown,
+  buildResistanceModifiers,
   defaultCharacteristic,
   filterToPlayerOwnedOptions,
   getBaseTokenOrActorOptions,
@@ -153,8 +155,31 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       baseChance: "",
 
       totalChance: totalChance,
+      totalChanceTooltip: ResistanceRequestDialogV2.buildChanceBreakdown(formData),
       canSendRequest: ResistanceRequestDialogV2.canSendRequest(formData),
     };
+  }
+
+  private static buildChanceBreakdown(formData: ResistanceRequestDialogFormData): string {
+    const active = resolveCharacteristicSide(
+      formData.targetTokenOrActorUuid,
+      formData.activeCharacteristics,
+      "",
+      0,
+      "",
+    );
+    const passive = resolveCharacteristicSide(
+      formData.passiveTokenOrActorUuid,
+      formData.passiveCharacteristics,
+      formData.passiveManualLabel,
+      formData.passiveManualValue,
+      "",
+    );
+    return buildResistanceChanceBreakdown(
+      active,
+      passive,
+      buildResistanceModifiers("0", "0", formData.otherModifier, formData.otherModifierDescription),
+    );
   }
 
   /** Both sides resolve to a value/label - gates the Send button. */
@@ -204,6 +229,11 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
     const formData = new foundry.applications.ux.FormDataExtended(this.element, {})
       .object as ResistanceRequestDialogFormData;
     this.updateTotalChanceDisplay(ResistanceRequestDialogV2.computeTotalChance(formData));
+
+    const targetChanceBox = this.element.querySelector<HTMLElement>("[data-target-chance-box]");
+    if (targetChanceBox) {
+      targetChanceBox.dataset["tooltip"] = ResistanceRequestDialogV2.buildChanceBreakdown(formData);
+    }
 
     const sendButton = this.element.querySelector<HTMLButtonElement>(
       "button[data-send-resistance-request]",

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
@@ -16,12 +16,16 @@ import {
   getBaseTokenOrActorOptions,
   getCharacteristicOptions,
   getTokenOrActorOptions,
+  initialResistanceRollMode,
+  RESISTANCE_REQUEST_ROLL_MODES,
   resolveActorFromUuid,
   resolveCharacteristicSide,
+  resolveResistanceRequestVisibility,
 } from "./resistance-roll-shared.ts";
 import { buildResistanceRollFlavor } from "../../rolls/resistance-roll/resistance-roll-flavor.ts";
 import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
 import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
+import { getConfiguredRollModeOptions, resolveRollModeFromForm } from "../app-parts/roll-mode";
 import { getSpeakerCompat } from "../../system/fvtt-type-compat";
 
 /**
@@ -44,6 +48,7 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
   ) {
     super(options);
     this.seed = seed;
+    this.rollMode = initialResistanceRollMode(undefined);
   }
 
   static override DEFAULT_OPTIONS = {
@@ -157,6 +162,8 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       totalChance: totalChance,
       totalChanceTooltip: ResistanceRequestDialogV2.buildChanceBreakdown(formData),
       canSendRequest: ResistanceRequestDialogV2.canSendRequest(formData),
+      rollMode: this.rollMode,
+      rollModes: getConfiguredRollModeOptions(RESISTANCE_REQUEST_ROLL_MODES),
     };
   }
 
@@ -271,6 +278,7 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       return;
     }
 
+    const rollMode = resolveRollModeFromForm(form);
     const chatSystemData = {
       state: "Requested",
       targetTokenOrActorUuid: formDataObject.targetTokenOrActorUuid,
@@ -284,6 +292,7 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       passiveActorName: passive.actorName,
       otherModifier: Number(formDataObject.otherModifier) || 0,
       otherModifierDescription: formDataObject.otherModifierDescription || undefined,
+      rollMode: rollMode,
       resistanceRoll: undefined,
     };
 
@@ -305,6 +314,11 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
     const targetActor =
       targetTokenOrActor instanceof TokenDocument ? targetTokenOrActor.actor : targetTokenOrActor;
 
+    const { whisper, blind } = resolveResistanceRequestVisibility(
+      rollMode,
+      targetActor ?? undefined,
+    );
+
     activateChatTab();
     const cm = await ChatMessage.create({
       type: "resistanceRequest",
@@ -312,6 +326,8 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       flavor: flavor,
       content: content,
       speaker: getSpeakerCompat({ actor: targetActor ?? undefined, token: targetToken }),
+      whisper: whisper,
+      blind: blind,
     } as any);
     if (cm && !Array.isArray(cm)) {
       cm.render(true);

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
@@ -314,10 +314,7 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
     const targetActor =
       targetTokenOrActor instanceof TokenDocument ? targetTokenOrActor.actor : targetTokenOrActor;
 
-    const { whisper, blind } = resolveResistanceRequestVisibility(
-      rollMode,
-      targetActor ?? undefined,
-    );
+    const { whisper, blind } = resolveResistanceRequestVisibility(rollMode, targetActor);
 
     activateChatTab();
     const cm = await ChatMessage.create({

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
@@ -275,6 +275,10 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       state: "Requested",
       targetTokenOrActorUuid: formDataObject.targetTokenOrActorUuid,
       activeCharacteristics: formDataObject.activeCharacteristics,
+      passiveCharacteristics:
+        formDataObject.passiveTokenOrActorUuid === MANUAL_SOURCE_VALUE
+          ? ""
+          : formDataObject.passiveCharacteristics,
       passiveValue: passive.value,
       passiveLabel: passive.label,
       passiveActorName: passive.actorName,

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
@@ -23,11 +23,8 @@ import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-
 import { getSpeakerCompat } from "../../system/fvtt-type-compat";
 
 /**
- * GM-facing dialog (#758 option C): pick who should roll (an actor/token's characteristic(s))
- * and what they're resisting (another actor's characteristic(s), or a manual value/label such as
- * a disease's POT), then post a chat card only that recipient (and the GM) can act on. Unlike
- * ResistanceRollDialogV2 this dialog never rolls anything itself - it only creates the request;
- * RespondToResistanceRequestDialogV2 is what the recipient uses to actually roll.
+ * GM builds a resistance-table check and posts it as a chat card the recipient rolls (via
+ * RespondToResistanceRequestDialogV2). Never rolls anything itself.
  */
 export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase {
   protected override getLivePreviewFormBehaviorConfig() {
@@ -88,19 +85,13 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       ? (fromUuidSync(initialTargetUuid) as TokenDocument | RqgActor | undefined)
       : undefined;
 
-    // Both sides share the same underlying targeted/owned-token/owned-actor scan - computed once
-    // here and handed to both calls below instead of each re-scanning it independently.
+    // One token/actor scan, shared by both pickers.
     const baseTokenOrActorOptions = getBaseTokenOrActorOptions();
 
-    // The active side is who gets asked to roll, so it's restricted to tokens/actors with an
-    // actual player owner - a GM owns every token, so without this an NPC/monster could be picked
-    // as the recipient and nobody but the GM could ever click that card's Roll button.
+    // Active side = the request recipient, so it's limited to player-owned actors (a GM owns
+    // every token) and has no Manual entry.
     const initialTargetActor = resolveActorFromUuid(initialTargetUuid);
     const initialTargetHasPlayerOwner = !!initialTargetActor?.hasPlayerOwner;
-    // No Manual entry - the active side must be a real actor/token, since it's who the request
-    // card is addressed to. `initialTargetUuid` is guaranteed to appear (even if not otherwise
-    // owned-via-token/actor-setting) so the sheet this dialog was opened from is always pickable -
-    // unless it has no player owner, in which case the GM must explicitly pick someone instead.
     const activeTokenOrActorOptions = getTokenOrActorOptions(
       initialTargetHasPlayerOwner ? initialTargetUuid : "",
       initialTargetHasPlayerOwner ? (initialTargetTokenOrActor?.name ?? "") : "",
@@ -108,9 +99,7 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       false,
       filterToPlayerOwnedOptions(baseTokenOrActorOptions),
     );
-    // Manual is the common case here (a GM-known value like a disease's POT), so it's included.
-    // A seeded passive (e.g. the NPC whose token HUD the request was opened from) is guaranteed to
-    // appear even if it's not on the current scene / not otherwise owned.
+    // Passive side includes Manual (a GM-known POT etc.); the seeded passive is always listed.
     const seededPassiveUuid = this.seed.passiveUuid ?? "";
     const seededPassive = seededPassiveUuid
       ? (fromUuidSync(seededPassiveUuid) as TokenDocument | RqgActor | undefined)
@@ -168,11 +157,7 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
     };
   }
 
-  /**
-   * Both sides resolved to a usable value/label - the active token/actor is picked and its
-   * characteristic(s) sum to something, and the passive side is either a real actor or a manual
-   * entry with a label. Gates the Send button so a bad request can never be posted.
-   */
+  /** Both sides resolve to a value/label - gates the Send button. */
   private static canSendRequest(formData: ResistanceRequestDialogFormData): boolean {
     if (!formData.targetTokenOrActorUuid) {
       return false;
@@ -251,8 +236,7 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       formDataObject.passiveManualName,
     );
 
-    // The Send button is disabled until this passes, so reaching here invalid needs an odd path
-    // (e.g. a stale submit) - bail silently rather than surfacing an error the UI already prevents.
+    // Send is disabled until valid; a stray submit just bails.
     if (!ResistanceRequestDialogV2.canSendRequest(formDataObject)) {
       return;
     }
@@ -269,9 +253,7 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       resistanceRoll: undefined,
     };
 
-    // Shown as the message author instead of the GM, so the card reads as the recipient's roll
-    // request even though the GM is the one who posted it. Rendered concurrently with the chat
-    // content below since neither depends on the other.
+    // Author the card as the recipient, not the GM.
     const [content, targetTokenOrActor] = await Promise.all([
       foundry.applications.handlebars.renderTemplate(
         templatePaths.resistanceRequestChatMessage,

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
@@ -1,0 +1,281 @@
+import { systemId } from "../../system/config";
+import { templatePaths } from "../../system/load-handlebars-templates";
+import type {
+  ResistanceRequestDialogContext,
+  ResistanceRequestDialogFormData,
+  ResistanceRequestSeed,
+} from "./resistance-request-dialog-data.types.ts";
+import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
+import { activateChatTab, localize } from "../../system/util";
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import {
+  augmentOptions,
+  filterToPlayerOwnedOptions,
+  getBaseTokenOrActorOptions,
+  getCharacteristicOptions,
+  getTokenOrActorOptions,
+  meditateOptions,
+  resolveActorFromUuid,
+  resolveCharacteristicSide,
+} from "./resistance-roll-shared.ts";
+import { buildResistanceRollFlavor } from "../../rolls/resistance-roll/resistance-roll-flavor.ts";
+import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
+import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
+import { getSpeakerCompat } from "../../system/fvtt-type-compat";
+
+/**
+ * GM-facing dialog (#758 option C): pick who should roll (an actor/token's characteristic(s))
+ * and what they're resisting (another actor's characteristic(s), or a manual value/label such as
+ * a disease's POT), then post a chat card only that recipient (and the GM) can act on. Unlike
+ * ResistanceRollDialogV2 this dialog never rolls anything itself - it only creates the request;
+ * RespondToResistanceRequestDialogV2 is what the recipient uses to actually roll.
+ */
+export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase {
+  protected override getLivePreviewFormBehaviorConfig() {
+    return {
+      submitButtonSelectorForBlurGuard: "button[data-send-resistance-request]",
+      updateLivePreview: () => this.updateLivePreview(),
+    };
+  }
+
+  private seed: ResistanceRequestSeed;
+
+  constructor(
+    seed: ResistanceRequestSeed = {},
+    options?: Partial<foundry.applications.types.ApplicationConfiguration>,
+  ) {
+    super(options);
+    this.seed = seed;
+  }
+
+  static override DEFAULT_OPTIONS = {
+    id: `resistance-request-{id}`,
+    tag: "form",
+    classes: [systemId, "form", "roll-dialog", "resistance-request-dialog"],
+    form: {
+      handler: ResistanceRequestDialogV2.onSubmit,
+      submitOnChange: false,
+      closeOnSubmit: true,
+    },
+    position: {
+      width: "auto" as const,
+      height: "auto" as const,
+      left: 35,
+      top: 15,
+    },
+    window: {
+      contentClasses: ["standard-form"],
+      icon: "fa-solid fa-scale-unbalanced",
+      title: "RQG.Dialog.ResistanceRequest.Title",
+      resizable: false,
+    },
+  };
+
+  static override PARTS = {
+    header: { template: templatePaths.rollHeader },
+    form: { template: templatePaths.resistanceRequestDialogV2, scrollable: [""] },
+    footer: { template: templatePaths.resistanceRequestFooter },
+  };
+
+  override async _prepareContext(): Promise<ResistanceRequestDialogContext> {
+    const formData = ((this.element &&
+      new foundry.applications.ux.FormDataExtended(this.form!, {}).object) ??
+      {}) as ResistanceRequestDialogFormData;
+
+    const defaultTargetUuid =
+      game.user?.targets.size === 1 ? (game.user.targets.first()?.document?.uuid ?? "") : "";
+    const initialTargetUuid = this.seed.activeUuid || defaultTargetUuid || "";
+    const initialTargetTokenOrActor = initialTargetUuid
+      ? (fromUuidSync(initialTargetUuid) as TokenDocument | RqgActor | undefined)
+      : undefined;
+
+    // Both sides share the same underlying targeted/owned-token/owned-actor scan - computed once
+    // here and handed to both calls below instead of each re-scanning it independently.
+    const baseTokenOrActorOptions = getBaseTokenOrActorOptions();
+
+    // The active side is who gets asked to roll, so it's restricted to tokens/actors with an
+    // actual player owner - a GM owns every token, so without this an NPC/monster could be picked
+    // as the recipient and nobody but the GM could ever click that card's Roll button.
+    const initialTargetActor = resolveActorFromUuid(initialTargetUuid);
+    const initialTargetHasPlayerOwner = !!initialTargetActor?.hasPlayerOwner;
+    // No Manual entry - the active side must be a real actor/token, since it's who the request
+    // card is addressed to. `initialTargetUuid` is guaranteed to appear (even if not otherwise
+    // owned-via-token/actor-setting) so the sheet this dialog was opened from is always pickable -
+    // unless it has no player owner, in which case the GM must explicitly pick someone instead.
+    const activeTokenOrActorOptions = getTokenOrActorOptions(
+      initialTargetHasPlayerOwner ? initialTargetUuid : "",
+      initialTargetHasPlayerOwner ? (initialTargetTokenOrActor?.name ?? "") : "",
+      initialTargetHasPlayerOwner ? initialTargetActor : undefined,
+      false,
+      filterToPlayerOwnedOptions(baseTokenOrActorOptions),
+    );
+    // Manual is the common case here (a GM-known value like a disease's POT), so it's included.
+    // A seeded passive (e.g. the NPC whose token HUD the request was opened from) is guaranteed to
+    // appear even if it's not on the current scene / not otherwise owned.
+    const seededPassiveUuid = this.seed.passiveUuid ?? "";
+    const seededPassive = seededPassiveUuid
+      ? (fromUuidSync(seededPassiveUuid) as TokenDocument | RqgActor | undefined)
+      : undefined;
+    const passiveTokenOrActorOptions = getTokenOrActorOptions(
+      seededPassiveUuid,
+      seededPassive?.name ?? "",
+      resolveActorFromUuid(seededPassiveUuid),
+      true,
+      baseTokenOrActorOptions,
+    );
+
+    formData.targetTokenOrActorUuid ??= initialTargetHasPlayerOwner ? initialTargetUuid : "";
+    formData.activeCharacteristics ??= "";
+
+    formData.passiveTokenOrActorUuid ??= this.seed.passiveUuid || MANUAL_SOURCE_VALUE;
+    formData.passiveCharacteristics ??= "";
+    formData.passiveManualName ??= "";
+    formData.passiveManualLabel ??= "";
+    formData.passiveManualValue ??= 0;
+
+    formData.augmentModifier ??= "0";
+    formData.meditateModifier ??= "0";
+    formData.otherModifier ??= "0";
+    formData.otherModifierDescription ??= localize("RQG.Dialog.Common.OtherModifier");
+
+    const totalChance = ResistanceRequestDialogV2.computeTotalChance(formData);
+    const active = resolveCharacteristicSide(
+      formData.targetTokenOrActorUuid,
+      formData.activeCharacteristics,
+      "",
+      0,
+      localize("RQG.Dialog.ResistanceRoll.Active"),
+    );
+    const passive = resolveCharacteristicSide(
+      formData.passiveTokenOrActorUuid,
+      formData.passiveCharacteristics,
+      formData.passiveManualLabel,
+      formData.passiveManualValue,
+      localize("RQG.Dialog.ResistanceRoll.Passive"),
+      formData.passiveManualName,
+    );
+
+    return {
+      formData: formData,
+      activeTokenOrActorOptions: activeTokenOrActorOptions,
+      passiveTokenOrActorOptions: passiveTokenOrActorOptions,
+      characteristicOptions: getCharacteristicOptions(),
+      augmentOptions: augmentOptions,
+      meditateOptions: meditateOptions,
+
+      // RollHeader
+      rollType: localize("RQG.Dialog.ResistanceRequest.Title"),
+      rollName: `${active.label || "?"} ${localize("RQG.Roll.ResistanceRoll.Vs")} ${passive.label || "?"}`,
+      baseChance: "",
+
+      totalChance: totalChance,
+    };
+  }
+
+  private static computeTotalChance(formData: ResistanceRequestDialogFormData): number {
+    const active = resolveCharacteristicSide(
+      formData.targetTokenOrActorUuid,
+      formData.activeCharacteristics,
+      "",
+      0,
+      "",
+    );
+    const passive = resolveCharacteristicSide(
+      formData.passiveTokenOrActorUuid,
+      formData.passiveCharacteristics,
+      formData.passiveManualLabel,
+      formData.passiveManualValue,
+      "",
+    );
+    return computeResistanceTargetChance(active.value, passive.value, [
+      Number(formData.augmentModifier),
+      Number(formData.meditateModifier),
+      Number(formData.otherModifier),
+    ]);
+  }
+
+  private updateLivePreview(): void {
+    const formData = new foundry.applications.ux.FormDataExtended(this.element, {})
+      .object as ResistanceRequestDialogFormData;
+    this.updateTotalChanceDisplay(ResistanceRequestDialogV2.computeTotalChance(formData));
+  }
+
+  private static async onSubmit(
+    event: SubmitEvent | Event,
+    form: HTMLFormElement,
+    formData: foundry.applications.ux.FormDataExtended,
+  ): Promise<void> {
+    const formDataObject = formData.object as ResistanceRequestDialogFormData;
+
+    const active = resolveCharacteristicSide(
+      formDataObject.targetTokenOrActorUuid,
+      formDataObject.activeCharacteristics,
+      "",
+      0,
+      "",
+    );
+    const passive = resolveCharacteristicSide(
+      formDataObject.passiveTokenOrActorUuid,
+      formDataObject.passiveCharacteristics,
+      formDataObject.passiveManualLabel,
+      formDataObject.passiveManualValue,
+      "",
+      formDataObject.passiveManualName,
+    );
+
+    if (!formDataObject.targetTokenOrActorUuid || !active.label) {
+      ui.notifications?.error("Pick who should roll and which characteristic(s) they roll with.");
+      return;
+    }
+    if (!passive.label) {
+      ui.notifications?.error("Pick or enter what the roll resists.");
+      return;
+    }
+
+    const chatSystemData = {
+      state: "Requested",
+      targetTokenOrActorUuid: formDataObject.targetTokenOrActorUuid,
+      activeCharacteristics: formDataObject.activeCharacteristics,
+      passiveValue: passive.value,
+      passiveLabel: passive.label,
+      passiveActorName: passive.actorName,
+      augmentModifier: Number(formDataObject.augmentModifier) || 0,
+      meditateModifier: Number(formDataObject.meditateModifier) || 0,
+      otherModifier: Number(formDataObject.otherModifier) || 0,
+      otherModifierDescription: formDataObject.otherModifierDescription || undefined,
+      resistanceRoll: undefined,
+    };
+
+    // Shown as the message author instead of the GM, so the card reads as the recipient's roll
+    // request even though the GM is the one who posted it. Rendered concurrently with the chat
+    // content below since neither depends on the other.
+    const [content, targetTokenOrActor] = await Promise.all([
+      foundry.applications.handlebars.renderTemplate(
+        templatePaths.resistanceRequestChatMessage,
+        chatSystemData,
+      ),
+      fromUuid(formDataObject.targetTokenOrActorUuid) as Promise<
+        TokenDocument | RqgActor | undefined
+      >,
+    ]);
+
+    const flavor = buildResistanceRollFlavor(active.label, passive.label, passive.actorName);
+
+    const targetToken =
+      targetTokenOrActor instanceof TokenDocument ? targetTokenOrActor : undefined;
+    const targetActor =
+      targetTokenOrActor instanceof TokenDocument ? targetTokenOrActor.actor : targetTokenOrActor;
+
+    activateChatTab();
+    const cm = await ChatMessage.create({
+      type: "resistanceRequest",
+      system: chatSystemData,
+      flavor: flavor,
+      content: content,
+      speaker: getSpeakerCompat({ actor: targetActor ?? undefined, token: targetToken }),
+    } as any);
+    if (cm && !Array.isArray(cm)) {
+      cm.render(true);
+    }
+  }
+}

--- a/src/applications/resistance-roll-dialog/resistance-request-footer.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-request-footer.hbs
@@ -1,5 +1,7 @@
 <footer class="flexrow flex-wrap gap1rem">
-  <div class="target-box" data-tooltip="{{localize 'RQG.Dialog.Common.TargetChance'}}">
+  <div class="target-box" data-target-chance-box
+       data-tooltip="{{#if totalChanceTooltip}}{{{totalChanceTooltip}}}{{else}}{{localize 'RQG.Dialog.Common.TargetChance'}}{{/if}}"
+       {{#if totalChanceTooltip}}data-tooltip-class="chance-breakdown-tooltip"{{/if}}>
     <i class="fa-solid fa-bullseye"></i><br>
     <span data-total-chance>{{totalChance}}%</span>
   </div>

--- a/src/applications/resistance-roll-dialog/resistance-request-footer.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-request-footer.hbs
@@ -5,5 +5,19 @@
     <i class="fa-solid fa-bullseye"></i><br>
     <span data-total-chance>{{totalChance}}%</span>
   </div>
+  {{#if rollModes.length}}
+    <div data-roll-mode-parent class="split-button flex-none">
+      {{#each rollModes as |mode|}}
+        <button type="button"
+                class="ui-control icon {{mode.icon}}"
+                data-action="rollMode"
+                data-roll-mode="{{mode.id}}"
+                aria-pressed="{{#if (eq ../rollMode mode.id)}}true{{else}}false{{/if}}"
+                data-tooltip="{{localize mode.label}}"
+                aria-label="{{localize mode.label}}">
+        </button>
+      {{/each}}
+    </div>
+  {{/if}}
   <button data-send-resistance-request {{#unless canSendRequest}}disabled{{/unless}}>{{localize "RQG.Dialog.ResistanceRequest.SendRequest"}}</button>
 </footer>

--- a/src/applications/resistance-roll-dialog/resistance-request-footer.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-request-footer.hbs
@@ -1,0 +1,7 @@
+<footer class="flexrow flex-wrap gap1rem">
+  <div class="target-box" data-tooltip="{{localize 'RQG.Dialog.Common.TargetChance'}}">
+    <i class="fa-solid fa-bullseye"></i><br>
+    <span data-total-chance>{{totalChance}}%</span>
+  </div>
+  <button data-send-resistance-request>{{localize "RQG.Dialog.ResistanceRequest.SendRequest"}}</button>
+</footer>

--- a/src/applications/resistance-roll-dialog/resistance-request-footer.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-request-footer.hbs
@@ -3,5 +3,5 @@
     <i class="fa-solid fa-bullseye"></i><br>
     <span data-total-chance>{{totalChance}}%</span>
   </div>
-  <button data-send-resistance-request>{{localize "RQG.Dialog.ResistanceRequest.SendRequest"}}</button>
+  <button data-send-resistance-request {{#unless canSendRequest}}disabled{{/unless}}>{{localize "RQG.Dialog.ResistanceRequest.SendRequest"}}</button>
 </footer>

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
@@ -31,7 +31,6 @@ export type ResistanceRollDialogContext = RollHeaderData &
   RollFooterData & {
     formData: ResistanceRollDialogFormData;
 
-    speakerName: string;
     activeTokenOrActorOptions: SelectOptionData<string>[];
     passiveTokenOrActorOptions: SelectOptionData<string>[];
     characteristicOptions: SelectOptionData<string>[];

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
@@ -51,6 +51,8 @@ export type ResistanceRollDialogFormData = {
   passiveTokenOrActorUuid: string;
   /** One characteristic name, or two joined by "+" (e.g. "size+dexterity"). */
   passiveCharacteristics: string;
+  /** Names a Manual passive for the "opposes X" flavor line, e.g. "Noxious Gas". */
+  passiveManualName: string;
   passiveManualLabel: string;
   passiveManualValue: number;
 

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
@@ -5,7 +5,7 @@ import type { Characteristics } from "../../data-model/actor-data/characteristic
 /** Sentinel value for the token/actor dropdown meaning "type in a value by hand instead". */
 export const MANUAL_SOURCE_VALUE = "manual";
 
-/** Prefill for one side (active or passive) of a resistance roll, e.g. from a spell's post-cast hook. */
+/** Prefill for one side of a resistance roll. */
 export type ResistanceRollSidePrefill =
   | {
       source: "tokenOrActor";
@@ -17,16 +17,11 @@ export type ResistanceRollSidePrefill =
 export type ResistanceRollDialogPrefill = {
   active?: ResistanceRollSidePrefill;
   passive?: ResistanceRollSidePrefill;
-  /** Shown in the roll header, e.g. the name of the spell that triggered this check. */
+  /** Shown in the roll header, e.g. the triggering spell's name. */
   description?: string;
 };
 
-/**
- * Canvas-derived starting point for a GM-opened {@link ResistanceRollDialogV2}
- * (`ResistanceRollDialogV2.openForGm`) - just the two sides' token/actor uuids, which the GM
- * then adjusts before rolling. Unlike {@link ResistanceRollDialogPrefill} nothing here is
- * authoritative; there is no self-actor and no spell dictating the characteristics.
- */
+/** Canvas-derived side uuids for a GM-opened dialog (openForGm); the GM adjusts before rolling. */
 export type ResistanceRollSeed = {
   activeUuid?: string | undefined;
   passiveUuid?: string | undefined;
@@ -64,6 +59,6 @@ export type ResistanceRollDialogFormData = {
   otherModifier: string;
   otherModifierDescription: string;
 
-  actorUuid: string; // hidden field - the actor whose sheet/token this dialog was opened from
+  actorUuid: string; // hidden field
   tokenUuid: string; // hidden field
 };

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
@@ -1,0 +1,58 @@
+import type { RollHeaderData } from "../app-parts/roll-header.types.ts";
+import type { RollFooterData } from "../app-parts/roll-footer.types.ts";
+import type { Characteristics } from "../../data-model/actor-data/characteristics.ts";
+
+/** Sentinel value for the token/actor dropdown meaning "type in a value by hand instead". */
+export const MANUAL_SOURCE_VALUE = "manual";
+
+/** Prefill for one side (active or passive) of a resistance roll, e.g. from a spell's post-cast hook. */
+export type ResistanceRollSidePrefill =
+  | {
+      source: "tokenOrActor";
+      tokenOrActorUuid: string;
+      characteristicNames: [keyof Characteristics] | [keyof Characteristics, keyof Characteristics];
+    }
+  | { source: "manual"; value: number; label: string };
+
+export type ResistanceRollDialogPrefill = {
+  active?: ResistanceRollSidePrefill;
+  passive?: ResistanceRollSidePrefill;
+  /** Shown in the roll header, e.g. the name of the spell that triggered this check. */
+  description?: string;
+};
+
+export type ResistanceRollDialogContext = RollHeaderData &
+  RollFooterData & {
+    formData: ResistanceRollDialogFormData;
+
+    speakerName: string;
+    activeTokenOrActorOptions: SelectOptionData<string>[];
+    passiveTokenOrActorOptions: SelectOptionData<string>[];
+    characteristicOptions: SelectOptionData<string>[];
+    augmentOptions: SelectOptionData<number>[];
+    meditateOptions: SelectOptionData<number>[];
+  };
+
+export type ResistanceRollDialogFormData = {
+  /** A token/actor uuid, or the MANUAL_SOURCE_VALUE sentinel. */
+  activeTokenOrActorUuid: string;
+  /** One characteristic name, or two joined by "+" (e.g. "strength+size"). */
+  activeCharacteristics: string;
+  activeManualLabel: string;
+  activeManualValue: number;
+
+  /** A token/actor uuid, or the MANUAL_SOURCE_VALUE sentinel. */
+  passiveTokenOrActorUuid: string;
+  /** One characteristic name, or two joined by "+" (e.g. "size+dexterity"). */
+  passiveCharacteristics: string;
+  passiveManualLabel: string;
+  passiveManualValue: number;
+
+  augmentModifier: string;
+  meditateModifier: string;
+  otherModifier: string;
+  otherModifierDescription: string;
+
+  actorUuid: string; // hidden field - the actor whose sheet/token this dialog was opened from
+  tokenUuid: string; // hidden field
+};

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
@@ -21,6 +21,17 @@ export type ResistanceRollDialogPrefill = {
   description?: string;
 };
 
+/**
+ * Canvas-derived starting point for a GM-opened {@link ResistanceRollDialogV2}
+ * (`ResistanceRollDialogV2.openForGm`) - just the two sides' token/actor uuids, which the GM
+ * then adjusts before rolling. Unlike {@link ResistanceRollDialogPrefill} nothing here is
+ * authoritative; there is no self-actor and no spell dictating the characteristics.
+ */
+export type ResistanceRollSeed = {
+  activeUuid?: string | undefined;
+  passiveUuid?: string | undefined;
+};
+
 export type ResistanceRollDialogContext = RollHeaderData &
   RollFooterData & {
     formData: ResistanceRollDialogFormData;

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
@@ -1,9 +1,4 @@
 <div class="scrollable">
-  <div class="key-value-grid p-0">
-    <label>{{localize "RQG.Dialog.Common.Character"}}</label>
-    <div>{{speakerName}}</div>
-  </div>
-
   <fieldset>
     <legend>{{localize "RQG.Dialog.ResistanceRoll.Active"}}</legend>
     <div class="key-value-grid p-0">

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
@@ -19,12 +19,16 @@
         </select>
       {{else}}
         <label>{{localize "RQG.Dialog.ResistanceRoll.ManualLabel"}}</label>
-        <input type="text" value="{{formData.activeManualLabel}}" name="activeManualLabel" list="resistance-manual-label-suggestions">
+        <input type="text" value="{{formData.activeManualLabel}}" name="activeManualLabel" list="resistance-manual-label-suggestions"
+               placeholder="{{localize 'RQG.Dialog.ResistanceRoll.ManualLabelPlaceholder'}}">
 
         <label>{{localize "RQG.Dialog.ResistanceRoll.ManualValue"}}</label>
         <input type="number" value="{{formData.activeManualValue}}" name="activeManualValue">
       {{/unless}}
     </div>
+    {{#if (eq formData.activeTokenOrActorUuid "manual")}}
+      <p class="hint">{{localize "RQG.Dialog.ResistanceRoll.ManualHint"}}</p>
+    {{/if}}
   </fieldset>
 
   <fieldset>
@@ -42,18 +46,23 @@
         </select>
       {{else}}
         <label>{{localize "RQG.Dialog.ResistanceRoll.ManualLabel"}}</label>
-        <input type="text" value="{{formData.passiveManualLabel}}" name="passiveManualLabel" list="resistance-manual-label-suggestions">
+        <input type="text" value="{{formData.passiveManualLabel}}" name="passiveManualLabel" list="resistance-manual-label-suggestions"
+               placeholder="{{localize 'RQG.Dialog.ResistanceRoll.ManualLabelPlaceholder'}}">
 
         <label>{{localize "RQG.Dialog.ResistanceRoll.ManualValue"}}</label>
         <input type="number" value="{{formData.passiveManualValue}}" name="passiveManualValue">
       {{/unless}}
     </div>
+    {{#if (eq formData.passiveTokenOrActorUuid "manual")}}
+      <p class="hint">{{localize "RQG.Dialog.ResistanceRoll.ManualHint"}}</p>
+    {{/if}}
   </fieldset>
 
   <datalist id="resistance-manual-label-suggestions">
-    <option value="POT">
+    <option value="{{localize 'RQG.Dialog.ResistanceRoll.Potency'}}">
     <option value="{{localize 'RQG.Actor.Characteristics.strength'}}">
     <option value="{{localize 'RQG.Actor.Characteristics.size'}}">
+    <option value="{{localize 'RQG.Actor.Characteristics.power'}}">
   </datalist>
 
   <div class="key-value-grid p-0">

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
@@ -45,6 +45,10 @@
           {{selectOptions characteristicOptions selected=formData.passiveCharacteristics localize=false}}
         </select>
       {{else}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualName"}}</label>
+        <input type="text" value="{{formData.passiveManualName}}" name="passiveManualName"
+               placeholder="{{localize 'RQG.Dialog.ResistanceRoll.ManualNamePlaceholder'}}">
+
         <label>{{localize "RQG.Dialog.ResistanceRoll.ManualLabel"}}</label>
         <input type="text" value="{{formData.passiveManualLabel}}" name="passiveManualLabel" list="resistance-manual-label-suggestions"
                placeholder="{{localize 'RQG.Dialog.ResistanceRoll.ManualLabelPlaceholder'}}">
@@ -65,22 +69,25 @@
     <option value="{{localize 'RQG.Actor.Characteristics.power'}}">
   </datalist>
 
-  <div class="key-value-grid p-0">
-    <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
-    <select name="augmentModifier">
-      {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
-    </select>
+  <fieldset>
+    <legend>{{localize "RQG.Dialog.Common.Modifiers"}}</legend>
+    <div class="key-value-grid p-0">
+      <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
+      <select name="augmentModifier">
+        {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
+      </select>
 
-    <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
-    <select name="meditateModifier">
-      {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
-    </select>
+      <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
+      <select name="meditateModifier">
+        {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
+      </select>
 
-    <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
-    <div>
-      <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
+      <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
+      <div>
+        <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
+      </div>
     </div>
-  </div>
+  </fieldset>
 
   <input type="hidden" value="{{formData.actorUuid}}" name="actorUuid">
   <input type="hidden" value="{{formData.tokenUuid}}" name="tokenUuid">

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
@@ -65,7 +65,7 @@
   </datalist>
 
   <fieldset>
-    <legend>{{localize "RQG.Dialog.Common.Modifiers"}}</legend>
+    <legend>{{localize "RQG.Dialog.ResistanceRoll.ModifiersLegend"}}</legend>
     <div class="key-value-grid p-0">
       <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
       <select name="augmentModifier">
@@ -82,6 +82,7 @@
         <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
       </div>
     </div>
+    <p class="hint">{{localize "RQG.Dialog.ResistanceRoll.ModifiersHint"}}</p>
   </fieldset>
 
   <input type="hidden" value="{{formData.actorUuid}}" name="actorUuid">

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
@@ -1,0 +1,78 @@
+<div class="scrollable">
+  <div class="key-value-grid p-0">
+    <label>{{localize "RQG.Dialog.Common.Character"}}</label>
+    <div>{{speakerName}}</div>
+  </div>
+
+  <fieldset>
+    <legend>{{localize "RQG.Dialog.ResistanceRoll.Active"}}</legend>
+    <div class="key-value-grid p-0">
+      <label>{{localize "RQG.Dialog.ResistanceRoll.TokenOrActor"}}</label>
+      <select name="activeTokenOrActorUuid">
+        {{selectOptions activeTokenOrActorOptions selected=formData.activeTokenOrActorUuid localize=false}}
+      </select>
+
+      {{#unless (eq formData.activeTokenOrActorUuid "manual")}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.Characteristic"}}</label>
+        <select name="activeCharacteristics">
+          {{selectOptions characteristicOptions selected=formData.activeCharacteristics localize=false}}
+        </select>
+      {{else}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualLabel"}}</label>
+        <input type="text" value="{{formData.activeManualLabel}}" name="activeManualLabel" list="resistance-manual-label-suggestions">
+
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualValue"}}</label>
+        <input type="number" value="{{formData.activeManualValue}}" name="activeManualValue">
+      {{/unless}}
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>{{localize "RQG.Dialog.ResistanceRoll.Passive"}}</legend>
+    <div class="key-value-grid p-0">
+      <label>{{localize "RQG.Dialog.ResistanceRoll.TokenOrActor"}}</label>
+      <select name="passiveTokenOrActorUuid">
+        {{selectOptions passiveTokenOrActorOptions selected=formData.passiveTokenOrActorUuid localize=false}}
+      </select>
+
+      {{#unless (eq formData.passiveTokenOrActorUuid "manual")}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.Characteristic"}}</label>
+        <select name="passiveCharacteristics">
+          {{selectOptions characteristicOptions selected=formData.passiveCharacteristics localize=false}}
+        </select>
+      {{else}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualLabel"}}</label>
+        <input type="text" value="{{formData.passiveManualLabel}}" name="passiveManualLabel" list="resistance-manual-label-suggestions">
+
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualValue"}}</label>
+        <input type="number" value="{{formData.passiveManualValue}}" name="passiveManualValue">
+      {{/unless}}
+    </div>
+  </fieldset>
+
+  <datalist id="resistance-manual-label-suggestions">
+    <option value="POT">
+    <option value="{{localize 'RQG.Actor.Characteristics.strength'}}">
+    <option value="{{localize 'RQG.Actor.Characteristics.size'}}">
+  </datalist>
+
+  <div class="key-value-grid p-0">
+    <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
+    <select name="augmentModifier">
+      {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
+    </select>
+
+    <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
+    <select name="meditateModifier">
+      {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
+    </select>
+
+    <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
+    <div>
+      <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
+    </div>
+  </div>
+
+  <input type="hidden" value="{{formData.actorUuid}}" name="actorUuid">
+  <input type="hidden" value="{{formData.tokenUuid}}" name="tokenUuid">
+</div>

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
@@ -82,7 +82,6 @@
         <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
       </div>
     </div>
-    <p class="hint">{{localize "RQG.Dialog.ResistanceRoll.ModifiersHint"}}</p>
   </fieldset>
 
   <input type="hidden" value="{{formData.actorUuid}}" name="actorUuid">

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
@@ -20,6 +20,21 @@
         <label>{{localize "RQG.Dialog.ResistanceRoll.ManualValue"}}</label>
         <input type="number" value="{{formData.activeManualValue}}" name="activeManualValue">
       {{/unless}}
+
+      <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
+      <select name="augmentModifier">
+        {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
+      </select>
+
+      <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
+      <select name="meditateModifier">
+        {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
+      </select>
+
+      <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
+      <div>
+        <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
+      </div>
     </div>
     {{#if (eq formData.activeTokenOrActorUuid "manual")}}
       <p class="hint">{{localize "RQG.Dialog.ResistanceRoll.ManualHint"}}</p>
@@ -63,26 +78,6 @@
     <option value="{{localize 'RQG.Actor.Characteristics.size'}}">
     <option value="{{localize 'RQG.Actor.Characteristics.power'}}">
   </datalist>
-
-  <fieldset>
-    <legend>{{localize "RQG.Dialog.ResistanceRoll.ModifiersLegend"}}</legend>
-    <div class="key-value-grid p-0">
-      <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
-      <select name="augmentModifier">
-        {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
-      </select>
-
-      <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
-      <select name="meditateModifier">
-        {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
-      </select>
-
-      <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
-      <div>
-        <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
-      </div>
-    </div>
-  </fieldset>
 
   <input type="hidden" value="{{formData.actorUuid}}" name="actorUuid">
   <input type="hidden" value="{{formData.tokenUuid}}" name="tokenUuid">

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
@@ -16,6 +16,7 @@ import { ResistanceRoll } from "../../rolls/resistance-roll/resistance-roll";
 import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
 import {
   augmentOptions,
+  buildResistanceChanceBreakdown,
   buildResistanceModifiers,
   decodeCharacteristics,
   defaultCharacteristic,
@@ -224,10 +225,28 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
 
       // RollFooter
       totalChance: totalChance,
+      totalChanceTooltip: ResistanceRollDialogV2.buildChanceBreakdown(formData, active, passive),
       rollMode: this.rollMode,
       rollModes: getConfiguredRollModeOptions(),
       disableRoll: !ResistanceRollDialogV2.canRoll(formData),
     };
+  }
+
+  private static buildChanceBreakdown(
+    formData: ResistanceRollDialogFormData,
+    active: { value: number; label: string },
+    passive: { value: number; label: string },
+  ): string {
+    return buildResistanceChanceBreakdown(
+      active,
+      passive,
+      buildResistanceModifiers(
+        formData.augmentModifier,
+        formData.meditateModifier,
+        formData.otherModifier,
+        formData.otherModifierDescription,
+      ),
+    );
   }
 
   /** Both sides resolve to a value/label - gates the Roll button. */
@@ -275,6 +294,15 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     const formData = new foundry.applications.ux.FormDataExtended(this.element, {})
       .object as ResistanceRollDialogFormData;
     this.updateTotalChanceDisplay(ResistanceRollDialogV2.computeTotalChance(formData));
+
+    const targetChanceBox = this.element.querySelector<HTMLElement>("[data-target-chance-box]");
+    if (targetChanceBox) {
+      targetChanceBox.dataset["tooltip"] = ResistanceRollDialogV2.buildChanceBreakdown(
+        formData,
+        ResistanceRollDialogV2.resolveSide(formData, "active"),
+        ResistanceRollDialogV2.resolveSide(formData, "passive"),
+      );
+    }
 
     const rollButton = this.element.querySelector<HTMLButtonElement>("button[data-ability-roll]");
     if (rollButton) {

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
@@ -8,7 +8,7 @@ import type {
   ResistanceRollSidePrefill,
 } from "./resistance-roll-dialog-data.types.ts";
 import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
-import { getSpeakerDisplayName, isDocumentSubType, localize, RqgError } from "../../system/util";
+import { isDocumentSubType, localize, RqgError } from "../../system/util";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
 import type { ResistanceRollOptions } from "../../rolls/resistance-roll/resistance-roll.types";
@@ -202,13 +202,6 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     formData.actorUuid ??= this.actor?.uuid ?? "";
     formData.tokenUuid ??= this.token?.uuid ?? "";
 
-    // GM cold-open: speak as the acting side.
-    const speakerActor =
-      this.actor ??
-      (formData.activeTokenOrActorUuid && formData.activeTokenOrActorUuid !== MANUAL_SOURCE_VALUE
-        ? resolveActorFromUuid(formData.activeTokenOrActorUuid)
-        : undefined);
-    const speaker = getSpeakerCompat({ actor: speakerActor, token: this.token });
     const totalChance = ResistanceRollDialogV2.computeTotalChance(formData);
     const active = ResistanceRollDialogV2.resolveSide(formData, "active");
     const passive = ResistanceRollDialogV2.resolveSide(formData, "passive");
@@ -216,7 +209,6 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     return {
       formData: formData,
 
-      speakerName: getSpeakerDisplayName(speaker),
       activeTokenOrActorOptions: tokenOrActorOptions,
       passiveTokenOrActorOptions: tokenOrActorOptions,
       characteristicOptions: getCharacteristicOptions(),

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
@@ -4,6 +4,7 @@ import type {
   ResistanceRollDialogContext,
   ResistanceRollDialogFormData,
   ResistanceRollDialogPrefill,
+  ResistanceRollSeed,
   ResistanceRollSidePrefill,
 } from "./resistance-roll-dialog-data.types.ts";
 import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
@@ -99,24 +100,39 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     };
   }
 
-  private actor: RqgActor;
+  // The actor whose sheet/token this dialog was opened from - the "self" default for the active
+  // side. Undefined when the GM opens the dialog cold (see openForGm): both sides come from the
+  // seed / the pickers instead.
+  private actor: RqgActor | undefined;
   private token: TokenDocument | null | undefined;
   private prefill: ResistanceRollDialogPrefill | undefined;
+  private seed: ResistanceRollSeed | undefined;
   // Applied once on the first _prepareContext only - _prepareContext reruns on every form change
-  // (RqgInteractiveRollApplicationBase re-renders on change), and re-applying the prefill on every
-  // one of those reruns would stomp over whatever the user just picked.
-  private prefillApplied = false;
+  // (RqgInteractiveRollApplicationBase re-renders on change), and re-applying the prefill/seed on
+  // every one of those reruns would stomp over whatever the user just picked.
+  private seedApplied = false;
 
   constructor(
-    actor: RqgActor,
+    actor?: RqgActor | null,
     token?: TokenDocument | null,
     prefill?: ResistanceRollDialogPrefill,
+    seed?: ResistanceRollSeed,
     options?: Partial<foundry.applications.types.ApplicationConfiguration>,
   ) {
     super(options);
-    this.actor = actor;
+    this.actor = actor ?? undefined;
     this.token = token;
     this.prefill = prefill;
+    this.seed = seed;
+  }
+
+  /**
+   * Open the dialog with no "self" actor, for a GM staging a resistance roll they will roll
+   * themselves (an NPC's POW-vs-POW, a poison's POT-vs-CON, an improvised STR contest). The
+   * seed pre-picks the two sides from canvas context; the GM adjusts before rolling.
+   */
+  static async openForGm(seed: ResistanceRollSeed = {}): Promise<void> {
+    await new ResistanceRollDialogV2(undefined, undefined, undefined, seed).render({ force: true });
   }
 
   static override DEFAULT_OPTIONS = {
@@ -153,14 +169,25 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
       new foundry.applications.ux.FormDataExtended(this.form!, {}).object) ??
       {}) as ResistanceRollDialogFormData;
 
-    const selfUuid = this.token?.uuid || this.actor.uuid || "";
+    const selfUuid = this.token?.uuid || this.actor?.uuid || "";
     const tokenOrActorOptions = getTokenOrActorOptions(
       selfUuid,
-      this.token?.name ?? this.actor.name ?? "",
+      this.token?.name ?? this.actor?.name ?? "",
       this.actor,
     );
     const defaultTargetUuid =
       game.user?.targets.size === 1 ? (game.user.targets.first()?.document?.uuid ?? "") : "";
+
+    // Seed the two sides before the ??= defaults so a GM-opened dialog with no "self" still
+    // lands on the canvas-derived token/actors; a spell prefill (applied below) overrides.
+    if (!this.seedApplied) {
+      if (this.seed?.activeUuid) {
+        formData.activeTokenOrActorUuid = this.seed.activeUuid;
+      }
+      if (this.seed?.passiveUuid) {
+        formData.passiveTokenOrActorUuid = this.seed.passiveUuid;
+      }
+    }
 
     formData.activeTokenOrActorUuid ??= selfUuid;
     formData.activeCharacteristics ??= defaultCharacteristic;
@@ -172,20 +199,26 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     formData.passiveManualLabel ??= "";
     formData.passiveManualValue ??= 0;
 
-    if (!this.prefillApplied) {
+    if (!this.seedApplied) {
       applyPrefill(formData, "active", this.prefill?.active);
       applyPrefill(formData, "passive", this.prefill?.passive);
-      this.prefillApplied = true;
+      this.seedApplied = true;
     }
 
     formData.augmentModifier ??= "0";
     formData.meditateModifier ??= "0";
     formData.otherModifier ??= "0";
     formData.otherModifierDescription ??= localize("RQG.Dialog.Common.OtherModifier");
-    formData.actorUuid ??= this.actor.uuid ?? "";
+    formData.actorUuid ??= this.actor?.uuid ?? "";
     formData.tokenUuid ??= this.token?.uuid ?? "";
 
-    const speaker = getSpeakerCompat({ actor: this.actor, token: this.token });
+    // No self actor (GM cold-open) -> speak as whoever is on the acting side of the roll.
+    const speakerActor =
+      this.actor ??
+      (formData.activeTokenOrActorUuid && formData.activeTokenOrActorUuid !== MANUAL_SOURCE_VALUE
+        ? resolveActorFromUuid(formData.activeTokenOrActorUuid)
+        : undefined);
+    const speaker = getSpeakerCompat({ actor: speakerActor, token: this.token });
     const totalChance = ResistanceRollDialogV2.computeTotalChance(formData);
     const active = ResistanceRollDialogV2.resolveSide(formData, "active");
     const passive = ResistanceRollDialogV2.resolveSide(formData, "passive");
@@ -278,24 +311,25 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
 
     const rollMode = resolveRollModeFromForm(form);
 
-    // Independent lookups from unrelated uuids - resolved concurrently.
-    const [actor, token] = (await Promise.all([
-      fromUuid(formDataObject.actorUuid),
-      formDataObject.tokenUuid ? fromUuid(formDataObject.tokenUuid) : undefined,
-    ])) as [RqgActor | undefined, TokenDocument | undefined];
-    if (!actor) {
-      ui.notifications?.error("Could not find an actor to roll a resistance roll for.");
-      return;
-    }
-
     // The Roll button is disabled until this passes; a submit that slips through anyway (stale
     // state, Enter key) bails silently rather than showing an error the UI already prevents.
     if (!ResistanceRollDialogV2.canRoll(formDataObject)) {
       return;
     }
 
+    // Independent lookups from unrelated uuids - resolved concurrently. A GM cold-open has no
+    // self actor/token; the speaker then falls back to the acting side's actor below.
+    const [selfActor, token] = (await Promise.all([
+      formDataObject.actorUuid ? fromUuid(formDataObject.actorUuid) : undefined,
+      formDataObject.tokenUuid ? fromUuid(formDataObject.tokenUuid) : undefined,
+    ])) as [RqgActor | undefined, TokenDocument | undefined];
+
     const active = ResistanceRollDialogV2.resolveSide(formDataObject, "active");
     const passive = ResistanceRollDialogV2.resolveSide(formDataObject, "passive");
+    const activeActor =
+      formDataObject.activeTokenOrActorUuid !== MANUAL_SOURCE_VALUE
+        ? resolveActorFromUuid(formDataObject.activeTokenOrActorUuid)
+        : undefined;
 
     const options: ResistanceRollOptions = {
       activeValue: active.value,
@@ -309,7 +343,7 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
         formDataObject.otherModifier,
         formDataObject.otherModifierDescription,
       ),
-      speaker: getSpeakerCompat({ actor, token }),
+      speaker: getSpeakerCompat({ actor: selfActor ?? activeActor, token }),
       rollMode: rollMode,
     };
 
@@ -321,13 +355,11 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     // Only POW earns an experience check from a resistance roll, credited to whichever actor
     // supplied the active side.
     if (
-      formDataObject.activeTokenOrActorUuid !== MANUAL_SOURCE_VALUE &&
-      decodeCharacteristics(formDataObject.activeCharacteristics).includes("power")
+      activeActor &&
+      decodeCharacteristics(formDataObject.activeCharacteristics).includes("power") &&
+      isDocumentSubType<CharacterActor>(activeActor, ActorTypeEnum.Character)
     ) {
-      const activeActor = resolveActorFromUuid(formDataObject.activeTokenOrActorUuid);
-      if (activeActor && isDocumentSubType<CharacterActor>(activeActor, ActorTypeEnum.Character)) {
-        await activeActor.checkExperience("power", roll.successLevel);
-      }
+      await activeActor.checkExperience("power", roll.successLevel);
     }
   }
 }

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
@@ -8,9 +8,8 @@ import type {
   ResistanceRollSidePrefill,
 } from "./resistance-roll-dialog-data.types.ts";
 import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
-import { isDocumentSubType, localize, RqgError } from "../../system/util";
+import { localize, RqgError } from "../../system/util";
 import type { RqgActor } from "@actors/rqg-actor.ts";
-import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
 import type { ResistanceRollOptions } from "../../rolls/resistance-roll/resistance-roll.types";
 import { ResistanceRoll } from "../../rolls/resistance-roll/resistance-roll";
 import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
@@ -18,7 +17,7 @@ import {
   augmentOptions,
   buildResistanceChanceBreakdown,
   buildResistanceModifiers,
-  decodeCharacteristics,
+  creditResistanceRollPowExperience,
   defaultCharacteristic,
   encodeCharacteristics,
   getCharacteristicOptions,
@@ -358,13 +357,11 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
       throw new RqgError("Evaluated ResistanceRoll didn't give successLevel");
     }
 
-    // Only POW earns experience, credited to the active side.
-    if (
-      activeActor &&
-      decodeCharacteristics(formDataObject.activeCharacteristics).includes("power") &&
-      isDocumentSubType<CharacterActor>(activeActor, ActorTypeEnum.Character)
-    ) {
-      await activeActor.checkExperience("power", roll.successLevel);
-    }
+    await creditResistanceRollPowExperience(
+      activeActor,
+      formDataObject.activeCharacteristics,
+      formDataObject.passiveCharacteristics,
+      roll,
+    );
   }
 }

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
@@ -39,9 +39,7 @@ type SideFields = {
   manualValue: number;
 };
 
-// The four fields making up a side are always named `${side}TokenOrActorUuid`,
-// `${side}Characteristics`, `${side}ManualLabel`, `${side}ManualValue` - read/write them via that
-// naming convention instead of branching on `side` per field.
+// Side fields are named `${side}TokenOrActorUuid` / `${side}Characteristics` / `${side}ManualLabel` / `${side}ManualValue`.
 function getSideFields(formData: ResistanceRollDialogFormData, side: Side): SideFields {
   return {
     tokenOrActorUuid: formData[`${side}TokenOrActorUuid`],
@@ -100,16 +98,12 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     };
   }
 
-  // The actor whose sheet/token this dialog was opened from - the "self" default for the active
-  // side. Undefined when the GM opens the dialog cold (see openForGm): both sides come from the
-  // seed / the pickers instead.
+  // The sheet/token this was opened from; undefined for a GM cold-open (openForGm).
   private actor: RqgActor | undefined;
   private token: TokenDocument | null | undefined;
   private prefill: ResistanceRollDialogPrefill | undefined;
   private seed: ResistanceRollSeed | undefined;
-  // Applied once on the first _prepareContext only - _prepareContext reruns on every form change
-  // (RqgInteractiveRollApplicationBase re-renders on change), and re-applying the prefill/seed on
-  // every one of those reruns would stomp over whatever the user just picked.
+  // Seed/prefill are first-render only; _prepareContext reruns on every form change.
   private seedApplied = false;
 
   constructor(
@@ -126,11 +120,7 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     this.seed = seed;
   }
 
-  /**
-   * Open the dialog with no "self" actor, for a GM staging a resistance roll they will roll
-   * themselves (an NPC's POW-vs-POW, a poison's POT-vs-CON, an improvised STR contest). The
-   * seed pre-picks the two sides from canvas context; the GM adjusts before rolling.
-   */
+  /** Open with no self actor, for a GM rolling a resistance check directly; the seed pre-picks the sides. */
   static async openForGm(seed: ResistanceRollSeed = {}): Promise<void> {
     await new ResistanceRollDialogV2(undefined, undefined, undefined, seed).render({ force: true });
   }
@@ -178,8 +168,7 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     const defaultTargetUuid =
       game.user?.targets.size === 1 ? (game.user.targets.first()?.document?.uuid ?? "") : "";
 
-    // Seed the two sides before the ??= defaults so a GM-opened dialog with no "self" still
-    // lands on the canvas-derived token/actors; a spell prefill (applied below) overrides.
+    // Seed before the ??= defaults; a spell prefill (below) still wins.
     if (!this.seedApplied) {
       if (this.seed?.activeUuid) {
         formData.activeTokenOrActorUuid = this.seed.activeUuid;
@@ -212,7 +201,7 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     formData.actorUuid ??= this.actor?.uuid ?? "";
     formData.tokenUuid ??= this.token?.uuid ?? "";
 
-    // No self actor (GM cold-open) -> speak as whoever is on the acting side of the roll.
+    // GM cold-open: speak as the acting side.
     const speakerActor =
       this.actor ??
       (formData.activeTokenOrActorUuid && formData.activeTokenOrActorUuid !== MANUAL_SOURCE_VALUE
@@ -248,10 +237,7 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     };
   }
 
-  /**
-   * Both sides usable: a picked token/actor whose characteristic(s) resolve, or a manual entry
-   * with a label. Gates the Roll button so an empty/0-value side can't be rolled.
-   */
+  /** Both sides resolve to a value/label - gates the Roll button. */
   private static canRoll(formData: ResistanceRollDialogFormData): boolean {
     const sideResolved = (side: Side): boolean => {
       const fields = getSideFields(formData, side);
@@ -311,14 +297,12 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
 
     const rollMode = resolveRollModeFromForm(form);
 
-    // The Roll button is disabled until this passes; a submit that slips through anyway (stale
-    // state, Enter key) bails silently rather than showing an error the UI already prevents.
+    // Roll is disabled until valid; a stray submit just bails.
     if (!ResistanceRollDialogV2.canRoll(formDataObject)) {
       return;
     }
 
-    // Independent lookups from unrelated uuids - resolved concurrently. A GM cold-open has no
-    // self actor/token; the speaker then falls back to the acting side's actor below.
+    // A GM cold-open has no self actor/token; speaker falls back to the acting actor below.
     const [selfActor, token] = (await Promise.all([
       formDataObject.actorUuid ? fromUuid(formDataObject.actorUuid) : undefined,
       formDataObject.tokenUuid ? fromUuid(formDataObject.tokenUuid) : undefined,
@@ -352,8 +336,7 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
       throw new RqgError("Evaluated ResistanceRoll didn't give successLevel");
     }
 
-    // Only POW earns an experience check from a resistance roll, credited to whichever actor
-    // supplied the active side.
+    // Only POW earns experience, credited to the active side.
     if (
       activeActor &&
       decodeCharacteristics(formDataObject.activeCharacteristics).includes("power") &&

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
@@ -1,0 +1,313 @@
+import { systemId } from "../../system/config";
+import { templatePaths } from "../../system/load-handlebars-templates";
+import type {
+  ResistanceRollDialogContext,
+  ResistanceRollDialogFormData,
+  ResistanceRollDialogPrefill,
+  ResistanceRollSidePrefill,
+} from "./resistance-roll-dialog-data.types.ts";
+import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
+import { getSpeakerDisplayName, isDocumentSubType, localize, RqgError } from "../../system/util";
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
+import type { ResistanceRollOptions } from "../../rolls/resistance-roll/resistance-roll.types";
+import { ResistanceRoll } from "../../rolls/resistance-roll/resistance-roll";
+import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
+import {
+  augmentOptions,
+  buildResistanceModifiers,
+  decodeCharacteristics,
+  encodeCharacteristics,
+  getCharacteristicOptions,
+  getTokenOrActorOptions,
+  meditateOptions,
+  resolveActorFromUuid,
+  resolveCharacteristicSide,
+} from "./resistance-roll-shared.ts";
+import { getConfiguredRollModeOptions, resolveRollModeFromForm } from "../app-parts/roll-mode";
+import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
+import { getSpeakerCompat } from "../../system/fvtt-type-compat";
+
+type Side = "active" | "passive";
+
+type SideFields = {
+  tokenOrActorUuid: string;
+  characteristics: string;
+  manualLabel: string;
+  manualValue: number;
+};
+
+// The four fields making up a side are always named `${side}TokenOrActorUuid`,
+// `${side}Characteristics`, `${side}ManualLabel`, `${side}ManualValue` - read/write them via that
+// naming convention instead of branching on `side` per field.
+function getSideFields(formData: ResistanceRollDialogFormData, side: Side): SideFields {
+  return {
+    tokenOrActorUuid: formData[`${side}TokenOrActorUuid`],
+    characteristics: formData[`${side}Characteristics`],
+    manualLabel: formData[`${side}ManualLabel`],
+    manualValue: formData[`${side}ManualValue`],
+  };
+}
+
+function setSideFields(
+  formData: ResistanceRollDialogFormData,
+  side: Side,
+  fields: Partial<SideFields>,
+): void {
+  if (fields.tokenOrActorUuid !== undefined) {
+    formData[`${side}TokenOrActorUuid`] = fields.tokenOrActorUuid;
+  }
+  if (fields.characteristics !== undefined) {
+    formData[`${side}Characteristics`] = fields.characteristics;
+  }
+  if (fields.manualLabel !== undefined) {
+    formData[`${side}ManualLabel`] = fields.manualLabel;
+  }
+  if (fields.manualValue !== undefined) {
+    formData[`${side}ManualValue`] = fields.manualValue;
+  }
+}
+
+function applyPrefill(
+  formData: ResistanceRollDialogFormData,
+  side: Side,
+  prefill: ResistanceRollSidePrefill | undefined,
+): void {
+  if (!prefill) {
+    return;
+  }
+  if (prefill.source === "manual") {
+    setSideFields(formData, side, {
+      tokenOrActorUuid: MANUAL_SOURCE_VALUE,
+      manualLabel: prefill.label,
+      manualValue: prefill.value,
+    });
+    return;
+  }
+  setSideFields(formData, side, {
+    tokenOrActorUuid: prefill.tokenOrActorUuid,
+    characteristics: encodeCharacteristics(prefill.characteristicNames),
+  });
+}
+
+export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
+  protected override getLivePreviewFormBehaviorConfig() {
+    return {
+      submitButtonSelectorForBlurGuard: "button[data-ability-roll]",
+      updateLivePreview: () => this.updateLivePreview(),
+    };
+  }
+
+  private actor: RqgActor;
+  private token: TokenDocument | null | undefined;
+  private prefill: ResistanceRollDialogPrefill | undefined;
+  // Applied once on the first _prepareContext only - _prepareContext reruns on every form change
+  // (RqgInteractiveRollApplicationBase re-renders on change), and re-applying the prefill on every
+  // one of those reruns would stomp over whatever the user just picked.
+  private prefillApplied = false;
+
+  constructor(
+    actor: RqgActor,
+    token?: TokenDocument | null,
+    prefill?: ResistanceRollDialogPrefill,
+    options?: Partial<foundry.applications.types.ApplicationConfiguration>,
+  ) {
+    super(options);
+    this.actor = actor;
+    this.token = token;
+    this.prefill = prefill;
+  }
+
+  static override DEFAULT_OPTIONS = {
+    id: `resistance-{id}`,
+    tag: "form",
+    classes: [systemId, "form", "roll-dialog", "resistance-roll-dialog"],
+    form: {
+      handler: ResistanceRollDialogV2.onSubmit,
+      submitOnChange: false,
+      closeOnSubmit: true,
+    },
+    position: {
+      width: "auto" as const,
+      height: "auto" as const,
+      left: 35,
+      top: 15,
+    },
+    window: {
+      contentClasses: ["standard-form"],
+      icon: "fa-solid fa-scale-unbalanced",
+      title: "RQG.Dialog.ResistanceRoll.Title",
+      resizable: false,
+    },
+  };
+
+  static override PARTS = {
+    header: { template: templatePaths.rollHeader },
+    form: { template: templatePaths.resistanceRollDialogV2, scrollable: [""] },
+    footer: { template: templatePaths.rollFooter },
+  };
+
+  override async _prepareContext(): Promise<ResistanceRollDialogContext> {
+    const formData = ((this.element &&
+      new foundry.applications.ux.FormDataExtended(this.form!, {}).object) ??
+      {}) as ResistanceRollDialogFormData;
+
+    const selfUuid = this.token?.uuid || this.actor.uuid || "";
+    const tokenOrActorOptions = getTokenOrActorOptions(
+      selfUuid,
+      this.token?.name ?? this.actor.name ?? "",
+      this.actor,
+    );
+    const defaultTargetUuid =
+      game.user?.targets.size === 1 ? (game.user.targets.first()?.document?.uuid ?? "") : "";
+
+    formData.activeTokenOrActorUuid ??= selfUuid;
+    formData.activeCharacteristics ??= "";
+    formData.activeManualLabel ??= "";
+    formData.activeManualValue ??= 0;
+
+    formData.passiveTokenOrActorUuid ??= defaultTargetUuid || MANUAL_SOURCE_VALUE;
+    formData.passiveCharacteristics ??= "";
+    formData.passiveManualLabel ??= "";
+    formData.passiveManualValue ??= 0;
+
+    if (!this.prefillApplied) {
+      applyPrefill(formData, "active", this.prefill?.active);
+      applyPrefill(formData, "passive", this.prefill?.passive);
+      this.prefillApplied = true;
+    }
+
+    formData.augmentModifier ??= "0";
+    formData.meditateModifier ??= "0";
+    formData.otherModifier ??= "0";
+    formData.otherModifierDescription ??= localize("RQG.Dialog.Common.OtherModifier");
+    formData.actorUuid ??= this.actor.uuid ?? "";
+    formData.tokenUuid ??= this.token?.uuid ?? "";
+
+    const speaker = getSpeakerCompat({ actor: this.actor, token: this.token });
+    const totalChance = ResistanceRollDialogV2.computeTotalChance(formData);
+    const active = ResistanceRollDialogV2.resolveSide(formData, "active");
+    const passive = ResistanceRollDialogV2.resolveSide(formData, "passive");
+
+    return {
+      formData: formData,
+
+      speakerName: getSpeakerDisplayName(speaker),
+      activeTokenOrActorOptions: tokenOrActorOptions,
+      passiveTokenOrActorOptions: tokenOrActorOptions,
+      characteristicOptions: getCharacteristicOptions(),
+      augmentOptions: augmentOptions,
+      meditateOptions: meditateOptions,
+
+      // RollHeader
+      rollType: localize("RQG.Roll.ResistanceRoll.Title"),
+      rollName:
+        this.prefill?.description ??
+        `${active.label || "?"} ${localize("RQG.Roll.ResistanceRoll.Vs")} ${passive.label || "?"}`,
+      baseChance: "",
+
+      // RollFooter
+      totalChance: totalChance,
+      rollMode: this.rollMode,
+      rollModes: getConfiguredRollModeOptions(),
+    };
+  }
+
+  private static resolveSide(
+    formData: ResistanceRollDialogFormData,
+    side: Side,
+  ): { value: number; label: string; actorName?: string } {
+    const fields = getSideFields(formData, side);
+    const fallbackLabel = localize(
+      side === "active" ? "RQG.Dialog.ResistanceRoll.Active" : "RQG.Dialog.ResistanceRoll.Passive",
+    );
+    return resolveCharacteristicSide(
+      fields.tokenOrActorUuid,
+      fields.characteristics,
+      fields.manualLabel,
+      fields.manualValue,
+      fallbackLabel,
+    );
+  }
+
+  private static computeTotalChance(formData: ResistanceRollDialogFormData): number {
+    const active = ResistanceRollDialogV2.resolveSide(formData, "active");
+    const passive = ResistanceRollDialogV2.resolveSide(formData, "passive");
+    return computeResistanceTargetChance(active.value, passive.value, [
+      Number(formData.augmentModifier),
+      Number(formData.meditateModifier),
+      Number(formData.otherModifier),
+    ]);
+  }
+
+  private updateLivePreview(): void {
+    const formData = new foundry.applications.ux.FormDataExtended(this.element, {})
+      .object as ResistanceRollDialogFormData;
+    this.updateTotalChanceDisplay(ResistanceRollDialogV2.computeTotalChance(formData));
+  }
+
+  private static async onSubmit(
+    event: SubmitEvent | Event,
+    form: HTMLFormElement,
+    formData: foundry.applications.ux.FormDataExtended,
+  ): Promise<void> {
+    const formDataObject = formData.object as ResistanceRollDialogFormData;
+
+    const rollMode = resolveRollModeFromForm(form);
+
+    // Independent lookups from unrelated uuids - resolved concurrently.
+    const [actor, token] = (await Promise.all([
+      fromUuid(formDataObject.actorUuid),
+      formDataObject.tokenUuid ? fromUuid(formDataObject.tokenUuid) : undefined,
+    ])) as [RqgActor | undefined, TokenDocument | undefined];
+    if (!actor) {
+      ui.notifications?.error("Could not find an actor to roll a resistance roll for.");
+      return;
+    }
+
+    const active = ResistanceRollDialogV2.resolveSide(formDataObject, "active");
+    const passive = ResistanceRollDialogV2.resolveSide(formDataObject, "passive");
+    const isSideResolved = (uuid: string, label: string) => uuid === MANUAL_SOURCE_VALUE || !!label;
+    if (
+      !isSideResolved(formDataObject.activeTokenOrActorUuid, active.label) ||
+      !isSideResolved(formDataObject.passiveTokenOrActorUuid, passive.label)
+    ) {
+      ui.notifications?.error("Pick an Active and a Passive value to roll a resistance roll.");
+      return;
+    }
+
+    const options: ResistanceRollOptions = {
+      activeValue: active.value,
+      activeLabel: active.label,
+      passiveValue: passive.value,
+      passiveLabel: passive.label,
+      passiveActorName: passive.actorName,
+      modifiers: buildResistanceModifiers(
+        formDataObject.augmentModifier,
+        formDataObject.meditateModifier,
+        formDataObject.otherModifier,
+        formDataObject.otherModifierDescription,
+      ),
+      speaker: getSpeakerCompat({ actor, token }),
+      rollMode: rollMode,
+    };
+
+    const roll = await ResistanceRoll.rollAndShow(options);
+    if (roll.successLevel == null) {
+      throw new RqgError("Evaluated ResistanceRoll didn't give successLevel");
+    }
+
+    // Award POW-experience (or any other characteristic-use bookkeeping) to whichever actor's
+    // characteristic(s) were actually used as the active side, not necessarily the dialog's own
+    // actor - both characteristics of a combo (e.g. Knockback's STR+SIZ) get checked.
+    const activeCharacteristicNames = decodeCharacteristics(formDataObject.activeCharacteristics);
+    if (formDataObject.activeTokenOrActorUuid !== MANUAL_SOURCE_VALUE) {
+      const activeActor = resolveActorFromUuid(formDataObject.activeTokenOrActorUuid);
+      if (activeActor && isDocumentSubType<CharacterActor>(activeActor, ActorTypeEnum.Character)) {
+        for (const characteristicName of activeCharacteristicNames) {
+          await activeActor.checkExperience(characteristicName, roll.successLevel);
+        }
+      }
+    }
+  }
+}

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
@@ -185,6 +185,7 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
 
     formData.passiveTokenOrActorUuid ??= defaultTargetUuid || MANUAL_SOURCE_VALUE;
     formData.passiveCharacteristics ??= defaultCharacteristic;
+    formData.passiveManualName ??= "";
     formData.passiveManualLabel ??= "";
     formData.passiveManualValue ??= 0;
 
@@ -264,6 +265,7 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
       fields.manualLabel,
       fields.manualValue,
       fallbackLabel,
+      side === "passive" ? formData.passiveManualName : undefined,
     );
   }
 

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
@@ -17,6 +17,7 @@ import {
   augmentOptions,
   buildResistanceModifiers,
   decodeCharacteristics,
+  defaultCharacteristic,
   encodeCharacteristics,
   getCharacteristicOptions,
   getTokenOrActorOptions,
@@ -162,12 +163,12 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
       game.user?.targets.size === 1 ? (game.user.targets.first()?.document?.uuid ?? "") : "";
 
     formData.activeTokenOrActorUuid ??= selfUuid;
-    formData.activeCharacteristics ??= "";
+    formData.activeCharacteristics ??= defaultCharacteristic;
     formData.activeManualLabel ??= "";
     formData.activeManualValue ??= 0;
 
     formData.passiveTokenOrActorUuid ??= defaultTargetUuid || MANUAL_SOURCE_VALUE;
-    formData.passiveCharacteristics ??= "";
+    formData.passiveCharacteristics ??= defaultCharacteristic;
     formData.passiveManualLabel ??= "";
     formData.passiveManualValue ??= 0;
 
@@ -210,7 +211,24 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
       totalChance: totalChance,
       rollMode: this.rollMode,
       rollModes: getConfiguredRollModeOptions(),
+      disableRoll: !ResistanceRollDialogV2.canRoll(formData),
     };
+  }
+
+  /**
+   * Both sides usable: a picked token/actor whose characteristic(s) resolve, or a manual entry
+   * with a label. Gates the Roll button so an empty/0-value side can't be rolled.
+   */
+  private static canRoll(formData: ResistanceRollDialogFormData): boolean {
+    const sideResolved = (side: Side): boolean => {
+      const fields = getSideFields(formData, side);
+      if (fields.tokenOrActorUuid === MANUAL_SOURCE_VALUE) {
+        return !!fields.manualLabel;
+      }
+      return !!resolveCharacteristicSide(fields.tokenOrActorUuid, fields.characteristics, "", 0, "")
+        .label;
+    };
+    return sideResolved("active") && sideResolved("passive");
   }
 
   private static resolveSide(
@@ -244,6 +262,11 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
     const formData = new foundry.applications.ux.FormDataExtended(this.element, {})
       .object as ResistanceRollDialogFormData;
     this.updateTotalChanceDisplay(ResistanceRollDialogV2.computeTotalChance(formData));
+
+    const rollButton = this.element.querySelector<HTMLButtonElement>("button[data-ability-roll]");
+    if (rollButton) {
+      rollButton.disabled = !ResistanceRollDialogV2.canRoll(formData);
+    }
   }
 
   private static async onSubmit(
@@ -265,16 +288,14 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
       return;
     }
 
-    const active = ResistanceRollDialogV2.resolveSide(formDataObject, "active");
-    const passive = ResistanceRollDialogV2.resolveSide(formDataObject, "passive");
-    const isSideResolved = (uuid: string, label: string) => uuid === MANUAL_SOURCE_VALUE || !!label;
-    if (
-      !isSideResolved(formDataObject.activeTokenOrActorUuid, active.label) ||
-      !isSideResolved(formDataObject.passiveTokenOrActorUuid, passive.label)
-    ) {
-      ui.notifications?.error("Pick an Active and a Passive value to roll a resistance roll.");
+    // The Roll button is disabled until this passes; a submit that slips through anyway (stale
+    // state, Enter key) bails silently rather than showing an error the UI already prevents.
+    if (!ResistanceRollDialogV2.canRoll(formDataObject)) {
       return;
     }
+
+    const active = ResistanceRollDialogV2.resolveSide(formDataObject, "active");
+    const passive = ResistanceRollDialogV2.resolveSide(formDataObject, "passive");
 
     const options: ResistanceRollOptions = {
       activeValue: active.value,

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
@@ -297,16 +297,15 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
       throw new RqgError("Evaluated ResistanceRoll didn't give successLevel");
     }
 
-    // Award POW-experience (or any other characteristic-use bookkeeping) to whichever actor's
-    // characteristic(s) were actually used as the active side, not necessarily the dialog's own
-    // actor - both characteristics of a combo (e.g. Knockback's STR+SIZ) get checked.
-    const activeCharacteristicNames = decodeCharacteristics(formDataObject.activeCharacteristics);
-    if (formDataObject.activeTokenOrActorUuid !== MANUAL_SOURCE_VALUE) {
+    // Only POW earns an experience check from a resistance roll, credited to whichever actor
+    // supplied the active side.
+    if (
+      formDataObject.activeTokenOrActorUuid !== MANUAL_SOURCE_VALUE &&
+      decodeCharacteristics(formDataObject.activeCharacteristics).includes("power")
+    ) {
       const activeActor = resolveActorFromUuid(formDataObject.activeTokenOrActorUuid);
       if (activeActor && isDocumentSubType<CharacterActor>(activeActor, ActorTypeEnum.Character)) {
-        for (const characteristicName of activeCharacteristicNames) {
-          await activeActor.checkExperience(characteristicName, roll.successLevel);
-        }
+        await activeActor.checkExperience("power", roll.successLevel);
       }
     }
   }

--- a/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
@@ -270,15 +270,13 @@ export function buildResistanceChanceBreakdown(
 // "self"/"ic" make no sense when a GM asks a player to roll and needs to see the result.
 export const RESISTANCE_REQUEST_ROLL_MODES: readonly string[] = ["public", "gm", "blind"];
 
+const isRequestRollMode = (mode: string | undefined): mode is foundry.dice.Roll.Mode =>
+  !!mode && RESISTANCE_REQUEST_ROLL_MODES.includes(mode);
+
 /** A resistance dialog's starting roll mode: the stored one if it's still offered, else the client default, else public. */
-export function initialResistanceRollMode(stored: string | undefined): foundry.dice.Roll.Mode {
-  if (stored && RESISTANCE_REQUEST_ROLL_MODES.includes(stored)) {
-    return stored as foundry.dice.Roll.Mode;
-  }
-  const clientDefault = getDefaultRollMode();
-  return (
-    RESISTANCE_REQUEST_ROLL_MODES.includes(clientDefault) ? clientDefault : "public"
-  ) as foundry.dice.Roll.Mode;
+export function initialResistanceRollMode(stored?: string): foundry.dice.Roll.Mode {
+  const candidate = isRequestRollMode(stored) ? stored : getDefaultRollMode();
+  return isRequestRollMode(candidate) ? candidate : ("public" as foundry.dice.Roll.Mode);
 }
 
 /**
@@ -287,14 +285,12 @@ export function initialResistanceRollMode(stored: string | undefined): foundry.d
  */
 export function resolveResistanceRequestVisibility(
   mode: string,
-  targetActor: RqgActor | undefined,
+  targetActor: RqgActor | null | undefined,
 ): { whisper: string[]; blind: boolean } {
   if (mode !== "gm" && mode !== "blind") {
     return { whisper: [], blind: false };
   }
-  const gmIds = (game.users?.filter((u) => u.isGM) ?? [])
-    .map((u) => u.id)
-    .filter((id): id is string => !!id);
+  const gmIds = ChatMessage.getWhisperRecipients("GM").map((user) => user.id);
   const whisper = [...new Set([...gmIds, ...usersIdsThatOwnActor(targetActor ?? null)])];
   return { whisper, blind: mode === "blind" };
 }

--- a/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
@@ -1,0 +1,226 @@
+import { systemId } from "../../system/config";
+import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
+import {
+  getActorLinkDecoration,
+  localize,
+  normalizeOtherModifierDescriptionForRoll,
+  warnIfMultipleTargets,
+} from "../../system/util";
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import type { Characteristics } from "../../data-model/actor-data/characteristics";
+import type { Modifier } from "../../rolls/resistance-roll/resistance-roll.types.ts";
+
+export { augmentOptions, meditateOptions } from "../app-parts/augment-meditate-options";
+
+// Shared between ResistanceRollDialogV2, ResistanceRequestDialogV2 and
+// RespondToResistanceRequestDialogV2 - the token/actor + characteristic(s) picking logic is
+// identical no matter which of those dialogs is resolving a side's value.
+
+export const characteristicNames: (keyof Characteristics)[] = [
+  "strength",
+  "constitution",
+  "size",
+  "dexterity",
+  "intelligence",
+  "power",
+  "charisma",
+];
+
+export function encodeCharacteristics(names: (keyof Characteristics)[]): string {
+  return names.join("+");
+}
+
+export function decodeCharacteristics(value: string): (keyof Characteristics)[] {
+  return value ? (value.split("+") as (keyof Characteristics)[]) : [];
+}
+
+// The Characteristic dropdown also lists the only characteristic combinations the resistance
+// table is actually used for in RAW (Knockback: STR+SIZ vs SIZ+DEX; Grapple-throw: STR+DEX vs
+// SIZ+DEX) directly, instead of a separate "+ Characteristic" picker, since there are only ever
+// these three. Anything else goes through the Manual value entry.
+// Memoized (locale/actor-independent, only built once) since it's read on every render of every
+// resistance dialog, and each entry needs its label joined from a localize() call.
+let characteristicOptionsCache: SelectOptionData<string>[] | undefined;
+
+export function getCharacteristicOptions(): SelectOptionData<string>[] {
+  if (!characteristicOptionsCache) {
+    const shortLabel = (name: keyof Characteristics) =>
+      localize(`RQG.Actor.Characteristics.${name}`);
+    characteristicOptionsCache = [
+      ...characteristicNames.map((name) => ({ value: name, label: shortLabel(name) })),
+      ...(
+        [
+          ["strength", "size"],
+          ["strength", "dexterity"],
+          ["size", "dexterity"],
+        ] as [keyof Characteristics, keyof Characteristics][]
+      ).map(([a, b]) => ({
+        value: encodeCharacteristics([a, b]),
+        label: `${shortLabel(a)} + ${shortLabel(b)}`,
+      })),
+    ];
+  }
+  return characteristicOptionsCache;
+}
+
+/**
+ * The targeted-token/owned-token/owned-actor groups shared by every side of every resistance
+ * dialog - built once per render and reused for both the Active and Passive pickers (they only
+ * differ in which "self" entry and whether a Manual option gets added on top of this).
+ */
+export function getBaseTokenOrActorOptions(): SelectOptionData<string>[] {
+  warnIfMultipleTargets();
+
+  const targetedTokenOptions: SelectOptionData<string>[] =
+    game.user?.targets.size === 1
+      ? Array.from(game.user.targets).map((t) => ({
+          value: t.document?.uuid ?? "",
+          label: (t.document?.name ?? "") + getActorLinkDecoration(t.actor),
+          group: localize("RQG.Dialog.Common.TargetedToken"),
+        }))
+      : [];
+
+  const ownedTokens = game.scenes?.current?.tokens.filter((t) => t.isOwner) ?? [];
+  const ownedTokenOptions: SelectOptionData<string>[] = ownedTokens.map((tokenDocument) => ({
+    value: tokenDocument?.uuid ?? "",
+    label: (tokenDocument?.name ?? "") + getActorLinkDecoration(tokenDocument.actor),
+    group: localize("RQG.Dialog.Common.Tokens"),
+  }));
+
+  const allowCombatWithoutToken = game.settings?.get(systemId, "allowCombatWithoutToken");
+  let ownedActorOptions: SelectOptionData<string>[] = [];
+  if (allowCombatWithoutToken) {
+    const ownedTokenActorIds = ownedTokens.map((t) => t.actor?.id);
+    ownedActorOptions =
+      game.actors
+        ?.filter((a) => a.isOwner && !ownedTokenActorIds.includes(a.id))
+        .map((actor) => ({
+          value: actor.uuid ?? "",
+          label: (actor.name ?? "") + getActorLinkDecoration(actor),
+          group: localize("RQG.Dialog.Common.Actors"),
+        })) ?? [];
+  }
+
+  return [...targetedTokenOptions, ...ownedTokenOptions, ...ownedActorOptions];
+}
+
+/**
+ * Build one side's token/actor dropdown options, mirroring the attack/defence dialogs'
+ * attacker/defender pickers: the current single target (if any) first, then the user's own
+ * tokens on the scene, then the user's own actors without a scene token, then a manual entry.
+ * `selfUuid`/`selfName`/`selfActor` are an actor/token that should always appear (even if not
+ * otherwise owned/on-scene/allowed) so a dialog can default to whoever's sheet it was opened
+ * from - pass empty strings to skip this (e.g. the GM's request dialog has no "self").
+ * `baseOptions` lets a caller building both the Active and Passive dropdowns in one render pass
+ * the shared token/actor scan in once instead of repeating it per side.
+ */
+export function getTokenOrActorOptions(
+  selfUuid: string,
+  selfName: string,
+  selfActor: RqgActor | undefined,
+  includeManual = true,
+  baseOptions: SelectOptionData<string>[] = getBaseTokenOrActorOptions(),
+): SelectOptionData<string>[] {
+  const options = [...baseOptions];
+  const selfIsMissing = !!selfUuid && !options.some((o) => o.value === selfUuid);
+  if (selfIsMissing) {
+    options.unshift({
+      value: selfUuid,
+      label: selfName + getActorLinkDecoration(selfActor),
+      group: localize("RQG.Dialog.Common.Character"),
+    });
+  }
+
+  if (includeManual) {
+    const manualOption: SelectOptionData<string> = {
+      value: MANUAL_SOURCE_VALUE,
+      label: localize("RQG.Dialog.ResistanceRoll.SourceManual"),
+      group: localize("RQG.Dialog.Common.Other"),
+    };
+    // Manual sits right after the self entry rather than at the end: the Tokens/Actors groups
+    // can grow long, and Manual shouldn't get buried below them.
+    options.splice(selfIsMissing ? 1 : 0, 0, manualOption);
+  }
+
+  return options;
+}
+
+export function resolveActorFromUuid(uuid: string): RqgActor | undefined {
+  const doc = fromUuidSync(uuid) as TokenDocument | RqgActor | undefined;
+  return (doc instanceof TokenDocument ? doc.actor : doc) as RqgActor | undefined;
+}
+
+export function resolveCharacteristicValue(actor: RqgActor, name: keyof Characteristics): number {
+  const characteristics = (actor.system as unknown as { characteristics: Characteristics })
+    .characteristics;
+  return characteristics?.[name]?.value ?? 0;
+}
+
+export function resolveCharacteristicLabel(name: keyof Characteristics): string {
+  return localize(`RQG.Actor.Characteristics.${name}`);
+}
+
+/**
+ * Resolve a side's numeric value + display label, either from an actor/token's characteristic(s)
+ * (summed for the two-characteristic combos) or from a manual label/value pair. `manualName`
+ * lets a manual entry play the same role an actor-sourced passive's name does (the "opposes X"
+ * flavor line) - e.g. naming a disease or obstacle instead of leaving it anonymous.
+ */
+export function resolveCharacteristicSide(
+  tokenOrActorUuid: string,
+  characteristicsEncoded: string,
+  manualLabel: string,
+  manualValue: number,
+  fallbackLabel: string,
+  manualName?: string,
+): { value: number; label: string; actorName?: string } {
+  if (tokenOrActorUuid === MANUAL_SOURCE_VALUE) {
+    return {
+      value: Number(manualValue) || 0,
+      label: manualLabel || fallbackLabel,
+      actorName: manualName || undefined,
+    };
+  }
+
+  const sourceActor = tokenOrActorUuid ? resolveActorFromUuid(tokenOrActorUuid) : undefined;
+  const names = decodeCharacteristics(characteristicsEncoded);
+  if (!sourceActor || names.length === 0) {
+    return { value: 0, label: "" };
+  }
+
+  const value = names.reduce((sum, name) => sum + resolveCharacteristicValue(sourceActor, name), 0);
+  const label = names.map((name) => resolveCharacteristicLabel(name)).join(" + ");
+  return { value, label, actorName: sourceActor.name ?? undefined };
+}
+
+/**
+ * Restrict token/actor options to ones with an actual player owner. A GM owns every token, so the
+ * unfiltered list would let them pick an NPC/monster as who should roll a resistance *request* -
+ * nobody but the GM could ever click that card's Roll button. Only meant for the request dialog's
+ * Active picker; every other use of `getTokenOrActorOptions` legitimately wants any owned token.
+ */
+export function filterToPlayerOwnedOptions(
+  options: SelectOptionData<string>[],
+): SelectOptionData<string>[] {
+  return options.filter((option) => resolveActorFromUuid(option.value)?.hasPlayerOwner);
+}
+
+/**
+ * Build the Augment/Meditate/Other modifier list from a roll dialog's form fields, in the shape
+ * `ResistanceRoll` expects - shared by every dialog that actually performs the roll.
+ */
+export function buildResistanceModifiers(
+  augmentModifier: unknown,
+  meditateModifier: unknown,
+  otherModifier: unknown,
+  otherModifierDescription: string,
+): Modifier[] {
+  return [
+    { value: Number(augmentModifier), description: localize("RQG.Roll.Common.Augment") },
+    { value: Number(meditateModifier), description: localize("RQG.Roll.Common.Meditate") },
+    {
+      value: Number(otherModifier),
+      description: normalizeOtherModifierDescriptionForRoll(otherModifierDescription),
+    },
+  ];
+}

--- a/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
@@ -4,11 +4,13 @@ import {
   getActorLinkDecoration,
   localize,
   normalizeOtherModifierDescriptionForRoll,
+  toSignedString,
   warnIfMultipleTargets,
 } from "../../system/util";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { Characteristics } from "../../data-model/actor-data/characteristics";
 import type { Modifier } from "../../rolls/resistance-roll/resistance-roll.types.ts";
+import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
 
 export { augmentOptions, meditateOptions } from "../app-parts/augment-meditate-options";
 
@@ -200,4 +202,34 @@ export function buildResistanceModifiers(
       description: normalizeOtherModifierDescriptionForRoll(otherModifierDescription),
     },
   ];
+}
+
+type ResolvedSide = { value: number; label: string };
+
+/**
+ * `<br>`-joined breakdown for a resistance dialog's target% box tooltip, e.g.
+ * "STR 13 vs POT 5: 90% / +20% Augment / = 110%".
+ */
+export function buildResistanceChanceBreakdown(
+  active: ResolvedSide,
+  passive: ResolvedSide,
+  modifiers: Modifier[],
+): string {
+  const esc = (value: unknown): string => foundry.utils.escapeHTML(String(value ?? ""));
+  const side = (s: ResolvedSide): string => (s.label ? `${esc(s.label)} ${s.value}` : `${s.value}`);
+  const baseChance = computeResistanceTargetChance(active.value, passive.value);
+  const totalChance = computeResistanceTargetChance(
+    active.value,
+    passive.value,
+    modifiers.map((m) => Number(m.value)),
+  );
+  const vs = esc(localize("RQG.Roll.ResistanceRoll.Vs"));
+  return [
+    `<strong>${esc(localize("RQG.Dialog.Common.TargetChance"))}</strong>`,
+    `${side(active)} ${vs} ${side(passive)}: ${baseChance}%`,
+    ...modifiers
+      .filter((m) => Number.isFinite(Number(m.value)) && Number(m.value) !== 0)
+      .map((m) => `${toSignedString(Number(m.value))}% ${esc(m.description)}`),
+    `= ${totalChance}%`,
+  ].join("<br>");
 }

--- a/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
@@ -2,15 +2,19 @@ import { systemId } from "../../system/config";
 import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
 import {
   getActorLinkDecoration,
+  isDocumentSubType,
   localize,
   normalizeOtherModifierDescriptionForRoll,
   toSignedString,
   warnIfMultipleTargets,
 } from "../../system/util";
 import type { RqgActor } from "@actors/rqg-actor.ts";
+import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
 import type { Characteristics } from "../../data-model/actor-data/characteristics";
 import type { Modifier } from "../../rolls/resistance-roll/resistance-roll.types.ts";
 import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
+import { AbilitySuccessLevelEnum } from "../../rolls/ability-roll/ability-roll.defs.ts";
+import type { ResistanceRoll } from "../../rolls/resistance-roll/resistance-roll.ts";
 
 export { augmentOptions, meditateOptions } from "../app-parts/augment-meditate-options";
 
@@ -202,6 +206,33 @@ export function buildResistanceModifiers(
       description: normalizeOtherModifierDescriptionForRoll(otherModifierDescription),
     },
   ];
+}
+
+// Only a known POW-vs-POW success under 95% is awarded outright; other POW rolls get the reminder.
+export async function creditResistanceRollPowExperience(
+  activeActor: RqgActor | undefined,
+  activeCharacteristicsEncoded: string,
+  passiveCharacteristicsEncoded: string | undefined,
+  roll: ResistanceRoll,
+): Promise<void> {
+  if (
+    !activeActor ||
+    !isDocumentSubType<CharacterActor>(activeActor, ActorTypeEnum.Character) ||
+    roll.successLevel == null ||
+    !decodeCharacteristics(activeCharacteristicsEncoded).includes("power")
+  ) {
+    return;
+  }
+
+  const powVsPow = decodeCharacteristics(passiveCharacteristicsEncoded ?? "").includes("power");
+  if (powVsPow) {
+    if (roll.successLevel <= AbilitySuccessLevelEnum.Success && roll.targetChance < 95) {
+      await activeActor.awardPowExperience();
+    }
+    return;
+  }
+
+  await activeActor.checkExperience("power", roll.successLevel, roll.targetChance);
 }
 
 type ResolvedSide = { value: number; label: string };

--- a/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
@@ -6,8 +6,10 @@ import {
   localize,
   normalizeOtherModifierDescriptionForRoll,
   toSignedString,
+  usersIdsThatOwnActor,
   warnIfMultipleTargets,
 } from "../../system/util";
+import { getDefaultRollMode } from "../app-parts/roll-mode";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
 import type { Characteristics } from "../../data-model/actor-data/characteristics";
@@ -263,4 +265,36 @@ export function buildResistanceChanceBreakdown(
       .map((m) => `${toSignedString(Number(m.value))}% ${esc(m.description)}`),
     `= ${totalChance}%`,
   ].join("<br>");
+}
+
+// "self"/"ic" make no sense when a GM asks a player to roll and needs to see the result.
+export const RESISTANCE_REQUEST_ROLL_MODES: readonly string[] = ["public", "gm", "blind"];
+
+/** A resistance dialog's starting roll mode: the stored one if it's still offered, else the client default, else public. */
+export function initialResistanceRollMode(stored: string | undefined): foundry.dice.Roll.Mode {
+  if (stored && RESISTANCE_REQUEST_ROLL_MODES.includes(stored)) {
+    return stored as foundry.dice.Roll.Mode;
+  }
+  const clientDefault = getDefaultRollMode();
+  return (
+    RESISTANCE_REQUEST_ROLL_MODES.includes(clientDefault) ? clientDefault : "public"
+  ) as foundry.dice.Roll.Mode;
+}
+
+/**
+ * Chat visibility for a resistance request/response. The target's owners always see the card
+ * (they roll it); "gm" also whispers the GMs, "blind" hides the outcome until a GM reveals it.
+ */
+export function resolveResistanceRequestVisibility(
+  mode: string,
+  targetActor: RqgActor | undefined,
+): { whisper: string[]; blind: boolean } {
+  if (mode !== "gm" && mode !== "blind") {
+    return { whisper: [], blind: false };
+  }
+  const gmIds = (game.users?.filter((u) => u.isGM) ?? [])
+    .map((u) => u.id)
+    .filter((id): id is string => !!id);
+  const whisper = [...new Set([...gmIds, ...usersIdsThatOwnActor(targetActor ?? null)])];
+  return { whisper, blind: mode === "blind" };
 }

--- a/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
@@ -12,9 +12,7 @@ import type { Modifier } from "../../rolls/resistance-roll/resistance-roll.types
 
 export { augmentOptions, meditateOptions } from "../app-parts/augment-meditate-options";
 
-// Shared between ResistanceRollDialogV2, ResistanceRequestDialogV2 and
-// RespondToResistanceRequestDialogV2 - the token/actor + characteristic(s) picking logic is
-// identical no matter which of those dialogs is resolving a side's value.
+// Side-resolution logic shared by all three resistance dialogs.
 
 export const characteristicNames: (keyof Characteristics)[] = [
   "strength",
@@ -37,12 +35,8 @@ export function decodeCharacteristics(value: string): (keyof Characteristics)[] 
   return value ? (value.split("+") as (keyof Characteristics)[]) : [];
 }
 
-// The Characteristic dropdown also lists the only characteristic combinations the resistance
-// table is actually used for in RAW (Knockback: STR+SIZ vs SIZ+DEX; Grapple-throw: STR+DEX vs
-// SIZ+DEX) directly, instead of a separate "+ Characteristic" picker, since there are only ever
-// these three. Anything else goes through the Manual value entry.
-// Memoized (locale/actor-independent, only built once) since it's read on every render of every
-// resistance dialog, and each entry needs its label joined from a localize() call.
+// Includes the three characteristic combos the resistance table uses (knockback, grapple-throw);
+// anything else goes through Manual value. Memoized - read on every render of every dialog.
 let characteristicOptionsCache: SelectOptionData<string>[] | undefined;
 
 export function getCharacteristicOptions(): SelectOptionData<string>[] {
@@ -66,11 +60,7 @@ export function getCharacteristicOptions(): SelectOptionData<string>[] {
   return characteristicOptionsCache;
 }
 
-/**
- * The targeted-token/owned-token/owned-actor groups shared by every side of every resistance
- * dialog - built once per render and reused for both the Active and Passive pickers (they only
- * differ in which "self" entry and whether a Manual option gets added on top of this).
- */
+/** Targeted / owned token + actor options, shared by both pickers of every resistance dialog. */
 export function getBaseTokenOrActorOptions(): SelectOptionData<string>[] {
   warnIfMultipleTargets();
 
@@ -108,14 +98,9 @@ export function getBaseTokenOrActorOptions(): SelectOptionData<string>[] {
 }
 
 /**
- * Build one side's token/actor dropdown options, mirroring the attack/defence dialogs'
- * attacker/defender pickers: the current single target (if any) first, then the user's own
- * tokens on the scene, then the user's own actors without a scene token, then a manual entry.
- * `selfUuid`/`selfName`/`selfActor` are an actor/token that should always appear (even if not
- * otherwise owned/on-scene/allowed) so a dialog can default to whoever's sheet it was opened
- * from - pass empty strings to skip this (e.g. the GM's request dialog has no "self").
- * `baseOptions` lets a caller building both the Active and Passive dropdowns in one render pass
- * the shared token/actor scan in once instead of repeating it per side.
+ * One side's token/actor options: current target, owned tokens, owned actors, then Manual.
+ * `selfUuid`/`selfName`/`selfActor` force an entry that would otherwise be absent (pass "" to skip).
+ * `baseOptions` lets a caller share one scan across both sides.
  */
 export function getTokenOrActorOptions(
   selfUuid: string,
@@ -140,8 +125,7 @@ export function getTokenOrActorOptions(
       label: localize("RQG.Dialog.ResistanceRoll.SourceManual"),
       group: localize("RQG.Dialog.Common.Other"),
     };
-    // Manual sits right after the self entry rather than at the end: the Tokens/Actors groups
-    // can grow long, and Manual shouldn't get buried below them.
+    // Manual sits near the top so it isn't buried under long Tokens/Actors groups.
     options.splice(selfIsMissing ? 1 : 0, 0, manualOption);
   }
 
@@ -164,10 +148,8 @@ export function resolveCharacteristicLabel(name: keyof Characteristics): string 
 }
 
 /**
- * Resolve a side's numeric value + display label, either from an actor/token's characteristic(s)
- * (summed for the two-characteristic combos) or from a manual label/value pair. `manualName`
- * lets a manual entry play the same role an actor-sourced passive's name does (the "opposes X"
- * flavor line) - e.g. naming a disease or obstacle instead of leaving it anonymous.
+ * A side's value + label, from an actor's characteristic(s) or a manual label/value pair.
+ * `manualName` names a manual source for the "opposes X" flavor line.
  */
 export function resolveCharacteristicSide(
   tokenOrActorUuid: string,
@@ -196,22 +178,14 @@ export function resolveCharacteristicSide(
   return { value, label, actorName: sourceActor.name ?? undefined };
 }
 
-/**
- * Restrict token/actor options to ones with an actual player owner. A GM owns every token, so the
- * unfiltered list would let them pick an NPC/monster as who should roll a resistance *request* -
- * nobody but the GM could ever click that card's Roll button. Only meant for the request dialog's
- * Active picker; every other use of `getTokenOrActorOptions` legitimately wants any owned token.
- */
+/** Keep only player-owned actors - for the request dialog's active picker (a GM owns every token). */
 export function filterToPlayerOwnedOptions(
   options: SelectOptionData<string>[],
 ): SelectOptionData<string>[] {
   return options.filter((option) => resolveActorFromUuid(option.value)?.hasPlayerOwner);
 }
 
-/**
- * Build the Augment/Meditate/Other modifier list from a roll dialog's form fields, in the shape
- * `ResistanceRoll` expects - shared by every dialog that actually performs the roll.
- */
+/** The Augment/Meditate/Other modifier list in the shape `ResistanceRoll` expects. */
 export function buildResistanceModifiers(
   augmentModifier: unknown,
   meditateModifier: unknown,

--- a/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
@@ -26,6 +26,9 @@ export const characteristicNames: (keyof Characteristics)[] = [
   "charisma",
 ];
 
+/** The characteristic a resistance side starts on before the GM/player picks one. */
+export const defaultCharacteristic: keyof Characteristics = "strength";
+
 export function encodeCharacteristics(names: (keyof Characteristics)[]): string {
   return names.join("+");
 }

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-data.types.ts
@@ -1,8 +1,9 @@
 import type { RollHeaderData } from "../app-parts/roll-header.types.ts";
 import type { RollFooterData } from "../app-parts/roll-footer.types.ts";
 
+// No roll-mode control: the result is written back onto the GM's already-public request card.
 export type RespondToResistanceRequestDialogContext = RollHeaderData &
-  RollFooterData & {
+  Omit<RollFooterData, "rollMode" | "rollModes"> & {
     formData: RespondToResistanceRequestDialogFormData;
     speakerName: string;
     activeLabel: string;

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-data.types.ts
@@ -1,0 +1,21 @@
+import type { RollHeaderData } from "../app-parts/roll-header.types.ts";
+import type { RollFooterData } from "../app-parts/roll-footer.types.ts";
+
+export type RespondToResistanceRequestDialogContext = RollHeaderData &
+  RollFooterData & {
+    formData: RespondToResistanceRequestDialogFormData;
+    speakerName: string;
+    activeLabel: string;
+    passiveLabel: string;
+    augmentOptions: SelectOptionData<number>[];
+    meditateOptions: SelectOptionData<number>[];
+  };
+
+export type RespondToResistanceRequestDialogFormData = {
+  augmentModifier: string;
+  meditateModifier: string;
+  otherModifier: string;
+  otherModifierDescription: string;
+
+  chatMessageUuid: string; // hidden field - the resistanceRequest chat message being answered
+};

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-data.types.ts
@@ -1,9 +1,8 @@
 import type { RollHeaderData } from "../app-parts/roll-header.types.ts";
 import type { RollFooterData } from "../app-parts/roll-footer.types.ts";
 
-// No roll-mode control: the result is written back onto the GM's already-public request card.
 export type RespondToResistanceRequestDialogContext = RollHeaderData &
-  Omit<RollFooterData, "rollMode" | "rollModes"> & {
+  RollFooterData & {
     formData: RespondToResistanceRequestDialogFormData;
     speakerName: string;
     activeLabel: string;

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-data.types.ts
@@ -17,5 +17,5 @@ export type RespondToResistanceRequestDialogFormData = {
   otherModifier: string;
   otherModifierDescription: string;
 
-  chatMessageUuid: string; // hidden field - the resistanceRequest chat message being answered
+  chatMessageUuid: string; // hidden field
 };

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.hbs
@@ -1,0 +1,31 @@
+<div class="scrollable">
+  <div class="key-value-grid p-0">
+    <label>{{localize "RQG.Dialog.Common.Character"}}</label>
+    <div>{{speakerName}}</div>
+
+    <label>{{localize "RQG.Dialog.ResistanceRoll.Active"}}</label>
+    <div>{{activeLabel}}</div>
+
+    <label>{{localize "RQG.Dialog.ResistanceRoll.Passive"}}</label>
+    <div>{{passiveLabel}}</div>
+  </div>
+
+  <div class="key-value-grid p-0">
+    <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
+    <select name="augmentModifier">
+      {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
+    </select>
+
+    <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
+    <select name="meditateModifier">
+      {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
+    </select>
+
+    <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
+    <div>
+      <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
+    </div>
+  </div>
+
+  <input type="hidden" value="{{formData.chatMessageUuid}}" name="chatMessageUuid">
+</div>

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.hbs
@@ -8,9 +8,7 @@
 
     <label>{{localize "RQG.Dialog.ResistanceRoll.Passive"}}</label>
     <div>{{passiveLabel}}</div>
-  </div>
 
-  <div class="key-value-grid p-0">
     <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
     <select name="augmentModifier">
       {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -15,11 +15,15 @@ import {
   buildResistanceModifiers,
   creditResistanceRollPowExperience,
   decodeCharacteristics,
+  initialResistanceRollMode,
   meditateOptions,
+  RESISTANCE_REQUEST_ROLL_MODES,
   resolveCharacteristicLabel,
   resolveCharacteristicValue,
+  resolveResistanceRequestVisibility,
 } from "./resistance-roll-shared.ts";
 import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
+import { getConfiguredRollModeOptions, resolveRollModeFromForm } from "../app-parts/roll-mode";
 import { getSpeakerCompat } from "../../system/fvtt-type-compat";
 import { updateChatMessage } from "../../sockets/socketable-requests";
 import type { ResistanceRequestChatMessage } from "../../chat/data-model/resistance-request-chat-message.types.ts";
@@ -56,6 +60,7 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
       logger.throw("No resistance request chat message found", { chatMessageId });
     }
     this.requestChatMessage = requestChatMessage!;
+    this.rollMode = initialResistanceRollMode(this.requestChatMessage.system.rollMode);
   }
 
   static override DEFAULT_OPTIONS = {
@@ -163,6 +168,8 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
         formData,
       ),
       totalChanceTooltip: this.buildChanceBreakdown(formData),
+      rollMode: this.rollMode,
+      rollModes: getConfiguredRollModeOptions(RESISTANCE_REQUEST_ROLL_MODES),
     };
   }
 
@@ -247,19 +254,29 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
         formDataObject.otherModifierDescription,
       ),
       speaker: getSpeakerCompat({ actor: actor, token: token }),
+      rollMode: resolveRollModeFromForm(form),
     };
 
     const roll = new ResistanceRoll(undefined, {}, options);
     await roll.evaluate();
 
+    const { whisper, blind } = resolveResistanceRequestVisibility(
+      options.rollMode ?? "public",
+      actor,
+    );
+
     if (game.dice3d) {
-      await game.dice3d.showForRoll(roll, game.user, true, null, false);
+      await game.dice3d.showForRoll(roll, game.user, true, whisper.length ? whisper : null, blind);
     }
 
     const messageData = requestChatMessage!.toObject();
     foundry.utils.mergeObject(
       messageData,
-      { system: { state: "Rolled", resistanceRoll: roll.toJSON() } },
+      {
+        system: { state: "Rolled", resistanceRoll: roll.toJSON() },
+        whisper: whisper,
+        blind: blind,
+      },
       { overwrite: true },
     );
     messageData.content = await foundry.applications.handlebars.renderTemplate(

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -17,6 +17,7 @@ import { ResistanceRoll } from "../../rolls/resistance-roll/resistance-roll";
 import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
 import {
   augmentOptions,
+  buildResistanceChanceBreakdown,
   buildResistanceModifiers,
   decodeCharacteristics,
   meditateOptions,
@@ -47,6 +48,8 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
   private requestChatMessage: ResistanceRequestChatMessage;
   private activeValue = 0;
   private passiveValue = 0;
+  private activeLabel = "";
+  private passiveLabel = "";
 
   constructor(
     chatMessageId: string,
@@ -132,6 +135,8 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
     );
     this.activeValue = active.value;
     this.passiveValue = this.requestChatMessage.system.passiveValue;
+    this.activeLabel = active.label;
+    this.passiveLabel = this.requestChatMessage.system.passiveLabel;
 
     // Augment/Meditate are the roller's own choices; only Other is seeded from the request.
     formData.augmentModifier ??= "0";
@@ -143,19 +148,18 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
     formData.chatMessageUuid ??= this.requestChatMessage.uuid ?? "";
 
     const speaker = getSpeakerCompat({ actor: actor, token: token });
-    const passiveLabel = this.requestChatMessage.system.passiveLabel;
 
     return {
       formData: formData,
       speakerName: getSpeakerDisplayName(speaker),
-      activeLabel: active.label,
-      passiveLabel: passiveLabel,
+      activeLabel: this.activeLabel,
+      passiveLabel: this.passiveLabel,
       augmentOptions: augmentOptions,
       meditateOptions: meditateOptions,
 
       // RollHeader
       rollType: localize("RQG.Roll.ResistanceRoll.Title"),
-      rollName: `${active.label || "?"} ${localize("RQG.Roll.ResistanceRoll.Vs")} ${passiveLabel || "?"}`,
+      rollName: `${this.activeLabel || "?"} ${localize("RQG.Roll.ResistanceRoll.Vs")} ${this.passiveLabel || "?"}`,
       baseChance: "",
 
       // RollFooter
@@ -164,9 +168,23 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
         this.passiveValue,
         formData,
       ),
+      totalChanceTooltip: this.buildChanceBreakdown(formData),
       rollMode: this.rollMode,
       rollModes: getConfiguredRollModeOptions(),
     };
+  }
+
+  private buildChanceBreakdown(formData: RespondToResistanceRequestDialogFormData): string {
+    return buildResistanceChanceBreakdown(
+      { value: this.activeValue, label: this.activeLabel },
+      { value: this.passiveValue, label: this.passiveLabel },
+      buildResistanceModifiers(
+        formData.augmentModifier,
+        formData.meditateModifier,
+        formData.otherModifier,
+        formData.otherModifierDescription,
+      ),
+    );
   }
 
   private static computeTotalChance(
@@ -191,6 +209,11 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
         formData,
       ),
     );
+
+    const targetChanceBox = this.element.querySelector<HTMLElement>("[data-target-chance-box]");
+    if (targetChanceBox) {
+      targetChanceBox.dataset["tooltip"] = this.buildChanceBreakdown(formData);
+    }
   }
 
   private static async onSubmit(

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -1,0 +1,277 @@
+import { systemId } from "../../system/config";
+import { templatePaths } from "../../system/load-handlebars-templates";
+import type {
+  RespondToResistanceRequestDialogContext,
+  RespondToResistanceRequestDialogFormData,
+} from "./respond-to-resistance-request-dialog-data.types.ts";
+import {
+  activateChatTab,
+  getSpeakerDisplayName,
+  isDocumentSubType,
+  localize,
+} from "../../system/util";
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
+import type { ResistanceRollOptions } from "../../rolls/resistance-roll/resistance-roll.types";
+import { ResistanceRoll } from "../../rolls/resistance-roll/resistance-roll";
+import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
+import {
+  augmentOptions,
+  buildResistanceModifiers,
+  decodeCharacteristics,
+  meditateOptions,
+  resolveCharacteristicLabel,
+  resolveCharacteristicValue,
+} from "./resistance-roll-shared.ts";
+import { getConfiguredRollModeOptions, resolveRollModeFromForm } from "../app-parts/roll-mode";
+import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
+import { getSpeakerCompat } from "../../system/fvtt-type-compat";
+import { updateChatMessage } from "../../sockets/socketable-requests";
+import type { ResistanceRequestChatMessage } from "../../chat/data-model/resistance-request-chat-message.types.ts";
+import { RqgLogger } from "../../system/logging/rqg-logger";
+
+const logger = new RqgLogger("RespondToResistanceRequestDialogV2");
+
+/**
+ * Recipient-facing dialog (#758 option C): answers a GM-posted resistance-request chat card. The
+ * Active side (who rolls, with what characteristic(s)) and the Passive side's value are both
+ * fixed by the request - the recipient only picks their own Augment/Meditate/Other modifiers,
+ * same as ResistanceRollDialogV2, before rolling. On submit the roll is written back onto the
+ * original chat message (via a socket update if the GM, not the recipient, authored it) instead
+ * of creating a new one.
+ */
+export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase {
+  protected override getLivePreviewFormBehaviorConfig() {
+    return {
+      submitButtonSelectorForBlurGuard: "button[data-ability-roll]",
+      updateLivePreview: () => this.updateLivePreview(),
+    };
+  }
+
+  private requestChatMessage: ResistanceRequestChatMessage;
+  private activeValue = 0;
+  private passiveValue = 0;
+
+  constructor(
+    chatMessageId: string,
+    options?: Partial<foundry.applications.types.ApplicationConfiguration>,
+  ) {
+    super(options);
+    const requestChatMessage = game.messages?.get(chatMessageId ?? "") as
+      ResistanceRequestChatMessage | undefined;
+    if (!requestChatMessage) {
+      logger.throw("No resistance request chat message found", { chatMessageId });
+    }
+    this.requestChatMessage = requestChatMessage!;
+  }
+
+  static override DEFAULT_OPTIONS = {
+    id: `resistance-request-respond-{id}`,
+    tag: "form",
+    classes: [systemId, "form", "roll-dialog", "resistance-roll-dialog"],
+    form: {
+      handler: RespondToResistanceRequestDialogV2.onSubmit,
+      submitOnChange: false,
+      closeOnSubmit: true,
+    },
+    position: {
+      width: "auto" as const,
+      height: "auto" as const,
+      left: 35,
+      top: 15,
+    },
+    window: {
+      contentClasses: ["standard-form"],
+      icon: "fa-solid fa-scale-unbalanced",
+      title: "RQG.Dialog.ResistanceRoll.Title",
+      resizable: false,
+    },
+  };
+
+  static override PARTS = {
+    header: { template: templatePaths.rollHeader },
+    form: { template: templatePaths.respondToResistanceRequestDialogV2, scrollable: [""] },
+    footer: { template: templatePaths.rollFooter },
+  };
+
+  private static resolveTarget(requestChatMessage: ResistanceRequestChatMessage): {
+    actor: RqgActor | undefined;
+    token: TokenDocument | undefined;
+  } {
+    const tokenOrActor = fromUuidSync(requestChatMessage.system.targetTokenOrActorUuid) as
+      TokenDocument | RqgActor | undefined;
+    return {
+      actor: (tokenOrActor instanceof TokenDocument ? tokenOrActor.actor : tokenOrActor) as
+        RqgActor | undefined,
+      token: tokenOrActor instanceof TokenDocument ? tokenOrActor : undefined,
+    };
+  }
+
+  // Takes the already-resolved actor rather than re-deriving it via resolveTarget() itself, so
+  // callers that need both only look the target up once.
+  private static resolveActive(
+    actor: RqgActor | undefined,
+    activeCharacteristics: string,
+  ): { value: number; label: string } {
+    const names = decodeCharacteristics(activeCharacteristics);
+    if (!actor || names.length === 0) {
+      return { value: 0, label: "" };
+    }
+    return {
+      value: names.reduce((sum, name) => sum + resolveCharacteristicValue(actor, name), 0),
+      label: names.map((name) => resolveCharacteristicLabel(name)).join(" + "),
+    };
+  }
+
+  override async _prepareContext(): Promise<RespondToResistanceRequestDialogContext> {
+    const formData = ((this.element &&
+      new foundry.applications.ux.FormDataExtended(this.form!, {}).object) ??
+      {}) as RespondToResistanceRequestDialogFormData;
+
+    const { actor, token } = RespondToResistanceRequestDialogV2.resolveTarget(
+      this.requestChatMessage,
+    );
+    const active = RespondToResistanceRequestDialogV2.resolveActive(
+      actor,
+      this.requestChatMessage.system.activeCharacteristics,
+    );
+    this.activeValue = active.value;
+    this.passiveValue = this.requestChatMessage.system.passiveValue;
+
+    // Defaults come from the GM's request, but the recipient can still change them before rolling.
+    formData.augmentModifier ??= String(this.requestChatMessage.system.augmentModifier ?? 0);
+    formData.meditateModifier ??= String(this.requestChatMessage.system.meditateModifier ?? 0);
+    formData.otherModifier ??= String(this.requestChatMessage.system.otherModifier ?? 0);
+    formData.otherModifierDescription ??=
+      this.requestChatMessage.system.otherModifierDescription ||
+      localize("RQG.Dialog.Common.OtherModifier");
+    formData.chatMessageUuid ??= this.requestChatMessage.uuid ?? "";
+
+    const speaker = getSpeakerCompat({ actor: actor, token: token });
+    const passiveLabel = this.requestChatMessage.system.passiveLabel;
+
+    return {
+      formData: formData,
+      speakerName: getSpeakerDisplayName(speaker),
+      activeLabel: active.label,
+      passiveLabel: passiveLabel,
+      augmentOptions: augmentOptions,
+      meditateOptions: meditateOptions,
+
+      // RollHeader
+      rollType: localize("RQG.Roll.ResistanceRoll.Title"),
+      rollName: `${active.label || "?"} ${localize("RQG.Roll.ResistanceRoll.Vs")} ${passiveLabel || "?"}`,
+      baseChance: "",
+
+      // RollFooter
+      totalChance: RespondToResistanceRequestDialogV2.computeTotalChance(
+        this.activeValue,
+        this.passiveValue,
+        formData,
+      ),
+      rollMode: this.rollMode,
+      rollModes: getConfiguredRollModeOptions(),
+    };
+  }
+
+  private static computeTotalChance(
+    activeValue: number,
+    passiveValue: number,
+    formData: RespondToResistanceRequestDialogFormData,
+  ): number {
+    return computeResistanceTargetChance(activeValue, passiveValue, [
+      Number(formData.augmentModifier),
+      Number(formData.meditateModifier),
+      Number(formData.otherModifier),
+    ]);
+  }
+
+  private updateLivePreview(): void {
+    const formData = new foundry.applications.ux.FormDataExtended(this.element, {})
+      .object as RespondToResistanceRequestDialogFormData;
+    this.updateTotalChanceDisplay(
+      RespondToResistanceRequestDialogV2.computeTotalChance(
+        this.activeValue,
+        this.passiveValue,
+        formData,
+      ),
+    );
+  }
+
+  private static async onSubmit(
+    event: SubmitEvent | Event,
+    form: HTMLFormElement,
+    formData: foundry.applications.ux.FormDataExtended,
+  ): Promise<void> {
+    const formDataObject = formData.object as RespondToResistanceRequestDialogFormData;
+
+    // @ts-expect-error close - close immediately instead of waiting for the roll animation
+    this.close();
+
+    const requestChatMessage = (await fromUuid(formDataObject.chatMessageUuid)) as
+      ResistanceRequestChatMessage | undefined;
+    if (!requestChatMessage) {
+      logger.throw("Resistance request chat message not found", formDataObject);
+    }
+
+    const { actor, token } = RespondToResistanceRequestDialogV2.resolveTarget(requestChatMessage!);
+    const activeCharacteristicNames = decodeCharacteristics(
+      requestChatMessage!.system.activeCharacteristics,
+    );
+    const active = RespondToResistanceRequestDialogV2.resolveActive(
+      actor,
+      requestChatMessage!.system.activeCharacteristics,
+    );
+    if (!actor || !active.label) {
+      ui.notifications?.error("Could not find who this resistance request is for.");
+      return;
+    }
+
+    const options: ResistanceRollOptions = {
+      activeValue: active.value,
+      activeLabel: active.label,
+      passiveValue: requestChatMessage!.system.passiveValue,
+      passiveLabel: requestChatMessage!.system.passiveLabel,
+      passiveActorName: requestChatMessage!.system.passiveActorName,
+      modifiers: buildResistanceModifiers(
+        formDataObject.augmentModifier,
+        formDataObject.meditateModifier,
+        formDataObject.otherModifier,
+        formDataObject.otherModifierDescription,
+      ),
+      speaker: getSpeakerCompat({ actor: actor, token: token }),
+      rollMode: resolveRollModeFromForm(form),
+    };
+
+    const roll = new ResistanceRoll(undefined, {}, options);
+    await roll.evaluate();
+
+    if (game.dice3d) {
+      await game.dice3d.showForRoll(roll, game.user, true, null, false);
+    }
+
+    const messageData = requestChatMessage!.toObject();
+    foundry.utils.mergeObject(
+      messageData,
+      { system: { state: "Rolled", resistanceRoll: roll.toJSON() } },
+      { overwrite: true },
+    );
+    messageData.content = await foundry.applications.handlebars.renderTemplate(
+      templatePaths.resistanceRequestChatMessage,
+      messageData.system,
+    );
+
+    activateChatTab();
+    await updateChatMessage(requestChatMessage!, messageData);
+
+    // Both characteristics of a combo (e.g. Knockback's STR+SIZ) get checked, not just the first.
+    if (
+      isDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character) &&
+      roll.successLevel != null
+    ) {
+      for (const characteristicName of activeCharacteristicNames) {
+        await actor.checkExperience(characteristicName, roll.successLevel);
+      }
+    }
+  }
+}

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -138,9 +138,10 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
     this.activeValue = active.value;
     this.passiveValue = this.requestChatMessage.system.passiveValue;
 
-    // Defaults come from the GM's request, but the recipient can still change them before rolling.
-    formData.augmentModifier ??= String(this.requestChatMessage.system.augmentModifier ?? 0);
-    formData.meditateModifier ??= String(this.requestChatMessage.system.meditateModifier ?? 0);
+    // Augment/Meditate are the roller's own tactical choices. Only the situational Other modifier
+    // is seeded from the GM's request; the recipient can still change it before rolling.
+    formData.augmentModifier ??= "0";
+    formData.meditateModifier ??= "0";
     formData.otherModifier ??= String(this.requestChatMessage.system.otherModifier ?? 0);
     formData.otherModifierDescription ??=
       this.requestChatMessage.system.otherModifierDescription ||

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -19,7 +19,6 @@ import {
   resolveCharacteristicLabel,
   resolveCharacteristicValue,
 } from "./resistance-roll-shared.ts";
-import { getConfiguredRollModeOptions, resolveRollModeFromForm } from "../app-parts/roll-mode";
 import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
 import { getSpeakerCompat } from "../../system/fvtt-type-compat";
 import { updateChatMessage } from "../../sockets/socketable-requests";
@@ -164,8 +163,6 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
         formData,
       ),
       totalChanceTooltip: this.buildChanceBreakdown(formData),
-      rollMode: this.rollMode,
-      rollModes: getConfiguredRollModeOptions(),
     };
   }
 
@@ -250,7 +247,6 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
         formDataObject.otherModifierDescription,
       ),
       speaker: getSpeakerCompat({ actor: actor, token: token }),
-      rollMode: resolveRollModeFromForm(form),
     };
 
     const roll = new ResistanceRoll(undefined, {}, options);

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -4,14 +4,8 @@ import type {
   RespondToResistanceRequestDialogContext,
   RespondToResistanceRequestDialogFormData,
 } from "./respond-to-resistance-request-dialog-data.types.ts";
-import {
-  activateChatTab,
-  getSpeakerDisplayName,
-  isDocumentSubType,
-  localize,
-} from "../../system/util";
+import { activateChatTab, getSpeakerDisplayName, localize } from "../../system/util";
 import type { RqgActor } from "@actors/rqg-actor.ts";
-import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
 import type { ResistanceRollOptions } from "../../rolls/resistance-roll/resistance-roll.types";
 import { ResistanceRoll } from "../../rolls/resistance-roll/resistance-roll";
 import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
@@ -19,6 +13,7 @@ import {
   augmentOptions,
   buildResistanceChanceBreakdown,
   buildResistanceModifiers,
+  creditResistanceRollPowExperience,
   decodeCharacteristics,
   meditateOptions,
   resolveCharacteristicLabel,
@@ -279,13 +274,11 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
     activateChatTab();
     await updateChatMessage(requestChatMessage!, messageData);
 
-    // Only POW earns an experience check from a resistance roll.
-    if (
-      isDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character) &&
-      roll.successLevel != null &&
-      decodeCharacteristics(requestChatMessage!.system.activeCharacteristics).includes("power")
-    ) {
-      await actor.checkExperience("power", roll.successLevel);
-    }
+    await creditResistanceRollPowExperience(
+      actor,
+      requestChatMessage!.system.activeCharacteristics,
+      requestChatMessage!.system.passiveCharacteristics,
+      roll,
+    );
   }
 }

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -241,6 +241,7 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
       return;
     }
 
+    const rollMode = resolveRollModeFromForm(form);
     const options: ResistanceRollOptions = {
       activeValue: active.value,
       activeLabel: active.label,
@@ -254,16 +255,13 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
         formDataObject.otherModifierDescription,
       ),
       speaker: getSpeakerCompat({ actor: actor, token: token }),
-      rollMode: resolveRollModeFromForm(form),
+      rollMode: rollMode,
     };
 
     const roll = new ResistanceRoll(undefined, {}, options);
     await roll.evaluate();
 
-    const { whisper, blind } = resolveResistanceRequestVisibility(
-      options.rollMode ?? "public",
-      actor,
-    );
+    const { whisper, blind } = resolveResistanceRequestVisibility(rollMode, actor);
 
     if (game.dice3d) {
       await game.dice3d.showForRoll(roll, game.user, true, whisper.length ? whisper : null, blind);

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -215,9 +215,6 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
     }
 
     const { actor, token } = RespondToResistanceRequestDialogV2.resolveTarget(requestChatMessage!);
-    const activeCharacteristicNames = decodeCharacteristics(
-      requestChatMessage!.system.activeCharacteristics,
-    );
     const active = RespondToResistanceRequestDialogV2.resolveActive(
       actor,
       requestChatMessage!.system.activeCharacteristics,
@@ -264,14 +261,13 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
     activateChatTab();
     await updateChatMessage(requestChatMessage!, messageData);
 
-    // Both characteristics of a combo (e.g. Knockback's STR+SIZ) get checked, not just the first.
+    // Only POW earns an experience check from a resistance roll.
     if (
       isDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character) &&
-      roll.successLevel != null
+      roll.successLevel != null &&
+      decodeCharacteristics(requestChatMessage!.system.activeCharacteristics).includes("power")
     ) {
-      for (const characteristicName of activeCharacteristicNames) {
-        await actor.checkExperience(characteristicName, roll.successLevel);
-      }
+      await actor.checkExperience("power", roll.successLevel);
     }
   }
 }

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -215,7 +215,7 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
       requestChatMessage!.system.activeCharacteristics,
     );
     if (!actor || !active.label) {
-      ui.notifications?.error("Could not find who this resistance request is for.");
+      ui.notifications?.error(localize("RQG.Notification.Error.ResistanceRequestTargetNotFound"));
       return;
     }
 

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -33,12 +33,8 @@ import { RqgLogger } from "../../system/logging/rqg-logger";
 const logger = new RqgLogger("RespondToResistanceRequestDialogV2");
 
 /**
- * Recipient-facing dialog (#758 option C): answers a GM-posted resistance-request chat card. The
- * Active side (who rolls, with what characteristic(s)) and the Passive side's value are both
- * fixed by the request - the recipient only picks their own Augment/Meditate/Other modifiers,
- * same as ResistanceRollDialogV2, before rolling. On submit the roll is written back onto the
- * original chat message (via a socket update if the GM, not the recipient, authored it) instead
- * of creating a new one.
+ * The recipient answers a resistance-request card: both sides are fixed by the request, they only
+ * pick their own modifiers. The roll is written back onto the original message, not a new one.
  */
 export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase {
   protected override getLivePreviewFormBehaviorConfig() {
@@ -107,8 +103,7 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
     };
   }
 
-  // Takes the already-resolved actor rather than re-deriving it via resolveTarget() itself, so
-  // callers that need both only look the target up once.
+  // Takes the resolved actor so callers look the target up once.
   private static resolveActive(
     actor: RqgActor | undefined,
     activeCharacteristics: string,
@@ -138,8 +133,7 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
     this.activeValue = active.value;
     this.passiveValue = this.requestChatMessage.system.passiveValue;
 
-    // Augment/Meditate are the roller's own tactical choices. Only the situational Other modifier
-    // is seeded from the GM's request; the recipient can still change it before rolling.
+    // Augment/Meditate are the roller's own choices; only Other is seeded from the request.
     formData.augmentModifier ??= "0";
     formData.meditateModifier ??= "0";
     formData.otherModifier ??= String(this.requestChatMessage.system.otherModifier ?? 0);

--- a/src/chat/data-model/resistance-request-chat-message.data-model.ts
+++ b/src/chat/data-model/resistance-request-chat-message.data-model.ts
@@ -18,16 +18,14 @@ const resistanceRequestChatMessageSchema = {
   activeCharacteristics: new StringField({ blank: false, nullable: false, required: true }),
   passiveValue: new NumberField({ nullable: false, required: true, initial: 0 }),
   passiveLabel: new StringField({ blank: false, nullable: false, required: true }),
-  // The obstacle/disease/passive character's name, if any - either an actor's own name, or a
-  // GM-typed one for a Manual passive value. Feeds the roll's "opposes X" flavor line.
+  // Passive side's name (actor or GM-typed); feeds the "opposes X" flavor line.
   passiveActorName: new StringField({
     blank: true,
     nullable: true,
     initial: undefined,
     required: false,
   }),
-  // The GM's situational modifier for the contest - seeds the roller's Other modifier, which they
-  // can still change before rolling.
+  // GM's situational modifier; seeds the roller's Other modifier.
   otherModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
   otherModifierDescription: new StringField({
     blank: true,

--- a/src/chat/data-model/resistance-request-chat-message.data-model.ts
+++ b/src/chat/data-model/resistance-request-chat-message.data-model.ts
@@ -1,0 +1,57 @@
+import { resistanceRequestState } from "./resistance-request-chat-message.defs.ts";
+import { enumChoices } from "../../data-model/shared/enum-choices";
+
+const { NumberField, StringField, DocumentUUIDField, JSONField } = foundry.data.fields;
+
+const resistanceRequestChatMessageSchema = {
+  state: new StringField({
+    blank: false,
+    nullable: false,
+    initial: resistanceRequestState[0],
+    choices: enumChoices(resistanceRequestState, "RQG.Chat.ResistanceRequest.State."),
+  }),
+  targetTokenOrActorUuid: new DocumentUUIDField({
+    blank: false,
+    nullable: false,
+    required: true,
+  }),
+  activeCharacteristics: new StringField({ blank: false, nullable: false, required: true }),
+  passiveValue: new NumberField({ nullable: false, required: true, initial: 0 }),
+  passiveLabel: new StringField({ blank: false, nullable: false, required: true }),
+  // The obstacle/disease/passive character's name, if any - either an actor's own name, or a
+  // GM-typed one for a Manual passive value. Feeds the roll's "opposes X" flavor line.
+  passiveActorName: new StringField({
+    blank: true,
+    nullable: true,
+    initial: undefined,
+    required: false,
+  }),
+  // GM-prefilled defaults for the recipient's Augment/Meditate/Other modifiers - the recipient can
+  // still change them before rolling, same as ResistanceRollDialogV2.
+  augmentModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
+  meditateModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
+  otherModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
+  otherModifierDescription: new StringField({
+    blank: true,
+    nullable: true,
+    initial: undefined,
+    required: false,
+  }),
+  resistanceRoll: new JSONField({
+    blank: false,
+    nullable: true,
+    required: false,
+    initial: undefined,
+  }),
+} as const;
+
+type resistanceRequestDataType = typeof resistanceRequestChatMessageSchema;
+
+export class ResistanceRequestChatMessageData extends foundry.abstract.TypeDataModel<
+  resistanceRequestDataType,
+  any
+> {
+  static override defineSchema() {
+    return resistanceRequestChatMessageSchema;
+  }
+}

--- a/src/chat/data-model/resistance-request-chat-message.data-model.ts
+++ b/src/chat/data-model/resistance-request-chat-message.data-model.ts
@@ -26,10 +26,8 @@ const resistanceRequestChatMessageSchema = {
     initial: undefined,
     required: false,
   }),
-  // GM-prefilled defaults for the recipient's Augment/Meditate/Other modifiers - the recipient can
-  // still change them before rolling, same as ResistanceRollDialogV2.
-  augmentModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
-  meditateModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
+  // The GM's situational modifier for the contest - seeds the roller's Other modifier, which they
+  // can still change before rolling.
   otherModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
   otherModifierDescription: new StringField({
     blank: true,

--- a/src/chat/data-model/resistance-request-chat-message.data-model.ts
+++ b/src/chat/data-model/resistance-request-chat-message.data-model.ts
@@ -16,6 +16,8 @@ const resistanceRequestChatMessageSchema = {
     required: true,
   }),
   activeCharacteristics: new StringField({ blank: false, nullable: false, required: true }),
+  // "" when the passive side is a manual value rather than an actor characteristic.
+  passiveCharacteristics: new StringField({ blank: true, nullable: false, required: false }),
   passiveValue: new NumberField({ nullable: false, required: true, initial: 0 }),
   passiveLabel: new StringField({ blank: false, nullable: false, required: true }),
   // Passive side's name (actor or GM-typed); feeds the "opposes X" flavor line.

--- a/src/chat/data-model/resistance-request-chat-message.data-model.ts
+++ b/src/chat/data-model/resistance-request-chat-message.data-model.ts
@@ -35,6 +35,8 @@ const resistanceRequestChatMessageSchema = {
     initial: undefined,
     required: false,
   }),
+  // GM's chosen roll mode; seeds the roller's selection.
+  rollMode: new StringField({ blank: true, nullable: false, required: false, initial: "" }),
   resistanceRoll: new JSONField({
     blank: false,
     nullable: true,

--- a/src/chat/data-model/resistance-request-chat-message.defs.ts
+++ b/src/chat/data-model/resistance-request-chat-message.defs.ts
@@ -1,0 +1,1 @@
+export const resistanceRequestState = ["Requested", "Rolled"] as const;

--- a/src/chat/data-model/resistance-request-chat-message.types.ts
+++ b/src/chat/data-model/resistance-request-chat-message.types.ts
@@ -10,14 +10,14 @@ export type ResistanceRequestChatMessage = ChatMessage & {
 export interface ResistanceRequestDataSourceData {
   state: ResistanceRequestState;
   targetTokenOrActorUuid: string;
-  /** One characteristic name, or two joined by "+" (e.g. "strength+size") - what the target rolls. */
+  /** One characteristic name, or two joined by "+" (e.g. "strength+size"). */
   activeCharacteristics: string;
-  /** Snapshotted passive value/label set by the GM when the request was sent (e.g. a disease's POT). */
+  /** Passive value/label snapshotted when the GM sent the request. */
   passiveValue: number;
   passiveLabel: string;
-  /** The obstacle/disease/passive character's name, if any - feeds the "opposes X" flavor line. */
+  /** Passive side's name, if any - feeds the "opposes X" flavor line. */
   passiveActorName: string | undefined;
-  /** The GM's situational modifier for the contest - seeds the roller's Other modifier. */
+  /** GM's situational modifier; seeds the roller's Other modifier. */
   otherModifier: number;
   otherModifierDescription: string | undefined;
   resistanceRoll: string | object | undefined; // JSONField can be string or parsed object

--- a/src/chat/data-model/resistance-request-chat-message.types.ts
+++ b/src/chat/data-model/resistance-request-chat-message.types.ts
@@ -1,0 +1,38 @@
+import type { resistanceRequestState } from "./resistance-request-chat-message.defs";
+
+export type ResistanceRequestState = (typeof resistanceRequestState)[number];
+
+// Narrowed actor type for subtype "resistanceRequest"
+export type ResistanceRequestChatMessage = ChatMessage & {
+  system: ResistanceRequestDataPropertiesData;
+};
+
+export interface ResistanceRequestDataSourceData {
+  state: ResistanceRequestState;
+  targetTokenOrActorUuid: string;
+  /** One characteristic name, or two joined by "+" (e.g. "strength+size") - what the target rolls. */
+  activeCharacteristics: string;
+  /** Snapshotted passive value/label set by the GM when the request was sent (e.g. a disease's POT). */
+  passiveValue: number;
+  passiveLabel: string;
+  /** The obstacle/disease/passive character's name, if any - feeds the "opposes X" flavor line. */
+  passiveActorName: string | undefined;
+  /** GM-prefilled defaults for the recipient's modifiers - still editable before rolling. */
+  augmentModifier: number;
+  meditateModifier: number;
+  otherModifier: number;
+  otherModifierDescription: string | undefined;
+  resistanceRoll: string | object | undefined; // JSONField can be string or parsed object
+}
+
+export interface ResistanceRequestDataPropertiesData extends ResistanceRequestDataSourceData {}
+
+export interface ResistanceRequestDataSource {
+  type: "resistanceRequest";
+  system: ResistanceRequestDataSourceData;
+}
+
+export interface ResistanceRequestDataProperties {
+  type: "resistanceRequest";
+  system: ResistanceRequestDataPropertiesData;
+}

--- a/src/chat/data-model/resistance-request-chat-message.types.ts
+++ b/src/chat/data-model/resistance-request-chat-message.types.ts
@@ -22,6 +22,8 @@ export interface ResistanceRequestDataSourceData {
   /** GM's situational modifier; seeds the roller's Other modifier. */
   otherModifier: number;
   otherModifierDescription: string | undefined;
+  /** GM's chosen roll mode; seeds (but doesn't lock) the roller's selection. */
+  rollMode: string;
   resistanceRoll: string | object | undefined; // JSONField can be string or parsed object
 }
 

--- a/src/chat/data-model/resistance-request-chat-message.types.ts
+++ b/src/chat/data-model/resistance-request-chat-message.types.ts
@@ -17,9 +17,7 @@ export interface ResistanceRequestDataSourceData {
   passiveLabel: string;
   /** The obstacle/disease/passive character's name, if any - feeds the "opposes X" flavor line. */
   passiveActorName: string | undefined;
-  /** GM-prefilled defaults for the recipient's modifiers - still editable before rolling. */
-  augmentModifier: number;
-  meditateModifier: number;
+  /** The GM's situational modifier for the contest - seeds the roller's Other modifier. */
   otherModifier: number;
   otherModifierDescription: string | undefined;
   resistanceRoll: string | object | undefined; // JSONField can be string or parsed object

--- a/src/chat/data-model/resistance-request-chat-message.types.ts
+++ b/src/chat/data-model/resistance-request-chat-message.types.ts
@@ -12,6 +12,8 @@ export interface ResistanceRequestDataSourceData {
   targetTokenOrActorUuid: string;
   /** One characteristic name, or two joined by "+" (e.g. "strength+size"). */
   activeCharacteristics: string;
+  /** Encoded passive characteristic(s), or "" when the passive side is a manual value. */
+  passiveCharacteristics: string;
   /** Passive value/label snapshotted when the GM sent the request. */
   passiveValue: number;
   passiveLabel: string;

--- a/src/chat/resistance-request-chat-template.hbs
+++ b/src/chat/resistance-request-chat-template.hbs
@@ -1,0 +1,9 @@
+<div class="rqg chat-card">
+  {{#if (eq state 'Requested')}}
+    <button class="resistance-request-roll" data-only-owner-visible-uuid="{{targetTokenOrActorUuid}}"
+            data-roll-resistance-request>{{localize "RQG.ChatMessage.ResistanceRequest.Roll"}}
+    </button>
+  {{else}}
+    <span data-resistance-roll-html></span>
+  {{/if}}
+</div>

--- a/src/chat/resistance-request-handlers.ts
+++ b/src/chat/resistance-request-handlers.ts
@@ -1,0 +1,12 @@
+import { getRequiredDomDataset } from "../system/util";
+
+/**
+ * Open the dialog to respond to (and roll) a GM-posted resistance-request chat card (#758
+ * option C).
+ */
+export async function handleRollResistanceRequest(clickedButton: HTMLButtonElement): Promise<void> {
+  const chatMessageId = getRequiredDomDataset(clickedButton, "message-id");
+  const { RespondToResistanceRequestDialogV2 } =
+    await import("../applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2");
+  await new RespondToResistanceRequestDialogV2(chatMessageId).render({ force: true });
+}

--- a/src/chat/resistance-request-handlers.ts
+++ b/src/chat/resistance-request-handlers.ts
@@ -1,9 +1,6 @@
 import { getRequiredDomDataset } from "../system/util";
 
-/**
- * Open the dialog to respond to (and roll) a GM-posted resistance-request chat card (#758
- * option C).
- */
+/** Open the dialog to respond to a resistance-request chat card. */
 export async function handleRollResistanceRequest(clickedButton: HTMLButtonElement): Promise<void> {
   const chatMessageId = getRequiredDomDataset(clickedButton, "message-id");
   const { RespondToResistanceRequestDialogV2 } =

--- a/src/chat/rqg-chat-message.ts
+++ b/src/chat/rqg-chat-message.ts
@@ -130,6 +130,7 @@ export class RqgChatMessage extends ChatMessage {
       "resistanceRoll",
       "[data-resistance-roll-html]",
       ResistanceRoll,
+      !!this.blind && !game.user?.isGM,
     );
 
     this.#hideHtmlElementsByOwnership(html);
@@ -182,13 +183,14 @@ export class RqgChatMessage extends ChatMessage {
     systemDataRollName: string,
     domSelector: string,
     RollClass: any = AbilityRoll,
+    isPrivate = false,
   ): Promise<void> {
     const rollJson = (this.system as any)[systemDataRollName];
     const roll = safeFromJSON<AbilityRoll | ResistanceRoll>(RollClass, rollJson);
     if (roll?.isEvaluated) {
       const element = html.querySelector<HTMLElement>(domSelector);
       if (element) {
-        element.innerHTML = await roll.render();
+        element.innerHTML = await roll.render({ isPrivate });
       }
     }
   }

--- a/src/chat/rqg-chat-message.ts
+++ b/src/chat/rqg-chat-message.ts
@@ -130,7 +130,6 @@ export class RqgChatMessage extends ChatMessage {
       "resistanceRoll",
       "[data-resistance-roll-html]",
       ResistanceRoll,
-      !!this.blind && !game.user?.isGM,
     );
 
     this.#hideHtmlElementsByOwnership(html);
@@ -183,13 +182,14 @@ export class RqgChatMessage extends ChatMessage {
     systemDataRollName: string,
     domSelector: string,
     RollClass: any = AbilityRoll,
-    isPrivate = false,
   ): Promise<void> {
     const rollJson = (this.system as any)[systemDataRollName];
     const roll = safeFromJSON<AbilityRoll | ResistanceRoll>(RollClass, rollJson);
     if (roll?.isEvaluated) {
       const element = html.querySelector<HTMLElement>(domSelector);
       if (element) {
+        // A blind roll's result is obscured for everyone but the GM.
+        const isPrivate = !!this.blind && !game.user?.isGM;
         element.innerHTML = await roll.render({ isPrivate });
       }
     }

--- a/src/chat/rqg-chat-message.ts
+++ b/src/chat/rqg-chat-message.ts
@@ -102,7 +102,7 @@ export class RqgChatMessage extends ChatMessage {
 
     if (clickedButton?.dataset["rollResistanceRequest"] != null) {
       RqgChatMessage.commonClickHandling(clickEvent, clickedButton);
-      await handleRollResistanceRequest(clickedButton); // Open the resistance request response dialog
+      await handleRollResistanceRequest(clickedButton);
     }
   }
 

--- a/src/chat/rqg-chat-message.ts
+++ b/src/chat/rqg-chat-message.ts
@@ -5,14 +5,18 @@ import {
   handleRollDamageAndHitLocation,
   handleRollFumble,
 } from "./attack-flow-handlers";
+import { handleRollResistanceRequest } from "./resistance-request-handlers";
 import { AbilityRoll } from "../rolls/ability-roll/ability-roll";
 import { isFoundryElementInstanceOf, localize, safeFromJSON } from "../system/util";
 import { DamageRoll } from "../rolls/damage-roll/damage-roll";
 import { HitLocationRoll } from "../rolls/hit-location-roll/hit-location-roll";
+import { ResistanceRoll } from "../rolls/resistance-roll/resistance-roll";
 
 import { templatePaths } from "../system/load-handlebars-templates";
 import { CombatChatMessageData } from "./data-model/combat-chat-message.data-model.ts";
 import type { CombatDataProperties } from "./data-model/combat-chat-message.types.ts";
+import { ResistanceRequestChatMessageData } from "./data-model/resistance-request-chat-message.data-model.ts";
+import type { ResistanceRequestDataProperties } from "./data-model/resistance-request-chat-message.types.ts";
 
 // TODO how to type this so combat subtype data is typed?
 export class RqgChatMessage extends ChatMessage {
@@ -21,6 +25,7 @@ export class RqgChatMessage extends ChatMessage {
     CONFIG.ChatMessage.template = templatePaths.chatMessage;
 
     CONFIG.ChatMessage.dataModels["combat"] = CombatChatMessageData;
+    CONFIG.ChatMessage.dataModels["resistanceRequest"] = ResistanceRequestChatMessageData;
 
     Hooks.on("ready", () => {
       // one listener for sidebar chat, popped out chat & chat notification
@@ -94,6 +99,11 @@ export class RqgChatMessage extends ChatMessage {
     // *************************
     // *** END - Attack Flow ***
     // *************************
+
+    if (clickedButton?.dataset["rollResistanceRequest"] != null) {
+      RqgChatMessage.commonClickHandling(clickEvent, clickedButton);
+      await handleRollResistanceRequest(clickedButton); // Open the resistance request response dialog
+    }
   }
 
   private static commonClickHandling(clickEvent: MouseEvent, clickedButton: HTMLButtonElement) {
@@ -115,6 +125,12 @@ export class RqgChatMessage extends ChatMessage {
     await this.#enrichHtmlWithRoll(html, "defenceRoll", "[data-defence-roll-html]");
     await this.#enrichHtmlWithRoll(html, "damageRoll", "[data-damage-roll-html]");
     await this.#enrichHtmlWithRoll(html, "hitLocationRoll", "[data-hit-location-roll-html]");
+    await this.#enrichHtmlWithRoll(
+      html,
+      "resistanceRoll",
+      "[data-resistance-roll-html]",
+      ResistanceRoll,
+    );
 
     this.#hideHtmlElementsByOwnership(html);
 
@@ -165,9 +181,10 @@ export class RqgChatMessage extends ChatMessage {
     html: HTMLElement,
     systemDataRollName: string,
     domSelector: string,
+    RollClass: any = AbilityRoll,
   ): Promise<void> {
     const rollJson = (this.system as any)[systemDataRollName];
-    const roll = safeFromJSON<AbilityRoll>(AbilityRoll, rollJson);
+    const roll = safeFromJSON<AbilityRoll | ResistanceRoll>(RollClass, rollJson);
     if (roll?.isEvaluated) {
       const element = html.querySelector<HTMLElement>(domSelector);
       if (element) {
@@ -243,6 +260,16 @@ export class RqgChatMessage extends ChatMessage {
           `HitLocationRoll: ${hitLocationRoll.formula} = ${hitLocationRoll.total} = ${hitLocationRoll.hitLocationName}`,
         );
       }
+    } else if (this.isResistanceRequestMessage()) {
+      const resistanceRoll = safeFromJSON<ResistanceRoll>(
+        ResistanceRoll,
+        this.system.resistanceRoll,
+      );
+      if (resistanceRoll?.isEvaluated) {
+        content.push(
+          `ResistanceRoll: ${resistanceRoll.total} / ${resistanceRoll.targetChance} = ${localize(`RQG.Game.AbilityResultEnum.${resistanceRoll.successLevel}`)}`,
+        );
+      }
     }
 
     // Author and timestamp TODO users locale (don't have that), or maybe Gloranthan time formatting?
@@ -258,5 +285,9 @@ export class RqgChatMessage extends ChatMessage {
 
   isCombatMessage(): this is CombatDataProperties {
     return this.type === "combat";
+  }
+
+  isResistanceRequestMessage(): this is ResistanceRequestDataProperties {
+    return this.type === "resistanceRequest";
   }
 }

--- a/src/combat/rqg-combat-tracker.ts
+++ b/src/combat/rqg-combat-tracker.ts
@@ -141,6 +141,21 @@ export class RqgCombatTracker<
           }
         },
       },
+      {
+        label: "RQG.Game.RequestResistanceRoll",
+        icon: '<i class="fa-solid fa-scale-unbalanced fa-fw"></i>',
+        visible: () => game.user?.isGM ?? false,
+        onClick: async (_event: Event, li: HTMLElement) => {
+          const combatant = getCombatant(li);
+          const uuid = combatant?.token?.uuid ?? combatant?.actor?.uuid;
+          if (!uuid) {
+            return;
+          }
+          const { openResistanceRequest } =
+            await import("../applications/resistance-roll-dialog/open-resistance-request");
+          await openResistanceRequest(uuid);
+        },
+      },
     ];
     return entries as unknown as ContextMenu.Entry<HTMLElement>[];
   }

--- a/src/data-model/item-data/rune-magic-data-model.ts
+++ b/src/data-model/item-data/rune-magic-data-model.ts
@@ -2,7 +2,7 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
-import { promptResistanceRollForSuccessfulCast } from "../shared/spell-resistance-check";
+import { maybePromptResistanceRollForCast } from "../shared/spell-resistance-check";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { rqidLinkArraySchemaField } from "../shared/rqid-link-field";
@@ -33,7 +33,6 @@ import {
   spellItemTypes,
   SpellDurationEnum,
   SpellRangeEnum,
-  SpellResistanceCheckEnum,
 } from "./spell";
 
 export type RuneMagicItem = RqgItem & { system: Item.SystemOfType<"runeMagic"> };
@@ -353,16 +352,13 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
       boundSpiritDrainDecision.avoidRelease,
     );
 
-    if (
-      this.resistanceCheck === SpellResistanceCheckEnum.Single &&
-      runeMagicRoll.successLevel <= AbilitySuccessLevelEnum.Success
-    ) {
-      await promptResistanceRollForSuccessfulCast(
-        casterActor,
-        token,
-        runeMagicItemTyped.name ?? undefined,
-      );
-    }
+    await maybePromptResistanceRollForCast(
+      this.resistanceCheck,
+      runeMagicRoll.successLevel,
+      casterActor,
+      token,
+      runeMagicItemTyped.name ?? undefined,
+    );
   }
 
   /**

--- a/src/data-model/item-data/rune-magic-data-model.ts
+++ b/src/data-model/item-data/rune-magic-data-model.ts
@@ -2,6 +2,7 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
+import { promptResistanceRollForSuccessfulCast } from "../shared/spell-resistance-check";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { rqidLinkArraySchemaField } from "../shared/rqid-link-field";
@@ -32,6 +33,7 @@ import {
   spellItemTypes,
   SpellDurationEnum,
   SpellRangeEnum,
+  SpellResistanceCheckEnum,
 } from "./spell";
 
 export type RuneMagicItem = RqgItem & { system: Item.SystemOfType<"runeMagic"> };
@@ -350,6 +352,17 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
       casterActor,
       boundSpiritDrainDecision.avoidRelease,
     );
+
+    if (
+      this.resistanceCheck === SpellResistanceCheckEnum.Single &&
+      runeMagicRoll.successLevel <= AbilitySuccessLevelEnum.Success
+    ) {
+      await promptResistanceRollForSuccessfulCast(
+        casterActor,
+        token,
+        runeMagicItemTyped.name ?? undefined,
+      );
+    }
   }
 
   /**

--- a/src/data-model/item-data/spell.ts
+++ b/src/data-model/item-data/spell.ts
@@ -32,6 +32,15 @@ export const SpellConcentrationEnum = {
 export type SpellConcentrationEnum =
   (typeof SpellConcentrationEnum)[keyof typeof SpellConcentrationEnum];
 
+// Only None/Single are handled; areaOneRoll (Harmony/Inviolable) and perTarget (Turn Undead etc.)
+// are planned - see #1066.
+export const SpellResistanceCheckEnum = {
+  None: "none",
+  Single: "single",
+} as const;
+export type SpellResistanceCheckEnum =
+  (typeof SpellResistanceCheckEnum)[keyof typeof SpellResistanceCheckEnum];
+
 // Se core book p247
 export interface Spell {
   /** Learned strength */
@@ -42,5 +51,7 @@ export interface Spell {
   isRitual: boolean;
   /** Requires POW sacrifice by caster (possibly from others see core book p249) */
   isEnchantment: boolean;
+  /** POW vs POW resistance roll against the caster's target after a successful cast (p.145-147, 254) */
+  resistanceCheck: SpellResistanceCheckEnum;
   descriptionRqidLink: RqidLink | undefined;
 }

--- a/src/data-model/item-data/spell.ts
+++ b/src/data-model/item-data/spell.ts
@@ -32,8 +32,6 @@ export const SpellConcentrationEnum = {
 export type SpellConcentrationEnum =
   (typeof SpellConcentrationEnum)[keyof typeof SpellConcentrationEnum];
 
-// Only None/Single are handled; areaOneRoll (Harmony/Inviolable) and perTarget (Turn Undead etc.)
-// are planned - see #1066.
 export const SpellResistanceCheckEnum = {
   None: "none",
   Single: "single",
@@ -51,7 +49,7 @@ export interface Spell {
   isRitual: boolean;
   /** Requires POW sacrifice by caster (possibly from others see core book p249) */
   isEnchantment: boolean;
-  /** POW vs POW resistance roll against the caster's target after a successful cast (p.145-147, 254) */
+  /** Whether a successful cast triggers a POW-vs-POW resistance roll by the target. */
   resistanceCheck: SpellResistanceCheckEnum;
   descriptionRqidLink: RqidLink | undefined;
 }

--- a/src/data-model/item-data/spirit-magic-data-model.ts
+++ b/src/data-model/item-data/spirit-magic-data-model.ts
@@ -2,9 +2,11 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
+import { promptResistanceRollForSuccessfulCast } from "../shared/spell-resistance-check";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { RqgError, localize, assertDocumentSubType } from "../../system/util";
+import { AbilitySuccessLevelEnum } from "../../rolls/ability-roll/ability-roll.defs";
 import { getSpeakerCompat } from "../../system/fvtt-type-compat";
 import type { SpiritMagicRollOptions } from "../../rolls/spirit-magic-roll/spirit-magic-roll.types";
 import { ActorTypeEnum, type CharacterActor } from "../actor-data/rqg-actor-data";
@@ -20,6 +22,7 @@ import {
   spellItemTypes,
   SpellDurationEnum,
   SpellRangeEnum,
+  SpellResistanceCheckEnum,
 } from "./spell";
 
 export type SpiritMagicItem = RqgItem & { system: Item.SystemOfType<"spiritMagic"> };
@@ -167,6 +170,13 @@ export class SpiritMagicDataModel extends RqgItemDataModel<SpiritMagicSchema> {
       magicPointSource,
       boundSpiritDrainDecision.avoidRelease,
     );
+
+    if (
+      this.resistanceCheck === SpellResistanceCheckEnum.Single &&
+      spiritMagicRoll.successLevel <= AbilitySuccessLevelEnum.Success
+    ) {
+      await promptResistanceRollForSuccessfulCast(casterActor, token, item?.name ?? undefined);
+    }
   }
 
   /**

--- a/src/data-model/item-data/spirit-magic-data-model.ts
+++ b/src/data-model/item-data/spirit-magic-data-model.ts
@@ -2,11 +2,10 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
-import { promptResistanceRollForSuccessfulCast } from "../shared/spell-resistance-check";
+import { maybePromptResistanceRollForCast } from "../shared/spell-resistance-check";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { RqgError, localize, assertDocumentSubType } from "../../system/util";
-import { AbilitySuccessLevelEnum } from "../../rolls/ability-roll/ability-roll.defs";
 import { getSpeakerCompat } from "../../system/fvtt-type-compat";
 import type { SpiritMagicRollOptions } from "../../rolls/spirit-magic-roll/spirit-magic-roll.types";
 import { ActorTypeEnum, type CharacterActor } from "../actor-data/rqg-actor-data";
@@ -22,7 +21,6 @@ import {
   spellItemTypes,
   SpellDurationEnum,
   SpellRangeEnum,
-  SpellResistanceCheckEnum,
 } from "./spell";
 
 export type SpiritMagicItem = RqgItem & { system: Item.SystemOfType<"spiritMagic"> };
@@ -171,12 +169,13 @@ export class SpiritMagicDataModel extends RqgItemDataModel<SpiritMagicSchema> {
       boundSpiritDrainDecision.avoidRelease,
     );
 
-    if (
-      this.resistanceCheck === SpellResistanceCheckEnum.Single &&
-      spiritMagicRoll.successLevel <= AbilitySuccessLevelEnum.Success
-    ) {
-      await promptResistanceRollForSuccessfulCast(casterActor, token, item?.name ?? undefined);
-    }
+    await maybePromptResistanceRollForCast(
+      this.resistanceCheck,
+      spiritMagicRoll.successLevel,
+      casterActor,
+      token,
+      item?.name ?? undefined,
+    );
   }
 
   /**

--- a/src/data-model/json-schemas/generated/item/runeMagic.schema.json
+++ b/src/data-model/json-schemas/generated/item/runeMagic.schema.json
@@ -50,6 +50,15 @@
       "type": "boolean",
       "default": false
     },
+    "resistanceCheck": {
+      "type": "string",
+      "enum": [
+        "none",
+        "single"
+      ],
+      "minLength": 1,
+      "default": "none"
+    },
     "descriptionRqidLink": {
       "type": [
         "object",
@@ -125,6 +134,7 @@
     "concentration",
     "isRitual",
     "isEnchantment",
+    "resistanceCheck",
     "cultId",
     "runeRqidLinks",
     "isStackable",

--- a/src/data-model/json-schemas/generated/item/spiritMagic.schema.json
+++ b/src/data-model/json-schemas/generated/item/spiritMagic.schema.json
@@ -50,6 +50,15 @@
       "type": "boolean",
       "default": false
     },
+    "resistanceCheck": {
+      "type": "string",
+      "enum": [
+        "none",
+        "single"
+      ],
+      "minLength": 1,
+      "default": "none"
+    },
     "descriptionRqidLink": {
       "type": [
         "object",
@@ -105,6 +114,7 @@
     "concentration",
     "isRitual",
     "isEnchantment",
+    "resistanceCheck",
     "isVariable",
     "incompatibleWith",
     "spellFocus",

--- a/src/data-model/shared/spell-resistance-check.ts
+++ b/src/data-model/shared/spell-resistance-check.ts
@@ -4,17 +4,8 @@ import { AbilitySuccessLevelEnum } from "../../rolls/ability-roll/ability-roll.d
 import { SpellResistanceCheckEnum } from "../item-data/spell";
 
 /**
- * Post-cast hook shared by Rune Magic and Spirit Magic. When a resisted spell is cast
- * successfully, open a POW vs POW ResistanceRollDialogV2 pre-filled caster-vs-target (#757).
- * Deliberately a standalone step (not folded into point-spending/experience bookkeeping) so a
- * future spell-effect trigger (#443) can sit behind it.
- *
- * The resistance roll yields a graded success level (critical … fumble), not a bare pass/fail:
- * some spells key effects off the degree, and even a failed roll can carry an effect. Whatever
- * consumes the outcome must read `ResistanceRoll.successLevel`.
- *
- * Silently does nothing with zero targets (not every spell targets someone), and warns (without
- * rolling) on more than one target - the caster should pick a single target before casting.
+ * Post-cast hook for Rune/Spirit Magic: on a successful cast of a resisted spell, open a
+ * POW-vs-POW ResistanceRollDialogV2 caster-vs-target. No-op with no target; warns on multiple.
  */
 export async function maybePromptResistanceRollForCast(
   resistanceCheck: SpellResistanceCheckEnum,
@@ -40,8 +31,7 @@ export async function maybePromptResistanceRollForCast(
     return;
   }
 
-  // Dynamic import to avoid circular dependencies through rqgItem.ts, mirroring the other
-  // dynamic imports in the rune/spirit magic data models.
+  // Dynamic import to avoid a circular dependency through rqgItem.ts.
   const { ResistanceRollDialogV2 } =
     await import("../../applications/resistance-roll-dialog/resistance-roll-dialog-v2");
   await new ResistanceRollDialogV2(casterActor, token, {

--- a/src/data-model/shared/spell-resistance-check.ts
+++ b/src/data-model/shared/spell-resistance-check.ts
@@ -1,0 +1,49 @@
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import { warnIfMultipleTargets } from "../../system/util";
+
+/**
+ * After a spell with `resistanceCheck === "single"` is cast successfully, open a POW vs POW
+ * ResistanceRollDialogV2 pre-filled against the caster's current single target (#757).
+ * Shared between Rune Magic and Spirit Magic post-cast hooks. This is deliberately a standalone
+ * step (not folded into point-spending/experience bookkeeping) so it stays a clean pass/fail
+ * "gate" that a future spell-effect trigger (#443) can sit behind.
+ *
+ * Silently does nothing with zero targets (not every spell targets someone), and warns (without
+ * rolling) on more than one target - the caster should pick a single target before casting.
+ */
+export async function promptResistanceRollForSuccessfulCast(
+  casterActor: RqgActor,
+  token: TokenDocument | null | undefined,
+  spellName: string | undefined,
+): Promise<void> {
+  const targetCount = game.user?.targets.size ?? 0;
+  if (targetCount > 1) {
+    warnIfMultipleTargets();
+    return;
+  }
+  if (targetCount === 0) {
+    return;
+  }
+  const targetTokenUuid = game.user?.targets.first()?.document?.uuid;
+  if (!targetTokenUuid) {
+    return;
+  }
+
+  // Dynamic import to avoid circular dependencies through rqgItem.ts, mirroring the other
+  // dynamic imports in the rune/spirit magic data models.
+  const { ResistanceRollDialogV2 } =
+    await import("../../applications/resistance-roll-dialog/resistance-roll-dialog-v2");
+  await new ResistanceRollDialogV2(casterActor, token, {
+    active: {
+      source: "tokenOrActor",
+      tokenOrActorUuid: token?.uuid ?? casterActor.uuid ?? "",
+      characteristicNames: ["power"],
+    },
+    passive: {
+      source: "tokenOrActor",
+      tokenOrActorUuid: targetTokenUuid,
+      characteristicNames: ["power"],
+    },
+    description: spellName,
+  }).render({ force: true });
+}

--- a/src/data-model/shared/spell-resistance-check.ts
+++ b/src/data-model/shared/spell-resistance-check.ts
@@ -1,31 +1,42 @@
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import { warnIfMultipleTargets } from "../../system/util";
+import { AbilitySuccessLevelEnum } from "../../rolls/ability-roll/ability-roll.defs";
+import { SpellResistanceCheckEnum } from "../item-data/spell";
 
 /**
- * After a spell with `resistanceCheck === "single"` is cast successfully, open a POW vs POW
- * ResistanceRollDialogV2 pre-filled against the caster's current single target (#757).
- * Shared between Rune Magic and Spirit Magic post-cast hooks. This is deliberately a standalone
- * step (not folded into point-spending/experience bookkeeping) so it stays a clean pass/fail
- * "gate" that a future spell-effect trigger (#443) can sit behind.
+ * Post-cast hook shared by Rune Magic and Spirit Magic. When a resisted spell is cast
+ * successfully, open a POW vs POW ResistanceRollDialogV2 pre-filled caster-vs-target (#757).
+ * Deliberately a standalone step (not folded into point-spending/experience bookkeeping) so a
+ * future spell-effect trigger (#443) can sit behind it.
+ *
+ * The resistance roll yields a graded success level (critical … fumble), not a bare pass/fail:
+ * some spells key effects off the degree, and even a failed roll can carry an effect. Whatever
+ * consumes the outcome must read `ResistanceRoll.successLevel`.
  *
  * Silently does nothing with zero targets (not every spell targets someone), and warns (without
  * rolling) on more than one target - the caster should pick a single target before casting.
  */
-export async function promptResistanceRollForSuccessfulCast(
+export async function maybePromptResistanceRollForCast(
+  resistanceCheck: SpellResistanceCheckEnum,
+  castSuccessLevel: AbilitySuccessLevelEnum,
   casterActor: RqgActor,
   token: TokenDocument | null | undefined,
   spellName: string | undefined,
 ): Promise<void> {
+  if (
+    resistanceCheck !== SpellResistanceCheckEnum.Single ||
+    castSuccessLevel > AbilitySuccessLevelEnum.Success
+  ) {
+    return;
+  }
+
   const targetCount = game.user?.targets.size ?? 0;
   if (targetCount > 1) {
     warnIfMultipleTargets();
     return;
   }
-  if (targetCount === 0) {
-    return;
-  }
   const targetTokenUuid = game.user?.targets.first()?.document?.uuid;
-  if (!targetTokenUuid) {
+  if (targetCount === 0 || !targetTokenUuid) {
     return;
   }
 

--- a/src/data-model/shared/spell-schema-fields.ts
+++ b/src/data-model/shared/spell-schema-fields.ts
@@ -1,5 +1,10 @@
 import { rqidLinkSchemaField } from "./rqid-link-field";
-import { SpellConcentrationEnum, SpellDurationEnum, SpellRangeEnum } from "../item-data/spell";
+import {
+  SpellConcentrationEnum,
+  SpellDurationEnum,
+  SpellRangeEnum,
+  SpellResistanceCheckEnum,
+} from "../item-data/spell";
 import { enumChoices } from "./enum-choices";
 
 const { BooleanField, NumberField, StringField } = foundry.data.fields;
@@ -31,6 +36,12 @@ export function spellSchemaFields() {
     }),
     isRitual: new BooleanField({ nullable: false, initial: false }),
     isEnchantment: new BooleanField({ nullable: false, initial: false }),
+    resistanceCheck: new StringField({
+      blank: false,
+      nullable: false,
+      initial: SpellResistanceCheckEnum.None,
+      choices: enumChoices(SpellResistanceCheckEnum, "RQG.Item.Spell.ResistanceCheckEnum."),
+    }),
     descriptionRqidLink: rqidLinkSchemaField({ nullable: true }),
   } as const;
 }

--- a/src/foundry-ui/rqg-actor-directory.ts
+++ b/src/foundry-ui/rqg-actor-directory.ts
@@ -1,0 +1,38 @@
+import type { RqgContextMenuEntry } from "./rqg-context-menu";
+
+import ActorDirectory = foundry.applications.sidebar.tabs.ActorDirectory;
+import ContextMenu = foundry.applications.ux.ContextMenu;
+
+/**
+ * Actors sidebar with an extra GM-only "Request Resistance Roll" context-menu entry, so the GM
+ * can start a resistance request without a token on the scene or opening the actor sheet.
+ */
+export class RqgActorDirectory<
+  RenderContext extends ActorDirectory.RenderContext = ActorDirectory.RenderContext,
+  Configuration extends ActorDirectory.Configuration = ActorDirectory.Configuration,
+  RenderOptions extends ActorDirectory.RenderOptions = ActorDirectory.RenderOptions,
+> extends ActorDirectory<RenderContext, Configuration, RenderOptions> {
+  static init() {
+    CONFIG.ui.actors = RqgActorDirectory;
+  }
+
+  override _getEntryContextOptions(): ContextMenu.Entry<HTMLElement>[] {
+    const entries = super._getEntryContextOptions() as unknown as RqgContextMenuEntry[];
+    entries.push({
+      label: "RQG.Game.RequestResistanceRoll",
+      icon: '<i class="fa-solid fa-scale-unbalanced fa-fw"></i>',
+      visible: () => game.user?.isGM ?? false,
+      onClick: async (_event: Event, li: HTMLElement) => {
+        const actorId = li.dataset["entryId"];
+        const actor = actorId ? game.actors?.get(actorId) : undefined;
+        if (!actor?.uuid) {
+          return;
+        }
+        const { openResistanceRequest } =
+          await import("../applications/resistance-roll-dialog/open-resistance-request");
+        await openResistanceRequest(actor.uuid);
+      },
+    });
+    return entries as unknown as ContextMenu.Entry<HTMLElement>[];
+  }
+}

--- a/src/foundry-ui/rqg-actor-directory.ts
+++ b/src/foundry-ui/rqg-actor-directory.ts
@@ -3,10 +3,7 @@ import type { RqgContextMenuEntry } from "./rqg-context-menu";
 import ActorDirectory = foundry.applications.sidebar.tabs.ActorDirectory;
 import ContextMenu = foundry.applications.ux.ContextMenu;
 
-/**
- * Actors sidebar with an extra GM-only "Request Resistance Roll" context-menu entry, so the GM
- * can start a resistance request without a token on the scene or opening the actor sheet.
- */
+/** Actors sidebar plus a GM-only "Request Resistance Roll" context-menu entry. */
 export class RqgActorDirectory<
   RenderContext extends ActorDirectory.RenderContext = ActorDirectory.RenderContext,
   Configuration extends ActorDirectory.Configuration = ActorDirectory.Configuration,

--- a/src/foundry-ui/rqg-token-hud.ts
+++ b/src/foundry-ui/rqg-token-hud.ts
@@ -21,7 +21,7 @@ export class RqgTokenHud {
     }
 
     const label = localize("RQG.Game.RequestResistanceRoll");
-    // No data-action - AppV2 would warn about an unregistered handler; the click listener drives it.
+    // Injected via the render hook, so it drives its own click listener rather than the HUD's data-action map.
     const button = document.createElement("button");
     button.type = "button";
     button.className = "control-icon";

--- a/src/foundry-ui/rqg-token-hud.ts
+++ b/src/foundry-ui/rqg-token-hud.ts
@@ -1,0 +1,43 @@
+import { systemId } from "../system/config";
+import { localize } from "../system/util";
+
+/**
+ * Adds a GM-only "Request Resistance Roll" button to the Token HUD's left column, so the GM can
+ * start a resistance request straight from a token on the canvas. Hidden when the
+ * `showResistanceRequestTokenHudButton` client setting is off.
+ */
+export class RqgTokenHud {
+  static init() {
+    Hooks.on("renderTokenHUD", RqgTokenHud.onRenderTokenHUD);
+  }
+
+  private static onRenderTokenHUD(
+    hud: foundry.applications.hud.TokenHUD,
+    element: HTMLElement,
+  ): void {
+    if (!game.user?.isGM || !game.settings?.get(systemId, "showResistanceRequestTokenHudButton")) {
+      return;
+    }
+    const leftColumn = element.querySelector<HTMLElement>(".col.left");
+    const tokenUuid = hud.document?.uuid;
+    if (!leftColumn || !tokenUuid) {
+      return;
+    }
+
+    const label = localize("RQG.Game.RequestResistanceRoll");
+    // No data-action - AppV2 would warn about an unregistered handler; the click listener below
+    // drives it directly instead.
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "control-icon";
+    button.setAttribute("data-tooltip", label);
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<i class="fa-solid fa-scale-unbalanced" inert></i>';
+    button.addEventListener("click", async () => {
+      const { openResistanceRequest } =
+        await import("../applications/resistance-roll-dialog/open-resistance-request");
+      await openResistanceRequest(tokenUuid);
+    });
+    leftColumn.appendChild(button);
+  }
+}

--- a/src/foundry-ui/rqg-token-hud.ts
+++ b/src/foundry-ui/rqg-token-hud.ts
@@ -1,11 +1,7 @@
 import { systemId } from "../system/config";
 import { localize } from "../system/util";
 
-/**
- * Adds a GM-only "Request Resistance Roll" button to the Token HUD's left column, so the GM can
- * start a resistance request straight from a token on the canvas. Hidden when the
- * `showResistanceRequestTokenHudButton` client setting is off.
- */
+/** GM-only "Request Resistance Roll" button on the Token HUD, gated by a client setting. */
 export class RqgTokenHud {
   static init() {
     Hooks.on("renderTokenHUD", RqgTokenHud.onRenderTokenHUD);
@@ -25,8 +21,7 @@ export class RqgTokenHud {
     }
 
     const label = localize("RQG.Game.RequestResistanceRoll");
-    // No data-action - AppV2 would warn about an unregistered handler; the click listener below
-    // drives it directly instead.
+    // No data-action - AppV2 would warn about an unregistered handler; the click listener drives it.
     const button = document.createElement("button");
     button.type = "button";
     button.className = "control-icon";

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -33,6 +33,7 @@ import type { SpiritMagicDataModel } from "./data-model/item-data/spirit-magic-d
 import type { WeaponDataModel } from "./data-model/item-data/weapon-data-model";
 import type { CharacterDataModel } from "./data-model/actor-data/character-data-model";
 import type { CombatChatMessageData } from "./chat/data-model/combat-chat-message.data-model.ts";
+import type { ResistanceRequestChatMessageData } from "./chat/data-model/resistance-request-chat-message.data-model.ts";
 import type { Dice3D } from "./module-integrations/dice-so-nice";
 
 // Namespace imports for Foundry document types (from fvtt-types)
@@ -105,6 +106,7 @@ declare global {
     };
     ChatMessage: {
       combat: typeof CombatChatMessageData;
+      resistanceRequest: typeof ResistanceRequestChatMessageData;
     };
     RegionBehavior: {
       clickableScripts: typeof ClickableScriptsRegionBehavior;
@@ -150,6 +152,7 @@ declare global {
     "rqg.showActorActiveEffectsTab": boolean;
     "rqg.naturalHealingEnabled": boolean;
     "rqg.magicPointRecoveryEnabled": boolean;
+    "rqg.showResistanceRequestTokenHudButton": boolean;
   }
 
   interface ConfiguredCombatant {

--- a/src/items/rune-magic-item/rune-magic-sheet-v2-rune-magic.hbs
+++ b/src/items/rune-magic-item/rune-magic-sheet-v2-rune-magic.hbs
@@ -18,6 +18,11 @@
     <input type="checkbox" id="is-enchantment-{{id}}" name="system.isEnchantment" {{checked
       system.isEnchantment}}>
 
+    <label for="resistance-check-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistanceCheck"}}</label>
+    <select id="resistance-check-{{id}}" name="system.resistanceCheck">
+      {{selectOptions resistanceCheckOptions selected=system.resistanceCheck localize=true}}
+    </select>
+
     <label for="is-stackable-{{id}}">{{localize "RQG.Item.RuneMagic.Stackable"}}</label>
     <input type="checkbox" id="is-stackable-{{id}}" name="system.isStackable" {{checked system.isStackable}}>
 

--- a/src/items/rune-magic-item/rune-magic-sheet-v2.ts
+++ b/src/items/rune-magic-item/rune-magic-sheet-v2.ts
@@ -1,7 +1,7 @@
 import { ItemTypeEnum } from "@item-model/item-types.ts";
 import { getSelectRuneOptions, isDocumentSubType } from "../../system/util";
 import { RqgItemSheetV2, type RqgItemSheetContext } from "../rqg-item-sheet-v2";
-import { SpellDurationEnum, SpellRangeEnum } from "@item-model/spell.ts";
+import { SpellDurationEnum, SpellRangeEnum, SpellResistanceCheckEnum } from "@item-model/spell.ts";
 import { systemId } from "../../system/config";
 import { templatePaths } from "../../system/load-handlebars-templates";
 import type { CultItem } from "@item-model/cult-data-model.ts";
@@ -12,6 +12,7 @@ interface RuneMagicSheetContext extends RqgItemSheetContext {
   allRuneOptions: SelectOptionData<string>[];
   rangeOptions: SelectOptionData<SpellRangeEnum>[];
   durationOptions: SelectOptionData<SpellDurationEnum>[];
+  resistanceCheckOptions: SelectOptionData<SpellResistanceCheckEnum>[];
   actorCultOptions: SelectOptionData<string>[];
 }
 
@@ -57,6 +58,10 @@ export class RuneMagicSheetV2 extends RqgItemSheetV2 {
       durationOptions: Object.values(SpellDurationEnum).map((range) => ({
         value: range,
         label: "RQG.Item.Spell.DurationEnum." + (range || "undefined"),
+      })),
+      resistanceCheckOptions: Object.values(SpellResistanceCheckEnum).map((value) => ({
+        value: value,
+        label: "RQG.Item.Spell.ResistanceCheckEnum." + value,
       })),
       actorCultOptions: this.getActorCultOptions(),
       allRuneOptions: getSelectRuneOptions("RQG.Item.RuneMagic.AddRuneMagicRunePlaceholder"),

--- a/src/items/spirit-magic-item/spirit-magic-sheet-v2-spirit-magic.hbs
+++ b/src/items/spirit-magic-item/spirit-magic-sheet-v2-spirit-magic.hbs
@@ -28,6 +28,11 @@
     <label for="is-enchantment-{{id}}">{{localize "RQG.Item.Spell.Enchantment"}}</label>
     <input type="checkbox" id="is-enchantment-{{id}}" name="system.isEnchantment" {{checked system.isEnchantment}}>
 
+    <label for="resistance-check-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistanceCheck"}}</label>
+    <select id="resistance-check-{{id}}" name="system.resistanceCheck">
+      {{selectOptions resistanceCheckOptions selected=system.resistanceCheck localize=true}}
+    </select>
+
     <label for="is-matrix-{{id}}">{{localize "RQG.Item.SpiritMagic.MatrixQ"}}</label>
     <input type="checkbox" id="is-matrix-{{id}}" name="system.isMatrix" {{checked system.isMatrix}}>
 

--- a/src/items/spirit-magic-item/spirit-magic-sheet-v2.ts
+++ b/src/items/spirit-magic-item/spirit-magic-sheet-v2.ts
@@ -1,5 +1,10 @@
 import { RqgItemSheetV2, type RqgItemSheetContext } from "../rqg-item-sheet-v2";
-import { SpellConcentrationEnum, SpellDurationEnum, SpellRangeEnum } from "@item-model/spell.ts";
+import {
+  SpellConcentrationEnum,
+  SpellDurationEnum,
+  SpellRangeEnum,
+  SpellResistanceCheckEnum,
+} from "@item-model/spell.ts";
 import { systemId } from "../../system/config";
 import { templatePaths } from "../../system/load-handlebars-templates";
 import type { SpiritMagicItem } from "@item-model/spirit-magic-data-model.ts";
@@ -8,6 +13,7 @@ interface SpiritMagicSheetContext extends RqgItemSheetContext {
   rangeOptions: SelectOptionData<SpellRangeEnum>[];
   durationOptions: SelectOptionData<SpellDurationEnum>[];
   concentrationOptions: SelectOptionData<SpellConcentrationEnum>[];
+  resistanceCheckOptions: SelectOptionData<SpellResistanceCheckEnum>[];
 }
 
 export class SpiritMagicSheetV2 extends RqgItemSheetV2 {
@@ -56,6 +62,10 @@ export class SpiritMagicSheetV2 extends RqgItemSheetV2 {
       concentrationOptions: Object.values(SpellConcentrationEnum).map((range) => ({
         value: range,
         label: "RQG.Item.Spell.ConcentrationEnum." + (range || "undefined"),
+      })),
+      resistanceCheckOptions: Object.values(SpellResistanceCheckEnum).map((value) => ({
+        value: value,
+        label: "RQG.Item.Spell.ResistanceCheckEnum." + value,
       })),
     };
 

--- a/src/rolls/resistance-roll/resistance-roll-flavor.ts
+++ b/src/rolls/resistance-roll/resistance-roll-flavor.ts
@@ -1,0 +1,19 @@
+import { localize } from "../../system/util";
+
+/**
+ * The "opposes X" / "active vs passive" / "Resistance Roll" header markup, shared between an
+ * actual ResistanceRoll's flavor and a resistance-request chat card's flavor, so both look the
+ * same whether the roll happened directly or via a GM request.
+ */
+export function buildResistanceRollFlavor(
+  activeLabel: string,
+  passiveLabel: string,
+  passiveActorName?: string,
+): string {
+  const resistanceTranslation = localize("RQG.Roll.ResistanceRoll.Title");
+  const opposesLine = passiveActorName
+    ? `<span>${localize("RQG.Roll.ResistanceRoll.Opposes", { targetName: `<b>${passiveActorName}</b>` })}</span><br>`
+    : "";
+  return `${opposesLine}<span class="roll-action">${activeLabel} ${localize("RQG.Roll.ResistanceRoll.Vs")} ${passiveLabel}</span>
+          <span>${resistanceTranslation}</span><br>`;
+}

--- a/src/rolls/resistance-roll/resistance-roll-flavor.ts
+++ b/src/rolls/resistance-roll/resistance-roll-flavor.ts
@@ -1,10 +1,6 @@
 import { localize } from "../../system/util";
 
-/**
- * The "opposes X" / "active vs passive" / "Resistance Roll" header markup, shared between an
- * actual ResistanceRoll's flavor and a resistance-request chat card's flavor, so both look the
- * same whether the roll happened directly or via a GM request.
- */
+/** Shared flavor markup for a resistance roll and a resistance-request card. */
 export function buildResistanceRollFlavor(
   activeLabel: string,
   passiveLabel: string,

--- a/src/rolls/resistance-roll/resistance-roll-formula.test.ts
+++ b/src/rolls/resistance-roll/resistance-roll-formula.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { computeResistanceTargetChance } from "./resistance-roll-formula";
+
+// Core rulebook: "General Use" text on p.146, Resistance Table on p.147.
+describe("computeResistanceTargetChance", () => {
+  describe("equal and opposed characteristic values", () => {
+    it("is 50% when the active equals the passive", () => {
+      expect(computeResistanceTargetChance(1, 1)).toBe(50);
+      expect(computeResistanceTargetChance(10, 10)).toBe(50);
+      expect(computeResistanceTargetChance(21, 21)).toBe(50);
+    });
+
+    it("gains 5% for every point the active is above the passive", () => {
+      expect(computeResistanceTargetChance(11, 10)).toBe(55);
+      expect(computeResistanceTargetChance(15, 10)).toBe(75);
+      expect(computeResistanceTargetChance(19, 10)).toBe(95);
+    });
+
+    it("loses 5% for every point the active is below the passive", () => {
+      expect(computeResistanceTargetChance(10, 11)).toBe(45);
+      expect(computeResistanceTargetChance(10, 15)).toBe(25);
+      expect(computeResistanceTargetChance(10, 19)).toBe(5);
+    });
+
+    it("is not clamped to 0-100 - the 1-5/96-00 rule is a roll-time concern, not the target%", () => {
+      expect(computeResistanceTargetChance(20, 1)).toBe(145);
+      expect(computeResistanceTargetChance(1, 11)).toBe(0);
+      expect(computeResistanceTargetChance(1, 21)).toBe(-50);
+    });
+  });
+
+  describe("modifiers", () => {
+    it("applies no modifier by default", () => {
+      expect(computeResistanceTargetChance(12, 10)).toBe(60);
+    });
+
+    it("adds a positive modifier (augment / Meditate)", () => {
+      expect(computeResistanceTargetChance(10, 10, [20])).toBe(70);
+    });
+
+    it("subtracts a negative modifier (failed augment)", () => {
+      expect(computeResistanceTargetChance(10, 10, [-20])).toBe(30);
+    });
+
+    it("sums several modifiers with the characteristic difference", () => {
+      // 50 + (10 - 12) * 5 + (20 + 15 - 5)
+      expect(computeResistanceTargetChance(10, 12, [20, 15, -5])).toBe(70);
+    });
+
+    it("treats a non-finite modifier entry as 0", () => {
+      expect(computeResistanceTargetChance(10, 10, [Number.NaN, 10])).toBe(60);
+    });
+  });
+
+  describe("fractional inputs round the target% up, toward the active side", () => {
+    it("rounds a fractional gain up", () => {
+      expect(computeResistanceTargetChance(10, 10, [2.5])).toBe(53);
+    });
+
+    it("rounds a fractional penalty up (a smaller penalty than the raw value)", () => {
+      expect(computeResistanceTargetChance(10, 10, [-2.5])).toBe(48);
+    });
+
+    it("rounds a fractional characteristic difference up", () => {
+      expect(computeResistanceTargetChance(10.5, 10)).toBe(53);
+    });
+
+    it("leaves an already-whole result alone", () => {
+      expect(computeResistanceTargetChance(10, 10, [1.5, 0.5])).toBe(52);
+    });
+  });
+
+  describe("agrees with the printed Resistance Table (Core p.147)", () => {
+    // Transcribed row by row as printed: line index = passive 1..21, entry index = active 1..21.
+    // "-" is the table's "—" dash (no positive chance; the active side can still only make it on a 1-5).
+    const printedRows = [
+      "50 55 60 65 70 75 80 85 90 95 100 105 110 115 120 125 130 135 140 145 150",
+      "45 50 55 60 65 70 75 80 85 90 95 100 105 110 115 120 125 130 135 140 145",
+      "40 45 50 55 60 65 70 75 80 85 90 95 100 105 110 115 120 125 130 135 140",
+      "35 40 45 50 55 60 65 70 75 80 85 90 95 100 105 110 115 120 125 130 135",
+      "30 35 40 45 50 55 60 65 70 75 80 85 90 95 100 105 110 115 120 125 130",
+      "25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 100 105 110 115 120 125",
+      "20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 100 105 110 115 120",
+      "15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 100 105 110 115",
+      "10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 100 105 110",
+      "5 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 100 105",
+      "- 5 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 100",
+      "- - 5 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95",
+      "- - - 5 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90",
+      "- - - - 5 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85",
+      "- - - - - 5 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80",
+      "- - - - - - 5 10 15 20 25 30 35 40 45 50 55 60 65 70 75",
+      "- - - - - - - 5 10 15 20 25 30 35 40 45 50 55 60 65 70",
+      "- - - - - - - - 5 10 15 20 25 30 35 40 45 50 55 60 65",
+      "- - - - - - - - - 5 10 15 20 25 30 35 40 45 50 55 60",
+      "- - - - - - - - - - 5 10 15 20 25 30 35 40 45 50 55",
+      "- - - - - - - - - - - 5 10 15 20 25 30 35 40 45 50",
+    ];
+
+    printedRows.forEach((printedRow, rowIndex) => {
+      const passive = rowIndex + 1;
+      it(`reproduces every active 1-21 vs passive ${passive} cell`, () => {
+        const expected = printedRow.split(" ").map((cell) => (cell === "-" ? null : Number(cell)));
+        const actual = expected.map((_, colIndex) => {
+          const chance = computeResistanceTargetChance(colIndex + 1, passive);
+          return chance > 0 ? chance : null;
+        });
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
+
+  describe("matches the worked examples in the rulebook text", () => {
+    it("Vasana's Demoralize: POW 15 vs POW 14 is 55% (p.146)", () => {
+      expect(computeResistanceTargetChance(15, 14)).toBe(55);
+    });
+
+    it("Vasana's Demoralize with a +15% Meditate bonus is 70% (p.146)", () => {
+      expect(computeResistanceTargetChance(15, 14, [15])).toBe(70);
+    });
+
+    it("Sorala vs the gas: CON 11 vs POT 8 is 65%, leaving the gas a 35% chance (p.147)", () => {
+      const soralaChance = computeResistanceTargetChance(11, 8);
+      expect(soralaChance).toBe(65);
+      expect(100 - soralaChance).toBe(35);
+    });
+  });
+});

--- a/src/rolls/resistance-roll/resistance-roll-formula.ts
+++ b/src/rolls/resistance-roll/resistance-roll-formula.ts
@@ -1,9 +1,4 @@
-/**
- * The resistance-table formula (core rulebook p.145-147): active vs passive characteristic (or
- * sum of characteristics), plus any modifiers, folded into a single d100 target%. Shared by
- * `ResistanceRoll.targetChance` and every dialog's live target-% preview, so a future RAW tweak
- * only needs to change one place.
- */
+/** The resistance-table formula (p.145-147): active vs passive + modifiers, as a d100 target%. */
 export function computeResistanceTargetChance(
   activeValue: number,
   passiveValue: number,

--- a/src/rolls/resistance-roll/resistance-roll-formula.ts
+++ b/src/rolls/resistance-roll/resistance-roll-formula.ts
@@ -1,0 +1,14 @@
+/**
+ * The resistance-table formula (core rulebook p.145-147): active vs passive characteristic (or
+ * sum of characteristics), plus any modifiers, folded into a single d100 target%. Shared by
+ * `ResistanceRoll.targetChance` and every dialog's live target-% preview, so a future RAW tweak
+ * only needs to change one place.
+ */
+export function computeResistanceTargetChance(
+  activeValue: number,
+  passiveValue: number,
+  modifierValues: number[] = [],
+): number {
+  const modifiersSum = modifierValues.reduce((sum, value) => sum + (Number(value) || 0), 0);
+  return Math.ceil(50 + (activeValue - passiveValue) * 5 + modifiersSum);
+}

--- a/src/rolls/resistance-roll/resistance-roll-tooltip.hbs
+++ b/src/rolls/resistance-roll/resistance-roll-tooltip.hbs
@@ -1,0 +1,7 @@
+<div class="dice-tooltip" data-only-owner-visible-uuid="{{speakerUuid}}">
+  <b>{{activeValue}}</b><sub><i>{{activeLabel}}</i></sub> {{localize "RQG.Roll.ResistanceRoll.Vs"}}
+  <b>{{passiveValue}}</b><sub><i>{{passiveLabel}}</i></sub>
+  {{#each modifiers}}
+    <b>{{value}}</b><sub><i>{{description}}</i></sub>
+  {{/each}}
+</div>

--- a/src/rolls/resistance-roll/resistance-roll.hbs
+++ b/src/rolls/resistance-roll/resistance-roll.hbs
@@ -1,0 +1,14 @@
+<div class="dice-roll">
+  <div class="dice-result">
+    <div class="dice-total success-level-{{successLevel}}">
+      {{#if successLevelText}}
+        <div class="outcome">{{successLevelText}}</div>
+      {{/if}}
+      <div data-tooltip="1d100"><i class="fa-solid fa-dice"></i>{{total}}</div>
+      {{#if target}}
+        <div class="target" data-only-owner-visible-uuid="{{speakerUuid}}"><i class="fa-solid fa-bullseye"></i> {{target}}%</div>
+      {{/if}}
+    </div>
+  </div>
+  {{{tooltip}}}
+</div>

--- a/src/rolls/resistance-roll/resistance-roll.hbs
+++ b/src/rolls/resistance-roll/resistance-roll.hbs
@@ -5,7 +5,7 @@
         <div class="outcome">{{successLevelText}}</div>
       {{/if}}
       <div data-tooltip="1d100"><i class="fa-solid fa-dice"></i>{{total}}</div>
-      {{#if target}}
+      {{#if showTarget}}
         <div class="target" data-only-owner-visible-uuid="{{speakerUuid}}"><i class="fa-solid fa-bullseye"></i> {{target}}%</div>
       {{/if}}
     </div>

--- a/src/rolls/resistance-roll/resistance-roll.ts
+++ b/src/rolls/resistance-roll/resistance-roll.ts
@@ -9,11 +9,7 @@ import type { AnyObject, EmptyObject } from "fvtt-types/utils";
 
 import Roll = foundry.dice.Roll;
 
-/**
- * A roll on the Resistance Table (RQG core rulebook p.145-147): active vs passive characteristic
- * (or sum of characteristics) folded into a single d100 target%, resolved with the same
- * success-band mechanic as skill/characteristic rolls.
- */
+/** A roll on the RQG Resistance Table (p.145-147): active vs passive characteristic as a d100 target%. */
 export class ResistanceRoll<D extends AnyObject = EmptyObject> extends Roll<D> {
   declare options: ResistanceRollOptions;
 
@@ -93,9 +89,7 @@ export class ResistanceRoll<D extends AnyObject = EmptyObject> extends Roll<D> {
     });
   }
 
-  // Html for what the roll is about. A small "opposes <name>" line (mirroring the attack chat
-  // card's "attacks <name>") comes first when the passive side came from a targeted actor, then
-  // the bold "active vs passive" header naming the characteristic(s) rolled.
+  // Html for what the roll is about
   get flavor(): string {
     return buildResistanceRollFlavor(
       this.options.activeLabel,

--- a/src/rolls/resistance-roll/resistance-roll.ts
+++ b/src/rolls/resistance-roll/resistance-roll.ts
@@ -64,6 +64,7 @@ export class ResistanceRoll<D extends AnyObject = EmptyObject> extends Roll<D> {
       tooltip: isPrivate ? "" : await this.getTooltip(),
       total: isPrivate ? "??" : Math.round(this.total! * 100) / 100,
       target: isPrivate ? undefined : this.targetChance,
+      showTarget: !isPrivate,
       successLevel: isPrivate ? "private" : this.successLevel,
       successLevelText: isPrivate
         ? undefined

--- a/src/rolls/resistance-roll/resistance-roll.ts
+++ b/src/rolls/resistance-roll/resistance-roll.ts
@@ -1,0 +1,106 @@
+import { activateChatTab, isTruthy, localize, toSignedString } from "../../system/util";
+import { templatePaths } from "../../system/load-handlebars-templates";
+import { calculateAbilitySuccessLevel } from "../ability-roll/calculate-ability-success-level";
+import { AbilitySuccessLevelEnum } from "../ability-roll/ability-roll.defs";
+import type { ResistanceRollOptions } from "./resistance-roll.types.ts";
+import { buildResistanceRollFlavor } from "./resistance-roll-flavor.ts";
+import { computeResistanceTargetChance } from "./resistance-roll-formula.ts";
+import type { AnyObject, EmptyObject } from "fvtt-types/utils";
+
+import Roll = foundry.dice.Roll;
+
+/**
+ * A roll on the Resistance Table (RQG core rulebook p.145-147): active vs passive characteristic
+ * (or sum of characteristics) folded into a single d100 target%, resolved with the same
+ * success-band mechanic as skill/characteristic rolls.
+ */
+export class ResistanceRoll<D extends AnyObject = EmptyObject> extends Roll<D> {
+  declare options: ResistanceRollOptions;
+
+  public static async rollAndShow(options: ResistanceRollOptions) {
+    const roll = new ResistanceRoll(undefined, {}, options);
+    await roll.evaluate();
+    activateChatTab();
+    const msg = await roll.toMessage({ flavor: roll.flavor, speaker: options.speaker }, {
+      messageMode: options.rollMode,
+      create: true,
+    } as unknown as Record<string, unknown>);
+
+    if (msg?.id != null) {
+      await game.dice3d?.waitFor3DAnimationByMessageID(msg.id);
+    }
+    return roll;
+  }
+
+  constructor(formula: string = "1d100", data?: D, options?: ResistanceRollOptions) {
+    super(formula, data, options);
+  }
+
+  get isEvaluated(): boolean {
+    return this._evaluated;
+  }
+
+  get targetChance(): number {
+    const modifierValues = this.options?.modifiers?.map((mod) => mod?.value) ?? [];
+    return computeResistanceTargetChance(
+      this.options.activeValue,
+      this.options.passiveValue,
+      modifierValues,
+    );
+  }
+
+  get successLevel(): AbilitySuccessLevelEnum | undefined {
+    if (!this._evaluated || this.total == null) {
+      return undefined;
+    }
+    return calculateAbilitySuccessLevel(this.targetChance, this.total);
+  }
+
+  // Html for the "content" of the chat-message
+  override async render({ flavor = this.flavor, isPrivate = false } = {}) {
+    if (!this._evaluated) {
+      await this.evaluate();
+    }
+    const chatData = {
+      formula: isPrivate ? "???" : this._formula,
+      flavor: isPrivate ? null : flavor,
+      user: game.user!.id,
+      tooltip: isPrivate ? "" : await this.getTooltip(),
+      total: isPrivate ? "??" : Math.round(this.total! * 100) / 100,
+      target: isPrivate ? undefined : this.targetChance,
+      successLevel: isPrivate ? "private" : this.successLevel,
+      successLevelText: isPrivate
+        ? undefined
+        : localize(`RQG.Game.AbilityResultEnum.${this.successLevel}`),
+      speakerUuid: ChatMessage.getSpeakerActor(this.options.speaker)?.uuid, // Used for hiding parts
+    };
+    return foundry.applications.handlebars.renderTemplate(templatePaths.resistanceRoll, chatData);
+  }
+
+  // Html for what modifiers are applied
+  override async getTooltip(): Promise<string> {
+    const modifiers = this.options.modifiers ?? [];
+    const nonzeroSignedModifiers = modifiers
+      .filter((m) => isTruthy(m.value))
+      .map((m) => ({ ...m, value: toSignedString(Number(m.value)) }));
+    return foundry.applications.handlebars.renderTemplate(templatePaths.resistanceRollTooltip, {
+      activeLabel: this.options.activeLabel,
+      activeValue: this.options.activeValue,
+      passiveLabel: this.options.passiveLabel,
+      passiveValue: this.options.passiveValue,
+      modifiers: nonzeroSignedModifiers,
+      speakerUuid: ChatMessage.getSpeakerActor(this.options.speaker)?.uuid, // Used for hiding parts
+    });
+  }
+
+  // Html for what the roll is about. A small "opposes <name>" line (mirroring the attack chat
+  // card's "attacks <name>") comes first when the passive side came from a targeted actor, then
+  // the bold "active vs passive" header naming the characteristic(s) rolled.
+  get flavor(): string {
+    return buildResistanceRollFlavor(
+      this.options.activeLabel,
+      this.options.passiveLabel,
+      this.options.passiveActorName,
+    );
+  }
+}

--- a/src/rolls/resistance-roll/resistance-roll.types.ts
+++ b/src/rolls/resistance-roll/resistance-roll.types.ts
@@ -1,0 +1,13 @@
+export type Modifier = { description: string; value: number };
+
+export type ResistanceRollOptions = Partial<foundry.dice.terms.DiceTerm.EvaluationOptions> & {
+  activeValue: number;
+  activeLabel: string;
+  passiveValue: number;
+  passiveLabel: string;
+  /** Name of the actor the passive value was drawn from, if any (not set for a manual value). */
+  passiveActorName?: string;
+  modifiers?: Modifier[];
+  speaker?: ChatMessage.SpeakerData;
+  rollMode?: foundry.dice.Roll.Mode;
+};

--- a/src/rolls/resistance-roll/resistance-roll.types.ts
+++ b/src/rolls/resistance-roll/resistance-roll.types.ts
@@ -5,7 +5,7 @@ export type ResistanceRollOptions = Partial<foundry.dice.terms.DiceTerm.Evaluati
   activeLabel: string;
   passiveValue: number;
   passiveLabel: string;
-  /** Name of the actor the passive value was drawn from, if any (not set for a manual value). */
+  /** Actor the passive value came from, if any (unset for a manual value). */
   passiveActorName?: string;
   modifiers?: Modifier[];
   speaker?: ChatMessage.SpeakerData;

--- a/src/rqg.css
+++ b/src/rqg.css
@@ -910,6 +910,11 @@
         & .context-icon-img {
           height: 16pt;
         }
+
+        & .context-icon-fa {
+          font-size: 16pt;
+          color: white;
+        }
       }
     }
 
@@ -972,6 +977,10 @@
       & button:disabled {
         color: var(--color-text-dark-inactive);
         cursor: progress;
+      }
+
+      & button.resistance-request-roll {
+        width: 100%;
       }
     }
 
@@ -1936,6 +1945,12 @@
       color: var(--color-level-error);
       border: 1px solid var(--color-level-error);
       background-color: transparent;
+    }
+  }
+
+  .rqg.form.roll-dialog.resistance-request-dialog {
+    & .scrollable > * + * {
+      margin-top: 0.6rem;
     }
   }
 

--- a/src/rqg.css
+++ b/src/rqg.css
@@ -1948,7 +1948,8 @@
     }
   }
 
-  .rqg.form.roll-dialog.resistance-request-dialog {
+  .rqg.form.roll-dialog.resistance-request-dialog,
+  .rqg.form.roll-dialog.resistance-roll-dialog {
     & .scrollable > * + * {
       margin-top: 0.6rem;
     }

--- a/src/rqg.css
+++ b/src/rqg.css
@@ -910,11 +910,6 @@
         & .context-icon-img {
           height: 16pt;
         }
-
-        & .context-icon-fa {
-          font-size: 16pt;
-          color: white;
-        }
       }
     }
 

--- a/src/rqg.css
+++ b/src/rqg.css
@@ -1953,6 +1953,14 @@
     & .scrollable > * + * {
       margin-top: 0.6rem;
     }
+
+    /* Read-only value cells and the "N %" wrapper share the input row height so the
+       characteristic/modifier rows line up in one grid. */
+    & .key-value-grid > div {
+      display: flex;
+      align-items: center;
+      min-height: var(--input-height);
+    }
   }
 
   #tooltip.chance-breakdown-tooltip,

--- a/src/rqg.ts
+++ b/src/rqg.ts
@@ -15,6 +15,8 @@ import { nameGeneration } from "./system/api/name-generation.js";
 import { openDataModelRepairDialog } from "./system/api/data-model-repair";
 import { Rqid } from "./system/api/rqid-api.js";
 import { RqgHotbar } from "./foundry-ui/rqg-hotbar";
+import { RqgActorDirectory } from "./foundry-ui/rqg-actor-directory";
+import { RqgTokenHud } from "./foundry-ui/rqg-token-hud";
 import { TextEditorHooks } from "./foundry-ui/text-editor-hooks";
 import { RqgJournalEntry } from "./journals/rqg-journal-entry";
 import { getTokenStatusEffects } from "./system/token-status-effects";
@@ -31,6 +33,7 @@ import { SpiritMagicRoll } from "./rolls/spirit-magic-roll/spirit-magic-roll";
 import { RuneMagicRoll } from "./rolls/rune-magic-roll/rune-magic-roll";
 import { HitLocationRoll } from "./rolls/hit-location-roll/hit-location-roll";
 import { DamageRoll } from "./rolls/damage-roll/damage-roll";
+import { ResistanceRoll } from "./rolls/resistance-roll/resistance-roll";
 import { RqgRollTableSheet } from "./roll-tables/rqg-roll-table-sheet";
 import { RqgTokenRuler } from "./combat/rqg-token-ruler";
 import { ClickableScriptsRegionBehavior } from "./scene/clickable-scripts-region-behavior";
@@ -92,6 +95,7 @@ Hooks.once("init", () => {
     RuneMagicRoll,
     HitLocationRoll,
     DamageRoll,
+    ResistanceRoll,
   ];
 
   Rqid.init();
@@ -105,6 +109,8 @@ Hooks.once("init", () => {
   initCharacterPassiveRecovery();
   RqgItem.init();
   RqgHotbar.init();
+  RqgActorDirectory.init();
+  RqgTokenHud.init();
   RqgJournalEntry.init();
   TextEditorHooks.init();
   RqgSettings.init();

--- a/src/system/load-handlebars-templates.ts
+++ b/src/system/load-handlebars-templates.ts
@@ -81,6 +81,8 @@ export const templatePaths = {
   characteristicRollTooltip:
     "systems/rqg/rolls/characteristic-roll/characteristic-roll-tooltip.hbs",
   characteristicRoll: "systems/rqg/rolls/characteristic-roll/characteristic-roll.hbs",
+  resistanceRollTooltip: "systems/rqg/rolls/resistance-roll/resistance-roll-tooltip.hbs",
+  resistanceRoll: "systems/rqg/rolls/resistance-roll/resistance-roll.hbs",
   hitLocationRoll: "systems/rqg/rolls/hit-location-roll/hit-location-roll.hbs",
   hitLocationTooltip: "systems/rqg/rolls/hit-location-roll/hit-location-roll-tooltip.hbs",
   spiritMagicRollTooltip: "systems/rqg/rolls/spirit-magic-roll/spirit-magic-roll-tooltip.hbs",
@@ -96,6 +98,7 @@ export const templatePaths = {
   // Chat
   chatMessage: "systems/rqg/chat/chat-message.hbs",
   attackChatMessage: "systems/rqg/applications/attack-flow/attack-chat-template.hbs",
+  resistanceRequestChatMessage: "systems/rqg/chat/resistance-request-chat-template.hbs",
 
   rqidTooltip: "systems/rqg/documents/rqid-tooltip.hbs",
 
@@ -137,6 +140,14 @@ export const templatePaths = {
   abilityRollDialogV2: "systems/rqg/applications/ability-roll-dialog/ability-roll-dialog-v2.hbs",
   characteristicRollDialogV2:
     "systems/rqg/applications/characteristic-roll-dialog/characteristic-roll-dialog-v2.hbs",
+  resistanceRollDialogV2:
+    "systems/rqg/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs",
+  resistanceRequestDialogV2:
+    "systems/rqg/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs",
+  resistanceRequestFooter:
+    "systems/rqg/applications/resistance-roll-dialog/resistance-request-footer.hbs",
+  respondToResistanceRequestDialogV2:
+    "systems/rqg/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.hbs",
   spiritMagicRollDialogV2:
     "systems/rqg/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-v2.hbs",
   runeMagicRollDialogV2:

--- a/src/system/rqg-system-settings.ts
+++ b/src/system/rqg-system-settings.ts
@@ -157,6 +157,15 @@ export const registerRqgSystemSettings = function () {
     default: true,
   });
 
+  game.settings?.register(systemId, "showResistanceRequestTokenHudButton", {
+    name: "RQG.Settings.ShowResistanceRequestTokenHudButton.settingName",
+    hint: "RQG.Settings.ShowResistanceRequestTokenHudButton.settingHint",
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
+
   game.settings?.register(systemId, "actor-wizard-feature-flag", {
     name: "Feature Flag: Enable Actor Wizard",
     hint: "For RnD use only",

--- a/src/system/util.ts
+++ b/src/system/util.ts
@@ -974,3 +974,12 @@ export function getActorLinkDecoration(actor: RqgActor | Actor | null | undefine
     return "";
   }
 }
+
+/**
+ * Warn the user if more than one token is targeted where a dialog can only sensibly use one.
+ */
+export function warnIfMultipleTargets(): void {
+  if ((game.user?.targets.size ?? 0) > 1) {
+    ui.notifications?.info("Please target one token only");
+  }
+}

--- a/src/system/util.ts
+++ b/src/system/util.ts
@@ -975,9 +975,6 @@ export function getActorLinkDecoration(actor: RqgActor | Actor | null | undefine
   }
 }
 
-/**
- * Warn the user if more than one token is targeted where a dialog can only sensibly use one.
- */
 export function warnIfMultipleTargets(): void {
   if ((game.user?.targets.size ?? 0) > 1) {
     ui.notifications?.info("Please target one token only");

--- a/src/system/util.ts
+++ b/src/system/util.ts
@@ -977,6 +977,6 @@ export function getActorLinkDecoration(actor: RqgActor | Actor | null | undefine
 
 export function warnIfMultipleTargets(): void {
   if ((game.user?.targets.size ?? 0) > 1) {
-    ui.notifications?.info("Please target one token only");
+    ui.notifications?.info(localize("RQG.Notification.Warn.TargetOneTokenOnly"));
   }
 }

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -605,7 +605,8 @@
       },
       "ResistanceRequest": {
         "Title": "Request Resistance Roll",
-        "ModifierDefaults": "Modifier defaults (recipient may change)",
+        "SituationalModifier": "Situational modifier",
+        "SituationalModifierHint": "Sent to the roller as a starting Other modifier. They pick their own Augment and Meditate when they roll.",
         "SendRequest": "Send Request"
       },
       "SpiritMagicRoll": {

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -611,7 +611,7 @@
       "ResistanceRequest": {
         "Title": "Request Resistance Roll",
         "SituationalModifier": "Situational modifier",
-        "SituationalModifierHint": "Sent to the roller as a starting Other modifier. They pick their own Augment and Meditate when they roll.",
+        "SituationalModifierHint": "Sent to the Active side as a starting Other modifier. They pick their own Augment and Meditate when they roll.",
         "SendRequest": "Send Request"
       },
       "SpiritMagicRoll": {

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -605,7 +605,9 @@
         "ManualLabel": "Characteristic",
         "ManualLabelPlaceholder": "POT, STR, SIZ, POW…",
         "ManualValue": "Value",
-        "ManualHint": "Stand-in for something with no sheet — e.g. a poison's POT."
+        "ManualHint": "Stand-in for something with no sheet — e.g. a poison's POT.",
+        "ModifiersLegend": "Active modifiers",
+        "ModifiersHint": "Augment and Meditate are the rolling character's own; the last field is a situational adjustment. All raise the success chance."
       },
       "ResistanceRequest": {
         "Title": "Request Resistance Roll",

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -606,8 +606,7 @@
         "ManualLabelPlaceholder": "POT, STR, SIZ, POW…",
         "ManualValue": "Value",
         "ManualHint": "Stand-in for something with no sheet — e.g. a poison's POT.",
-        "ModifiersLegend": "Active modifiers",
-        "ModifiersHint": "Augment and Meditate are the rolling character's own; the last field is a situational adjustment. All raise the success chance."
+        "ModifiersLegend": "Active modifiers"
       },
       "ResistanceRequest": {
         "Title": "Request Resistance Roll",

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -1543,7 +1543,7 @@
         "settingHint": "If enabled, a GM-only Active Effects debug tab is shown on the actor sheet."
       },
       "ShowResistanceRequestTokenHudButton": {
-        "settingName": "Resistance Request Button on Token HUD",
+        "settingName": "Resistance Request on Token HUD",
         "settingHint": "If enabled, GMs get a 'Request Resistance Roll' button on the Token HUD to start a resistance request straight from a token on the canvas."
       },
       "TokenRulerSettings": {

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -21,7 +21,8 @@
       "character": "Character"
     },
     "ChatMessage": {
-      "combat": "Combat"
+      "combat": "Combat",
+      "resistanceRequest": "Resistance Request"
     },
     "RegionBehavior": {
       "clickableScripts": "Click to Execute Script"
@@ -511,6 +512,9 @@
         "AttackerFumble": "Attacker Fumble",
         "DefenderFumble": "Defender Fumble",
         "ApplyNaturalWeaponDamageNotImplemented": "Automatically applying damage to natural weapons is not supported yet.<br>Please manually add {weaponDamage} damage to the appropriate hit location, AP is not subtracted from {weaponDamage}.<br>Then close this notification."
+      },
+      "ResistanceRequest": {
+        "Roll": "Roll"
       }
     },
     "Dialog": {
@@ -588,6 +592,22 @@
           "6": "Very simple action (*6)"
         }
       },
+      "ResistanceRoll": {
+        "Title": "Resistance Roll",
+        "Active": "Active",
+        "Passive": "Passive",
+        "TokenOrActor": "Token/Actor",
+        "SourceManual": "Manual value...",
+        "Characteristic": "Characteristic",
+        "ManualName": "Name",
+        "ManualLabel": "Label",
+        "ManualValue": "Value"
+      },
+      "ResistanceRequest": {
+        "Title": "Request Resistance Roll",
+        "ModifierDefaults": "Modifier defaults (recipient may change)",
+        "SendRequest": "Send Request"
+      },
       "SpiritMagicRoll": {
         "Title": "Cast Spirit Magic",
         "LevelUsed": "Level",
@@ -648,6 +668,7 @@
         "TargetedToken": "targeted token",
         "Tokens": "tokens",
         "Actors": "actors",
+        "Other": "other",
         "AugmentOptions": {
           "None": "None",
           "CriticalSuccess": "Critical Success +50%",
@@ -1098,6 +1119,11 @@
         "Points": "Points",
         "Ritual": "Ritual",
         "Enchantment": "Enchantment",
+        "ResistanceCheck": "Resistance Check",
+        "ResistanceCheckEnum": {
+          "none": "None",
+          "single": "Single target (POW vs POW)"
+        },
         "DurationEnum": {
           "undefined": "None",
           "instant": "Instant",
@@ -1218,6 +1244,11 @@
           "6": "very simple action"
         }
       },
+      "ResistanceRoll": {
+        "Title": "Resistance Roll",
+        "Vs": "vs",
+        "Opposes": "opposes {targetName}"
+      },
       "HitLocationRoll": {
         "FallbackHitLocationName": "Hit Location"
       },
@@ -1322,6 +1353,7 @@
       "RollCharacteristicQuick": "Direct Roll *5 (dbl click)",
       "RollTitle": "Roll via Dialog (click), Direct Roll (dbl click)",
       "InitiateCombat": "Initiate combat",
+      "RequestResistanceRoll": "Request Resistance Roll",
       "WeaponUsage": {
         "oneHand": "1H",
         "offHand": "offH",
@@ -1504,6 +1536,10 @@
       "ShowActorActiveEffectsTab": {
         "settingName": "Show Actor Active Effects Tab",
         "settingHint": "If enabled, a GM-only Active Effects debug tab is shown on the actor sheet."
+      },
+      "ShowResistanceRequestTokenHudButton": {
+        "settingName": "Resistance Request Button on Token HUD",
+        "settingHint": "If enabled, GMs get a 'Request Resistance Roll' button on the Token HUD to start a resistance request straight from a token on the canvas."
       },
       "TokenRulerSettings": {
         "dialogTitle": "Token Ruler Settings",

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -599,9 +599,13 @@
         "TokenOrActor": "Token/Actor",
         "SourceManual": "Manual value...",
         "Characteristic": "Characteristic",
+        "Potency": "POT",
         "ManualName": "Name",
-        "ManualLabel": "Label",
-        "ManualValue": "Value"
+        "ManualNamePlaceholder": "Poison, disease, trap…",
+        "ManualLabel": "Characteristic",
+        "ManualLabelPlaceholder": "POT, STR, SIZ, POW…",
+        "ManualValue": "Value",
+        "ManualHint": "Stand-in for something with no sheet — e.g. a poison's POT."
       },
       "ResistanceRequest": {
         "Title": "Request Resistance Roll",

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -1478,12 +1478,14 @@
     },
     "Notification": {
       "Error": {
-        "GMOnlyOperation": "This operation is only allowed for GMs"
+        "GMOnlyOperation": "This operation is only allowed for GMs",
+        "ResistanceRequestTargetNotFound": "Could not find who this resistance request is for."
       },
       "Warn": {
         "NameGenRqidNotSupported": "Name Generation: The RQG System ID \"{rqid}\" is not supported for name generation.",
         "NameGenRqidNotFound": "Name Generation: The RQG System ID \"{rqid}\" was not found as a Roll Table or Journal Entry or the Journal Entry was not formatted properly as a Name Base.",
-        "NameBaseNotLongEnough": "Name Generation: The RQG System ID \"{rqid}\" references a Name Base Journal Entry that was not long enough to generate a name after {attempts} attempts.  Consider adding more entries."
+        "NameBaseNotLongEnough": "Name Generation: The RQG System ID \"{rqid}\" references a Name Base Journal Entry that was not long enough to generate a name after {attempts} attempts.  Consider adding more entries.",
+        "TargetOneTokenOnly": "Please target one token only"
       }
     },
     "Settings": {

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -605,12 +605,10 @@
         "ManualLabel": "Characteristic",
         "ManualLabelPlaceholder": "POT, STR, SIZ, POW…",
         "ManualValue": "Value",
-        "ManualHint": "Stand-in for something with no sheet — e.g. a poison's POT.",
-        "ModifiersLegend": "Active modifiers"
+        "ManualHint": "Stand-in for something with no sheet — e.g. a poison's POT."
       },
       "ResistanceRequest": {
         "Title": "Request Resistance Roll",
-        "SituationalModifier": "Situational modifier",
         "SituationalModifierHint": "Sent to the Active side as a starting Other modifier. They pick their own Augment and Meditate when they roll.",
         "SendRequest": "Send Request"
       },

--- a/static/system.json
+++ b/static/system.json
@@ -56,7 +56,8 @@
       "character": {}
     },
     "ChatMessage": {
-      "combat": {}
+      "combat": {},
+      "resistanceRequest": {}
     },
     "Item": {
       "armor": {},


### PR DESCRIPTION
Closes #758. Also implements the spell POW-vs-POW hook from #757 (the `resistanceCheck` field + post-cast prompt) — close that too if you agree the remaining refinement belongs in #1066.

## What's in it

### Roll
- **`ResistanceRoll`** — a `d100` folded into a single target% via the resistance-table formula (Core p.145–147: `50 + (active − passive)×5 + modifiers`), resolved with the same success bands as skill/characteristic rolls. Own chat card + tooltip, Dice-So-Nice aware. The formula lives in one place (`resistance-roll-formula.ts`) shared by the roll and every dialog's live preview.

### Dialogs
- **`ResistanceRollDialogV2`** — pick an Active and a Passive side; each is a token/actor's characteristic(s) or a **Manual value/label**. Augment / Meditate / Other modifiers, live target-% preview. POW-experience is credited to whichever actor's characteristic was actually used as the active side (both halves of a combo).
- **`ResistanceRequestDialogV2`** (GM) — build a request and post a chat card addressed to one recipient. Never rolls itself. The Active (recipient) side is restricted to player-owned tokens/actors.
- **`RespondToResistanceRequestDialogV2`** — the recipient answers the card. Active side + Passive value are locked by the request; they only choose their own modifiers. The roll is written back onto the original card (socket update when the GM authored it), not a new message.
- New **`resistanceRequest` ChatMessage subtype** + click handlers.

### Spell hook (#757)
- A **`resistanceCheck`** field (`"none" | "single"`) on Rune & Spirit Magic, replacing the never-shipped `requiresResistanceRoll` boolean. On a successful cast of a `single`-check spell, the dialog auto-opens POW(caster) vs POW(target) against the caster's current single target.
- Enum, not boolean, because multi-target resisted spells are real and split two ways (verified against the rulebook): Harmony/Inviolable are *one* caster roll vs every target in the radius (`areaOneRoll`, reserved), Turn Undead / Draw Beast roll *per target* (`perTarget`, reserved; Turn Undead is POW vs magic points).

### GM entry points
A shared `openResistanceRequest()` seeds the dialog from canvas state — a player-owned invocation target becomes the Active side, an NPC becomes the Passive threat, the GM's current single target fills whichever side is still open. Wired to:
- the actor-sheet **Combat tab** button
- the **combat-tracker** combatant context menu
- the **Actors sidebar** context menu (`RqgActorDirectory`)
- a GM-only **Token HUD** button (`renderTokenHUD`), gated by the new `showResistanceRequestTokenHudButton` client setting (default on)

## Not in scope (→ #1066)
- Sending the spell resistance check to the *target's* owner as a card with **Resist / Accept** buttons (RAW: a target always resists unless they voluntarily accept — Core p.242). Currently the roll opens on the caster's side.
- Pre-cast target validation: 0 targets → confirm as a self-cast, >1 → block **before** MP is spent.
- The `areaOneRoll` / `perTarget` modes.

Spell-content follow-up (setting `resistanceCheck` on the packs): sun-dragon-cult/fvtt-module-wiki-rqg-private#18.

## Checks
`typecheck`, `lint`, `i18n:audit:en`, `check:schemas`, `build:system`, `vitest` (789) — all green. No world migration (the boolean never shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
