### PR TITLE
refactor: rename spell `resistanceCheck` to `resistedBy` and settle the enum

### DIFF
--- a/buildScripts/i18n-dynamic-key-map.ts
+++ b/buildScripts/i18n-dynamic-key-map.ts
@@ -34,7 +34,7 @@ import {
   SpellRangeEnum,
   SpellDurationEnum,
   SpellConcentrationEnum,
-  SpellResistanceCheckEnum,
+  SpellResistedByEnum,
 } from "../src/data-model/item-data/spell";
 import { AbilitySuccessLevelEnum } from "../src/rolls/ability-roll/ability-roll.defs";
 
@@ -147,7 +147,7 @@ export const dynamicKeyMap: Record<string, readonly string[]> = {
     "undefined",
   ],
   "RQG.Item.Spell.RangeEnum.": [...Object.values(SpellRangeEnum).filter(Boolean), "undefined"],
-  "RQG.Item.Spell.ResistanceCheckEnum.": [...Object.values(SpellResistanceCheckEnum)],
+  "RQG.Item.Spell.ResistedByEnum.": [...Object.values(SpellResistedByEnum)],
 
   // Item - Weapon
   "RQG.Item.Weapon.combatManeuver.": [...combatManeuverNames],

--- a/buildScripts/i18n-dynamic-key-map.ts
+++ b/buildScripts/i18n-dynamic-key-map.ts
@@ -34,6 +34,7 @@ import {
   SpellRangeEnum,
   SpellDurationEnum,
   SpellConcentrationEnum,
+  SpellResistanceCheckEnum,
 } from "../src/data-model/item-data/spell";
 import { AbilitySuccessLevelEnum } from "../src/rolls/ability-roll/ability-roll.defs";
 
@@ -146,6 +147,7 @@ export const dynamicKeyMap: Record<string, readonly string[]> = {
     "undefined",
   ],
   "RQG.Item.Spell.RangeEnum.": [...Object.values(SpellRangeEnum).filter(Boolean), "undefined"],
+  "RQG.Item.Spell.ResistanceCheckEnum.": [...Object.values(SpellResistanceCheckEnum)],
 
   // Item - Weapon
   "RQG.Item.Weapon.combatManeuver.": [...combatManeuverNames],

--- a/src/actors/actorsheet-v2.css
+++ b/src/actors/actorsheet-v2.css
@@ -1480,6 +1480,16 @@
         display: flex;
         justify-content: space-between;
         align-items: baseline;
+
+        & button[data-request-resistance-roll] {
+          width: 1.7rem;
+          height: 1.7rem;
+          padding: 0;
+          align-self: center;
+          border-style: outset;
+          background-color: var(--rqg-color-sr-button-bg);
+          border-radius: var(--rqg-radius-md);
+        }
       }
 
       & .health-state {

--- a/src/actors/rqg-actor-sheet-v2.ts
+++ b/src/actors/rqg-actor-sheet-v2.ts
@@ -770,6 +770,15 @@ export class RqgActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
       });
     });
 
+    // GM-only: request a resistance-table check from this actor's owner (Combat tab)
+    this.element.querySelectorAll<HTMLElement>("[data-request-resistance-roll]").forEach((el) => {
+      el.addEventListener("click", async () => {
+        const { openResistanceRequest } =
+          await import("../applications/resistance-roll-dialog/open-resistance-request");
+        await openResistanceRequest(this.document.token?.uuid || this.actor.uuid || "");
+      });
+    });
+
     // Handle in-grid editing of runes
     this.element.querySelectorAll<HTMLElement>("[data-rune-grid-edit]").forEach((el) => {
       el.addEventListener("change", async (event) => {

--- a/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
+++ b/src/actors/sheet-parts-v2/actor-sheet-v2-combat.hbs
@@ -170,7 +170,14 @@
   {{!-- Combat Section --}}
   {{#if showUiSection.combat}}
     <div class="combat-section">
-      <h2 class="section-heading">{{localize "RQG.Actor.Nav.Combat"}}</h2>
+      <h2 class="section-heading">
+        <span>{{localize "RQG.Actor.Nav.Combat"}}</span>
+        {{#if @root.isGM}}
+          <button type="button" class="ui-control icon fa-solid fa-comment-dots" data-request-resistance-roll
+                  data-tooltip="{{localize 'RQG.Game.RequestResistanceRoll'}}"
+                  aria-label="{{localize 'RQG.Game.RequestResistanceRoll'}}"></button>
+        {{/if}}
+      </h2>
 
       {{!-- SR Buttons (only visible when in combat) --}}
       {{#if isInCombat}}

--- a/src/applications/app-parts/augment-meditate-options.ts
+++ b/src/applications/app-parts/augment-meditate-options.ts
@@ -1,0 +1,19 @@
+// Shared Augment/Meditate modifier options for any roll dialog that lets a player augment their
+// roll (RAW allows this for characteristic rolls, resistance rolls, etc. - core rulebook p.146).
+export const augmentOptions: SelectOptionData<number>[] = [
+  { value: 0, label: "RQG.Dialog.Common.AugmentOptions.None" },
+  { value: 50, label: "RQG.Dialog.Common.AugmentOptions.CriticalSuccess" },
+  { value: 30, label: "RQG.Dialog.Common.AugmentOptions.SpecialSuccess" },
+  { value: 20, label: "RQG.Dialog.Common.AugmentOptions.Success" },
+  { value: -20, label: "RQG.Dialog.Common.AugmentOptions.Failure" },
+  { value: -50, label: "RQG.Dialog.Common.AugmentOptions.Fumble" },
+];
+
+export const meditateOptions: SelectOptionData<number>[] = [
+  { value: 0, label: "RQG.Dialog.Common.MeditateOptions.None" },
+  { value: 5, label: "RQG.Dialog.Common.MeditateOptions.1mr" },
+  { value: 10, label: "RQG.Dialog.Common.MeditateOptions.2mr" },
+  { value: 15, label: "RQG.Dialog.Common.MeditateOptions.5mr" },
+  { value: 20, label: "RQG.Dialog.Common.MeditateOptions.25mr" },
+  { value: 25, label: "RQG.Dialog.Common.MeditateOptions.50mr" },
+];

--- a/src/applications/app-parts/roll-mode.ts
+++ b/src/applications/app-parts/roll-mode.ts
@@ -89,3 +89,16 @@ export function getSelectedRollModeFromClickEvent(event: MouseEvent): RollMode |
   const elementWithRollMode = target.closest<HTMLElement>("[data-roll-mode]");
   return getSelectedRollMode(elementWithRollMode?.dataset["rollMode"]);
 }
+
+/**
+ * Read whichever roll-mode toggle button is pressed on a roll-dialog form at submit time,
+ * falling back to the configured default.
+ */
+export function resolveRollModeFromForm(form: HTMLFormElement | undefined | null): RollMode {
+  return (
+    getSelectedRollMode(
+      form?.querySelector<HTMLButtonElement>('button[data-action="rollMode"][aria-pressed="true"]')
+        ?.dataset["rollMode"],
+    ) ?? getDefaultRollMode()
+  );
+}

--- a/src/applications/app-parts/rqg-interactive-roll-application-base.ts
+++ b/src/applications/app-parts/rqg-interactive-roll-application-base.ts
@@ -79,6 +79,18 @@ export abstract class RqgInteractiveRollApplicationBase extends HandlebarsApplic
     this.getLivePreviewFormBehaviorConfig().updateLivePreview();
   }
 
+  /**
+   * Write a freshly computed target% into the footer's `[data-total-chance]` element in place,
+   * without a full re-render. Shared DOM-plumbing for subclasses whose `updateLivePreview()`
+   * only needs to update that one number.
+   */
+  protected updateTotalChanceDisplay(totalChance: number): void {
+    const totalChanceElement = this.element.querySelector<HTMLElement>("[data-total-chance]");
+    if (totalChanceElement) {
+      totalChanceElement.textContent = `${totalChance}%`;
+    }
+  }
+
   override get element(): HTMLFormElement {
     return super.element as HTMLFormElement;
   }

--- a/src/applications/characteristic-roll-dialog/characteristic-roll-dialog-v2.ts
+++ b/src/applications/characteristic-roll-dialog/characteristic-roll-dialog-v2.ts
@@ -23,6 +23,7 @@ import {
   getDefaultRollMode,
   getSelectedRollMode,
 } from "../app-parts/roll-mode";
+import { augmentOptions, meditateOptions } from "../app-parts/augment-meditate-options";
 import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
 import { getSpeakerCompat } from "../../system/fvtt-type-compat";
 
@@ -45,24 +46,6 @@ export class CharacteristicRollDialogV2 extends RqgInteractiveRollApplicationBas
       Number(formData.otherModifier ?? 0)
     );
   }
-
-  private static augmentOptions: SelectOptionData<number>[] = [
-    { value: 0, label: "RQG.Dialog.Common.AugmentOptions.None" },
-    { value: 50, label: "RQG.Dialog.Common.AugmentOptions.CriticalSuccess" },
-    { value: 30, label: "RQG.Dialog.Common.AugmentOptions.SpecialSuccess" },
-    { value: 20, label: "RQG.Dialog.Common.AugmentOptions.Success" },
-    { value: -20, label: "RQG.Dialog.Common.AugmentOptions.Failure" },
-    { value: -50, label: "RQG.Dialog.Common.AugmentOptions.Fumble" },
-  ];
-
-  private static meditateOptions: SelectOptionData<number>[] = [
-    { value: 0, label: "RQG.Dialog.Common.MeditateOptions.None" },
-    { value: 5, label: "RQG.Dialog.Common.MeditateOptions.1mr" },
-    { value: 10, label: "RQG.Dialog.Common.MeditateOptions.2mr" },
-    { value: 15, label: "RQG.Dialog.Common.MeditateOptions.5mr" },
-    { value: 20, label: "RQG.Dialog.Common.MeditateOptions.25mr" },
-    { value: 25, label: "RQG.Dialog.Common.MeditateOptions.50mr" },
-  ];
 
   private static difficultyOptions: SelectOptionData<number>[] = [
     { value: 0, label: "RQG.Dialog.CharacteristicRoll.RollDifficultyLevel.0" },
@@ -143,8 +126,8 @@ export class CharacteristicRollDialogV2 extends RqgInteractiveRollApplicationBas
       formData: formData,
 
       speakerName: getSpeakerDisplayName(speaker),
-      augmentOptions: CharacteristicRollDialogV2.augmentOptions,
-      meditateOptions: CharacteristicRollDialogV2.meditateOptions,
+      augmentOptions: augmentOptions,
+      meditateOptions: meditateOptions,
       difficultyOptions: CharacteristicRollDialogV2.difficultyOptions,
 
       // RollHeader

--- a/src/applications/resistance-roll-dialog/open-resistance-request.ts
+++ b/src/applications/resistance-roll-dialog/open-resistance-request.ts
@@ -1,0 +1,45 @@
+import { localize } from "../../system/util";
+import { resolveActorFromUuid } from "./resistance-roll-shared.ts";
+import type { ResistanceRequestSeed } from "./resistance-request-dialog-data.types.ts";
+
+/**
+ * Single GM entry point for opening the resistance-request dialog, shared by every UI surface
+ * that offers it (actor sheet Combat tab, token HUD, combat tracker, Actors sidebar).
+ *
+ * Seeds the dialog from canvas state so the GM rarely has to pick sides by hand:
+ * - invoked on a player-owned token/actor -> that's the active (rolling) side; the GM's current
+ *   single target, if any, becomes the passive side;
+ * - invoked on an NPC/monster -> that's the passive threat; a player-owned target becomes the
+ *   active side;
+ * - invoked with no context (e.g. a keybinding) -> only the active side is seeded, and only if
+ *   the current target is player-owned.
+ */
+export async function openResistanceRequest(invokedTokenOrActorUuid?: string): Promise<void> {
+  if (!game.user?.isGM) {
+    ui.notifications?.warn(localize("RQG.Notification.Error.GMOnlyOperation"));
+    return;
+  }
+
+  const targetUuid =
+    game.user.targets.size === 1
+      ? (game.user.targets.first()?.document?.uuid ?? undefined)
+      : undefined;
+  const invokedIsPlayerOwned =
+    !!invokedTokenOrActorUuid && !!resolveActorFromUuid(invokedTokenOrActorUuid)?.hasPlayerOwner;
+  const targetIsPlayerOwned = !!targetUuid && !!resolveActorFromUuid(targetUuid)?.hasPlayerOwner;
+
+  let seed: ResistanceRequestSeed;
+  if (invokedTokenOrActorUuid && invokedIsPlayerOwned) {
+    seed = { activeUuid: invokedTokenOrActorUuid, passiveUuid: targetUuid };
+  } else if (invokedTokenOrActorUuid) {
+    seed = {
+      passiveUuid: invokedTokenOrActorUuid,
+      activeUuid: targetIsPlayerOwned ? targetUuid : undefined,
+    };
+  } else {
+    seed = { activeUuid: targetIsPlayerOwned ? targetUuid : undefined };
+  }
+
+  const { ResistanceRequestDialogV2 } = await import("./resistance-request-dialog-v2.ts");
+  await new ResistanceRequestDialogV2(seed).render({ force: true });
+}

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
@@ -15,8 +15,6 @@ export type ResistanceRequestDialogContext = RollHeaderData & {
   activeTokenOrActorOptions: SelectOptionData<string>[];
   passiveTokenOrActorOptions: SelectOptionData<string>[];
   characteristicOptions: SelectOptionData<string>[];
-  augmentOptions: SelectOptionData<number>[];
-  meditateOptions: SelectOptionData<number>[];
   totalChance: number;
 };
 
@@ -34,9 +32,7 @@ export type ResistanceRequestDialogFormData = {
   passiveManualLabel: string;
   passiveManualValue: number;
 
-  // Prefilled defaults for the recipient's modifiers - they can still change them before rolling.
-  augmentModifier: string;
-  meditateModifier: string;
+  // GM's situational modifier for the contest - sent as the roller's starting Other modifier.
   otherModifier: string;
   otherModifierDescription: string;
 };

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-data.types.ts
@@ -1,0 +1,42 @@
+import type { RollHeaderData } from "../app-parts/roll-header.types.ts";
+
+/**
+ * Pre-fill for {@link ResistanceRequestDialogV2}, produced by `openResistanceRequest` from the
+ * invoking UI surface + the GM's current target. `activeUuid` is always a player-owned
+ * token/actor (whoever the request card is addressed to); `passiveUuid` may be any token/actor.
+ */
+export type ResistanceRequestSeed = {
+  activeUuid?: string | undefined;
+  passiveUuid?: string | undefined;
+};
+
+export type ResistanceRequestDialogContext = RollHeaderData & {
+  formData: ResistanceRequestDialogFormData;
+  activeTokenOrActorOptions: SelectOptionData<string>[];
+  passiveTokenOrActorOptions: SelectOptionData<string>[];
+  characteristicOptions: SelectOptionData<string>[];
+  augmentOptions: SelectOptionData<number>[];
+  meditateOptions: SelectOptionData<number>[];
+  totalChance: number;
+};
+
+export type ResistanceRequestDialogFormData = {
+  /** The actor/token who will be asked to roll - always a real actor, never manual. */
+  targetTokenOrActorUuid: string;
+  /** One characteristic name, or two joined by "+" (e.g. "strength+size") - what they roll. */
+  activeCharacteristics: string;
+
+  /** A token/actor uuid, or the MANUAL_SOURCE_VALUE sentinel. */
+  passiveTokenOrActorUuid: string;
+  passiveCharacteristics: string;
+  /** Only used for a Manual passive - names the obstacle/disease, e.g. "Noxious Gas". */
+  passiveManualName: string;
+  passiveManualLabel: string;
+  passiveManualValue: number;
+
+  // Prefilled defaults for the recipient's modifiers - they can still change them before rolling.
+  augmentModifier: string;
+  meditateModifier: string;
+  otherModifier: string;
+  otherModifierDescription: string;
+};

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
@@ -47,22 +47,13 @@
   </datalist>
 
   <fieldset>
-    <legend>{{localize "RQG.Dialog.ResistanceRequest.ModifierDefaults"}}</legend>
+    <legend>{{localize "RQG.Dialog.ResistanceRequest.SituationalModifier"}}</legend>
     <div class="key-value-grid p-0">
-      <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
-      <select name="augmentModifier">
-        {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
-      </select>
-
-      <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
-      <select name="meditateModifier">
-        {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
-      </select>
-
       <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
       <div>
         <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
       </div>
     </div>
+    <p class="hint">{{localize "RQG.Dialog.ResistanceRequest.SituationalModifierHint"}}</p>
   </fieldset>
 </div>

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs
@@ -1,0 +1,68 @@
+<div class="scrollable">
+  <fieldset>
+    <legend>{{localize "RQG.Dialog.ResistanceRoll.Active"}}</legend>
+    <div class="key-value-grid p-0">
+      <label>{{localize "RQG.Dialog.ResistanceRoll.TokenOrActor"}}</label>
+      <select name="targetTokenOrActorUuid">
+        {{selectOptions activeTokenOrActorOptions selected=formData.targetTokenOrActorUuid localize=false}}
+      </select>
+
+      <label>{{localize "RQG.Dialog.ResistanceRoll.Characteristic"}}</label>
+      <select name="activeCharacteristics">
+        {{selectOptions characteristicOptions selected=formData.activeCharacteristics localize=false}}
+      </select>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>{{localize "RQG.Dialog.ResistanceRoll.Passive"}}</legend>
+    <div class="key-value-grid p-0">
+      <label>{{localize "RQG.Dialog.ResistanceRoll.TokenOrActor"}}</label>
+      <select name="passiveTokenOrActorUuid">
+        {{selectOptions passiveTokenOrActorOptions selected=formData.passiveTokenOrActorUuid localize=false}}
+      </select>
+
+      {{#unless (eq formData.passiveTokenOrActorUuid "manual")}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.Characteristic"}}</label>
+        <select name="passiveCharacteristics">
+          {{selectOptions characteristicOptions selected=formData.passiveCharacteristics localize=false}}
+        </select>
+      {{else}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualName"}}</label>
+        <input type="text" value="{{formData.passiveManualName}}" name="passiveManualName">
+
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualLabel"}}</label>
+        <input type="text" value="{{formData.passiveManualLabel}}" name="passiveManualLabel" list="resistance-manual-label-suggestions">
+
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualValue"}}</label>
+        <input type="number" value="{{formData.passiveManualValue}}" name="passiveManualValue">
+      {{/unless}}
+    </div>
+  </fieldset>
+
+  <datalist id="resistance-manual-label-suggestions">
+    <option value="POT">
+    <option value="{{localize 'RQG.Actor.Characteristics.strength'}}">
+    <option value="{{localize 'RQG.Actor.Characteristics.size'}}">
+  </datalist>
+
+  <fieldset>
+    <legend>{{localize "RQG.Dialog.ResistanceRequest.ModifierDefaults"}}</legend>
+    <div class="key-value-grid p-0">
+      <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
+      <select name="augmentModifier">
+        {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
+      </select>
+
+      <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
+      <select name="meditateModifier">
+        {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
+      </select>
+
+      <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
+      <div>
+        <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
@@ -9,12 +9,10 @@ import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
 import { activateChatTab, localize } from "../../system/util";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import {
-  augmentOptions,
   filterToPlayerOwnedOptions,
   getBaseTokenOrActorOptions,
   getCharacteristicOptions,
   getTokenOrActorOptions,
-  meditateOptions,
   resolveActorFromUuid,
   resolveCharacteristicSide,
 } from "./resistance-roll-shared.ts";
@@ -133,8 +131,6 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
     formData.passiveManualLabel ??= "";
     formData.passiveManualValue ??= 0;
 
-    formData.augmentModifier ??= "0";
-    formData.meditateModifier ??= "0";
     formData.otherModifier ??= "0";
     formData.otherModifierDescription ??= localize("RQG.Dialog.Common.OtherModifier");
 
@@ -160,8 +156,6 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       activeTokenOrActorOptions: activeTokenOrActorOptions,
       passiveTokenOrActorOptions: passiveTokenOrActorOptions,
       characteristicOptions: getCharacteristicOptions(),
-      augmentOptions: augmentOptions,
-      meditateOptions: meditateOptions,
 
       // RollHeader
       rollType: localize("RQG.Dialog.ResistanceRequest.Title"),
@@ -188,8 +182,6 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       "",
     );
     return computeResistanceTargetChance(active.value, passive.value, [
-      Number(formData.augmentModifier),
-      Number(formData.meditateModifier),
       Number(formData.otherModifier),
     ]);
   }
@@ -239,8 +231,6 @@ export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase
       passiveValue: passive.value,
       passiveLabel: passive.label,
       passiveActorName: passive.actorName,
-      augmentModifier: Number(formDataObject.augmentModifier) || 0,
-      meditateModifier: Number(formDataObject.meditateModifier) || 0,
       otherModifier: Number(formDataObject.otherModifier) || 0,
       otherModifierDescription: formDataObject.otherModifierDescription || undefined,
       resistanceRoll: undefined,

--- a/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-request-dialog-v2.ts
@@ -1,0 +1,281 @@
+import { systemId } from "../../system/config";
+import { templatePaths } from "../../system/load-handlebars-templates";
+import type {
+  ResistanceRequestDialogContext,
+  ResistanceRequestDialogFormData,
+  ResistanceRequestSeed,
+} from "./resistance-request-dialog-data.types.ts";
+import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
+import { activateChatTab, localize } from "../../system/util";
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import {
+  augmentOptions,
+  filterToPlayerOwnedOptions,
+  getBaseTokenOrActorOptions,
+  getCharacteristicOptions,
+  getTokenOrActorOptions,
+  meditateOptions,
+  resolveActorFromUuid,
+  resolveCharacteristicSide,
+} from "./resistance-roll-shared.ts";
+import { buildResistanceRollFlavor } from "../../rolls/resistance-roll/resistance-roll-flavor.ts";
+import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
+import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
+import { getSpeakerCompat } from "../../system/fvtt-type-compat";
+
+/**
+ * GM-facing dialog (#758 option C): pick who should roll (an actor/token's characteristic(s))
+ * and what they're resisting (another actor's characteristic(s), or a manual value/label such as
+ * a disease's POT), then post a chat card only that recipient (and the GM) can act on. Unlike
+ * ResistanceRollDialogV2 this dialog never rolls anything itself - it only creates the request;
+ * RespondToResistanceRequestDialogV2 is what the recipient uses to actually roll.
+ */
+export class ResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase {
+  protected override getLivePreviewFormBehaviorConfig() {
+    return {
+      submitButtonSelectorForBlurGuard: "button[data-send-resistance-request]",
+      updateLivePreview: () => this.updateLivePreview(),
+    };
+  }
+
+  private seed: ResistanceRequestSeed;
+
+  constructor(
+    seed: ResistanceRequestSeed = {},
+    options?: Partial<foundry.applications.types.ApplicationConfiguration>,
+  ) {
+    super(options);
+    this.seed = seed;
+  }
+
+  static override DEFAULT_OPTIONS = {
+    id: `resistance-request-{id}`,
+    tag: "form",
+    classes: [systemId, "form", "roll-dialog", "resistance-request-dialog"],
+    form: {
+      handler: ResistanceRequestDialogV2.onSubmit,
+      submitOnChange: false,
+      closeOnSubmit: true,
+    },
+    position: {
+      width: "auto" as const,
+      height: "auto" as const,
+      left: 35,
+      top: 15,
+    },
+    window: {
+      contentClasses: ["standard-form"],
+      icon: "fa-solid fa-scale-unbalanced",
+      title: "RQG.Dialog.ResistanceRequest.Title",
+      resizable: false,
+    },
+  };
+
+  static override PARTS = {
+    header: { template: templatePaths.rollHeader },
+    form: { template: templatePaths.resistanceRequestDialogV2, scrollable: [""] },
+    footer: { template: templatePaths.resistanceRequestFooter },
+  };
+
+  override async _prepareContext(): Promise<ResistanceRequestDialogContext> {
+    const formData = ((this.element &&
+      new foundry.applications.ux.FormDataExtended(this.form!, {}).object) ??
+      {}) as ResistanceRequestDialogFormData;
+
+    const defaultTargetUuid =
+      game.user?.targets.size === 1 ? (game.user.targets.first()?.document?.uuid ?? "") : "";
+    const initialTargetUuid = this.seed.activeUuid || defaultTargetUuid || "";
+    const initialTargetTokenOrActor = initialTargetUuid
+      ? (fromUuidSync(initialTargetUuid) as TokenDocument | RqgActor | undefined)
+      : undefined;
+
+    // Both sides share the same underlying targeted/owned-token/owned-actor scan - computed once
+    // here and handed to both calls below instead of each re-scanning it independently.
+    const baseTokenOrActorOptions = getBaseTokenOrActorOptions();
+
+    // The active side is who gets asked to roll, so it's restricted to tokens/actors with an
+    // actual player owner - a GM owns every token, so without this an NPC/monster could be picked
+    // as the recipient and nobody but the GM could ever click that card's Roll button.
+    const initialTargetActor = resolveActorFromUuid(initialTargetUuid);
+    const initialTargetHasPlayerOwner = !!initialTargetActor?.hasPlayerOwner;
+    // No Manual entry - the active side must be a real actor/token, since it's who the request
+    // card is addressed to. `initialTargetUuid` is guaranteed to appear (even if not otherwise
+    // owned-via-token/actor-setting) so the sheet this dialog was opened from is always pickable -
+    // unless it has no player owner, in which case the GM must explicitly pick someone instead.
+    const activeTokenOrActorOptions = getTokenOrActorOptions(
+      initialTargetHasPlayerOwner ? initialTargetUuid : "",
+      initialTargetHasPlayerOwner ? (initialTargetTokenOrActor?.name ?? "") : "",
+      initialTargetHasPlayerOwner ? initialTargetActor : undefined,
+      false,
+      filterToPlayerOwnedOptions(baseTokenOrActorOptions),
+    );
+    // Manual is the common case here (a GM-known value like a disease's POT), so it's included.
+    // A seeded passive (e.g. the NPC whose token HUD the request was opened from) is guaranteed to
+    // appear even if it's not on the current scene / not otherwise owned.
+    const seededPassiveUuid = this.seed.passiveUuid ?? "";
+    const seededPassive = seededPassiveUuid
+      ? (fromUuidSync(seededPassiveUuid) as TokenDocument | RqgActor | undefined)
+      : undefined;
+    const passiveTokenOrActorOptions = getTokenOrActorOptions(
+      seededPassiveUuid,
+      seededPassive?.name ?? "",
+      resolveActorFromUuid(seededPassiveUuid),
+      true,
+      baseTokenOrActorOptions,
+    );
+
+    formData.targetTokenOrActorUuid ??= initialTargetHasPlayerOwner ? initialTargetUuid : "";
+    formData.activeCharacteristics ??= "";
+
+    formData.passiveTokenOrActorUuid ??= this.seed.passiveUuid || MANUAL_SOURCE_VALUE;
+    formData.passiveCharacteristics ??= "";
+    formData.passiveManualName ??= "";
+    formData.passiveManualLabel ??= "";
+    formData.passiveManualValue ??= 0;
+
+    formData.augmentModifier ??= "0";
+    formData.meditateModifier ??= "0";
+    formData.otherModifier ??= "0";
+    formData.otherModifierDescription ??= localize("RQG.Dialog.Common.OtherModifier");
+
+    const totalChance = ResistanceRequestDialogV2.computeTotalChance(formData);
+    const active = resolveCharacteristicSide(
+      formData.targetTokenOrActorUuid,
+      formData.activeCharacteristics,
+      "",
+      0,
+      localize("RQG.Dialog.ResistanceRoll.Active"),
+    );
+    const passive = resolveCharacteristicSide(
+      formData.passiveTokenOrActorUuid,
+      formData.passiveCharacteristics,
+      formData.passiveManualLabel,
+      formData.passiveManualValue,
+      localize("RQG.Dialog.ResistanceRoll.Passive"),
+      formData.passiveManualName,
+    );
+
+    return {
+      formData: formData,
+      activeTokenOrActorOptions: activeTokenOrActorOptions,
+      passiveTokenOrActorOptions: passiveTokenOrActorOptions,
+      characteristicOptions: getCharacteristicOptions(),
+      augmentOptions: augmentOptions,
+      meditateOptions: meditateOptions,
+
+      // RollHeader
+      rollType: localize("RQG.Dialog.ResistanceRequest.Title"),
+      rollName: `${active.label || "?"} ${localize("RQG.Roll.ResistanceRoll.Vs")} ${passive.label || "?"}`,
+      baseChance: "",
+
+      totalChance: totalChance,
+    };
+  }
+
+  private static computeTotalChance(formData: ResistanceRequestDialogFormData): number {
+    const active = resolveCharacteristicSide(
+      formData.targetTokenOrActorUuid,
+      formData.activeCharacteristics,
+      "",
+      0,
+      "",
+    );
+    const passive = resolveCharacteristicSide(
+      formData.passiveTokenOrActorUuid,
+      formData.passiveCharacteristics,
+      formData.passiveManualLabel,
+      formData.passiveManualValue,
+      "",
+    );
+    return computeResistanceTargetChance(active.value, passive.value, [
+      Number(formData.augmentModifier),
+      Number(formData.meditateModifier),
+      Number(formData.otherModifier),
+    ]);
+  }
+
+  private updateLivePreview(): void {
+    const formData = new foundry.applications.ux.FormDataExtended(this.element, {})
+      .object as ResistanceRequestDialogFormData;
+    this.updateTotalChanceDisplay(ResistanceRequestDialogV2.computeTotalChance(formData));
+  }
+
+  private static async onSubmit(
+    event: SubmitEvent | Event,
+    form: HTMLFormElement,
+    formData: foundry.applications.ux.FormDataExtended,
+  ): Promise<void> {
+    const formDataObject = formData.object as ResistanceRequestDialogFormData;
+
+    const active = resolveCharacteristicSide(
+      formDataObject.targetTokenOrActorUuid,
+      formDataObject.activeCharacteristics,
+      "",
+      0,
+      "",
+    );
+    const passive = resolveCharacteristicSide(
+      formDataObject.passiveTokenOrActorUuid,
+      formDataObject.passiveCharacteristics,
+      formDataObject.passiveManualLabel,
+      formDataObject.passiveManualValue,
+      "",
+      formDataObject.passiveManualName,
+    );
+
+    if (!formDataObject.targetTokenOrActorUuid || !active.label) {
+      ui.notifications?.error("Pick who should roll and which characteristic(s) they roll with.");
+      return;
+    }
+    if (!passive.label) {
+      ui.notifications?.error("Pick or enter what the roll resists.");
+      return;
+    }
+
+    const chatSystemData = {
+      state: "Requested",
+      targetTokenOrActorUuid: formDataObject.targetTokenOrActorUuid,
+      activeCharacteristics: formDataObject.activeCharacteristics,
+      passiveValue: passive.value,
+      passiveLabel: passive.label,
+      passiveActorName: passive.actorName,
+      augmentModifier: Number(formDataObject.augmentModifier) || 0,
+      meditateModifier: Number(formDataObject.meditateModifier) || 0,
+      otherModifier: Number(formDataObject.otherModifier) || 0,
+      otherModifierDescription: formDataObject.otherModifierDescription || undefined,
+      resistanceRoll: undefined,
+    };
+
+    // Shown as the message author instead of the GM, so the card reads as the recipient's roll
+    // request even though the GM is the one who posted it. Rendered concurrently with the chat
+    // content below since neither depends on the other.
+    const [content, targetTokenOrActor] = await Promise.all([
+      foundry.applications.handlebars.renderTemplate(
+        templatePaths.resistanceRequestChatMessage,
+        chatSystemData,
+      ),
+      fromUuid(formDataObject.targetTokenOrActorUuid) as Promise<
+        TokenDocument | RqgActor | undefined
+      >,
+    ]);
+
+    const flavor = buildResistanceRollFlavor(active.label, passive.label, passive.actorName);
+
+    const targetToken =
+      targetTokenOrActor instanceof TokenDocument ? targetTokenOrActor : undefined;
+    const targetActor =
+      targetTokenOrActor instanceof TokenDocument ? targetTokenOrActor.actor : targetTokenOrActor;
+
+    activateChatTab();
+    const cm = await ChatMessage.create({
+      type: "resistanceRequest",
+      system: chatSystemData,
+      flavor: flavor,
+      content: content,
+      speaker: getSpeakerCompat({ actor: targetActor ?? undefined, token: targetToken }),
+    } as any);
+    if (cm && !Array.isArray(cm)) {
+      cm.render(true);
+    }
+  }
+}

--- a/src/applications/resistance-roll-dialog/resistance-request-footer.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-request-footer.hbs
@@ -1,0 +1,7 @@
+<footer class="flexrow flex-wrap gap1rem">
+  <div class="target-box" data-tooltip="{{localize 'RQG.Dialog.Common.TargetChance'}}">
+    <i class="fa-solid fa-bullseye"></i><br>
+    <span data-total-chance>{{totalChance}}%</span>
+  </div>
+  <button data-send-resistance-request>{{localize "RQG.Dialog.ResistanceRequest.SendRequest"}}</button>
+</footer>

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-data.types.ts
@@ -1,0 +1,58 @@
+import type { RollHeaderData } from "../app-parts/roll-header.types.ts";
+import type { RollFooterData } from "../app-parts/roll-footer.types.ts";
+import type { Characteristics } from "../../data-model/actor-data/characteristics.ts";
+
+/** Sentinel value for the token/actor dropdown meaning "type in a value by hand instead". */
+export const MANUAL_SOURCE_VALUE = "manual";
+
+/** Prefill for one side (active or passive) of a resistance roll, e.g. from a spell's post-cast hook. */
+export type ResistanceRollSidePrefill =
+  | {
+      source: "tokenOrActor";
+      tokenOrActorUuid: string;
+      characteristicNames: [keyof Characteristics] | [keyof Characteristics, keyof Characteristics];
+    }
+  | { source: "manual"; value: number; label: string };
+
+export type ResistanceRollDialogPrefill = {
+  active?: ResistanceRollSidePrefill;
+  passive?: ResistanceRollSidePrefill;
+  /** Shown in the roll header, e.g. the name of the spell that triggered this check. */
+  description?: string;
+};
+
+export type ResistanceRollDialogContext = RollHeaderData &
+  RollFooterData & {
+    formData: ResistanceRollDialogFormData;
+
+    speakerName: string;
+    activeTokenOrActorOptions: SelectOptionData<string>[];
+    passiveTokenOrActorOptions: SelectOptionData<string>[];
+    characteristicOptions: SelectOptionData<string>[];
+    augmentOptions: SelectOptionData<number>[];
+    meditateOptions: SelectOptionData<number>[];
+  };
+
+export type ResistanceRollDialogFormData = {
+  /** A token/actor uuid, or the MANUAL_SOURCE_VALUE sentinel. */
+  activeTokenOrActorUuid: string;
+  /** One characteristic name, or two joined by "+" (e.g. "strength+size"). */
+  activeCharacteristics: string;
+  activeManualLabel: string;
+  activeManualValue: number;
+
+  /** A token/actor uuid, or the MANUAL_SOURCE_VALUE sentinel. */
+  passiveTokenOrActorUuid: string;
+  /** One characteristic name, or two joined by "+" (e.g. "size+dexterity"). */
+  passiveCharacteristics: string;
+  passiveManualLabel: string;
+  passiveManualValue: number;
+
+  augmentModifier: string;
+  meditateModifier: string;
+  otherModifier: string;
+  otherModifierDescription: string;
+
+  actorUuid: string; // hidden field - the actor whose sheet/token this dialog was opened from
+  tokenUuid: string; // hidden field
+};

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs
@@ -1,0 +1,78 @@
+<div class="scrollable">
+  <div class="key-value-grid p-0">
+    <label>{{localize "RQG.Dialog.Common.Character"}}</label>
+    <div>{{speakerName}}</div>
+  </div>
+
+  <fieldset>
+    <legend>{{localize "RQG.Dialog.ResistanceRoll.Active"}}</legend>
+    <div class="key-value-grid p-0">
+      <label>{{localize "RQG.Dialog.ResistanceRoll.TokenOrActor"}}</label>
+      <select name="activeTokenOrActorUuid">
+        {{selectOptions activeTokenOrActorOptions selected=formData.activeTokenOrActorUuid localize=false}}
+      </select>
+
+      {{#unless (eq formData.activeTokenOrActorUuid "manual")}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.Characteristic"}}</label>
+        <select name="activeCharacteristics">
+          {{selectOptions characteristicOptions selected=formData.activeCharacteristics localize=false}}
+        </select>
+      {{else}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualLabel"}}</label>
+        <input type="text" value="{{formData.activeManualLabel}}" name="activeManualLabel" list="resistance-manual-label-suggestions">
+
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualValue"}}</label>
+        <input type="number" value="{{formData.activeManualValue}}" name="activeManualValue">
+      {{/unless}}
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>{{localize "RQG.Dialog.ResistanceRoll.Passive"}}</legend>
+    <div class="key-value-grid p-0">
+      <label>{{localize "RQG.Dialog.ResistanceRoll.TokenOrActor"}}</label>
+      <select name="passiveTokenOrActorUuid">
+        {{selectOptions passiveTokenOrActorOptions selected=formData.passiveTokenOrActorUuid localize=false}}
+      </select>
+
+      {{#unless (eq formData.passiveTokenOrActorUuid "manual")}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.Characteristic"}}</label>
+        <select name="passiveCharacteristics">
+          {{selectOptions characteristicOptions selected=formData.passiveCharacteristics localize=false}}
+        </select>
+      {{else}}
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualLabel"}}</label>
+        <input type="text" value="{{formData.passiveManualLabel}}" name="passiveManualLabel" list="resistance-manual-label-suggestions">
+
+        <label>{{localize "RQG.Dialog.ResistanceRoll.ManualValue"}}</label>
+        <input type="number" value="{{formData.passiveManualValue}}" name="passiveManualValue">
+      {{/unless}}
+    </div>
+  </fieldset>
+
+  <datalist id="resistance-manual-label-suggestions">
+    <option value="POT">
+    <option value="{{localize 'RQG.Actor.Characteristics.strength'}}">
+    <option value="{{localize 'RQG.Actor.Characteristics.size'}}">
+  </datalist>
+
+  <div class="key-value-grid p-0">
+    <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
+    <select name="augmentModifier">
+      {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
+    </select>
+
+    <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
+    <select name="meditateModifier">
+      {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
+    </select>
+
+    <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
+    <div>
+      <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
+    </div>
+  </div>
+
+  <input type="hidden" value="{{formData.actorUuid}}" name="actorUuid">
+  <input type="hidden" value="{{formData.tokenUuid}}" name="tokenUuid">
+</div>

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
@@ -1,0 +1,313 @@
+import { systemId } from "../../system/config";
+import { templatePaths } from "../../system/load-handlebars-templates";
+import type {
+  ResistanceRollDialogContext,
+  ResistanceRollDialogFormData,
+  ResistanceRollDialogPrefill,
+  ResistanceRollSidePrefill,
+} from "./resistance-roll-dialog-data.types.ts";
+import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
+import { getSpeakerDisplayName, isDocumentSubType, localize, RqgError } from "../../system/util";
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
+import type { ResistanceRollOptions } from "../../rolls/resistance-roll/resistance-roll.types";
+import { ResistanceRoll } from "../../rolls/resistance-roll/resistance-roll";
+import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
+import {
+  augmentOptions,
+  buildResistanceModifiers,
+  decodeCharacteristics,
+  encodeCharacteristics,
+  getCharacteristicOptions,
+  getTokenOrActorOptions,
+  meditateOptions,
+  resolveActorFromUuid,
+  resolveCharacteristicSide,
+} from "./resistance-roll-shared.ts";
+import { getConfiguredRollModeOptions, resolveRollModeFromForm } from "../app-parts/roll-mode";
+import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
+import { getSpeakerCompat } from "../../system/fvtt-type-compat";
+
+type Side = "active" | "passive";
+
+type SideFields = {
+  tokenOrActorUuid: string;
+  characteristics: string;
+  manualLabel: string;
+  manualValue: number;
+};
+
+// The four fields making up a side are always named `${side}TokenOrActorUuid`,
+// `${side}Characteristics`, `${side}ManualLabel`, `${side}ManualValue` - read/write them via that
+// naming convention instead of branching on `side` per field.
+function getSideFields(formData: ResistanceRollDialogFormData, side: Side): SideFields {
+  return {
+    tokenOrActorUuid: formData[`${side}TokenOrActorUuid`],
+    characteristics: formData[`${side}Characteristics`],
+    manualLabel: formData[`${side}ManualLabel`],
+    manualValue: formData[`${side}ManualValue`],
+  };
+}
+
+function setSideFields(
+  formData: ResistanceRollDialogFormData,
+  side: Side,
+  fields: Partial<SideFields>,
+): void {
+  if (fields.tokenOrActorUuid !== undefined) {
+    formData[`${side}TokenOrActorUuid`] = fields.tokenOrActorUuid;
+  }
+  if (fields.characteristics !== undefined) {
+    formData[`${side}Characteristics`] = fields.characteristics;
+  }
+  if (fields.manualLabel !== undefined) {
+    formData[`${side}ManualLabel`] = fields.manualLabel;
+  }
+  if (fields.manualValue !== undefined) {
+    formData[`${side}ManualValue`] = fields.manualValue;
+  }
+}
+
+function applyPrefill(
+  formData: ResistanceRollDialogFormData,
+  side: Side,
+  prefill: ResistanceRollSidePrefill | undefined,
+): void {
+  if (!prefill) {
+    return;
+  }
+  if (prefill.source === "manual") {
+    setSideFields(formData, side, {
+      tokenOrActorUuid: MANUAL_SOURCE_VALUE,
+      manualLabel: prefill.label,
+      manualValue: prefill.value,
+    });
+    return;
+  }
+  setSideFields(formData, side, {
+    tokenOrActorUuid: prefill.tokenOrActorUuid,
+    characteristics: encodeCharacteristics(prefill.characteristicNames),
+  });
+}
+
+export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
+  protected override getLivePreviewFormBehaviorConfig() {
+    return {
+      submitButtonSelectorForBlurGuard: "button[data-ability-roll]",
+      updateLivePreview: () => this.updateLivePreview(),
+    };
+  }
+
+  private actor: RqgActor;
+  private token: TokenDocument | null | undefined;
+  private prefill: ResistanceRollDialogPrefill | undefined;
+  // Applied once on the first _prepareContext only - _prepareContext reruns on every form change
+  // (RqgInteractiveRollApplicationBase re-renders on change), and re-applying the prefill on every
+  // one of those reruns would stomp over whatever the user just picked.
+  private prefillApplied = false;
+
+  constructor(
+    actor: RqgActor,
+    token?: TokenDocument | null,
+    prefill?: ResistanceRollDialogPrefill,
+    options?: Partial<foundry.applications.types.ApplicationConfiguration>,
+  ) {
+    super(options);
+    this.actor = actor;
+    this.token = token;
+    this.prefill = prefill;
+  }
+
+  static override DEFAULT_OPTIONS = {
+    id: `resistance-{id}`,
+    tag: "form",
+    classes: [systemId, "form", "roll-dialog", "resistance-roll-dialog"],
+    form: {
+      handler: ResistanceRollDialogV2.onSubmit,
+      submitOnChange: false,
+      closeOnSubmit: true,
+    },
+    position: {
+      width: "auto" as const,
+      height: "auto" as const,
+      left: 35,
+      top: 15,
+    },
+    window: {
+      contentClasses: ["standard-form"],
+      icon: "fa-solid fa-scale-unbalanced",
+      title: "RQG.Dialog.ResistanceRoll.Title",
+      resizable: false,
+    },
+  };
+
+  static override PARTS = {
+    header: { template: templatePaths.rollHeader },
+    form: { template: templatePaths.resistanceRollDialogV2, scrollable: [""] },
+    footer: { template: templatePaths.rollFooter },
+  };
+
+  override async _prepareContext(): Promise<ResistanceRollDialogContext> {
+    const formData = ((this.element &&
+      new foundry.applications.ux.FormDataExtended(this.form!, {}).object) ??
+      {}) as ResistanceRollDialogFormData;
+
+    const selfUuid = this.token?.uuid || this.actor.uuid || "";
+    const tokenOrActorOptions = getTokenOrActorOptions(
+      selfUuid,
+      this.token?.name ?? this.actor.name ?? "",
+      this.actor,
+    );
+    const defaultTargetUuid =
+      game.user?.targets.size === 1 ? (game.user.targets.first()?.document?.uuid ?? "") : "";
+
+    formData.activeTokenOrActorUuid ??= selfUuid;
+    formData.activeCharacteristics ??= "";
+    formData.activeManualLabel ??= "";
+    formData.activeManualValue ??= 0;
+
+    formData.passiveTokenOrActorUuid ??= defaultTargetUuid || MANUAL_SOURCE_VALUE;
+    formData.passiveCharacteristics ??= "";
+    formData.passiveManualLabel ??= "";
+    formData.passiveManualValue ??= 0;
+
+    if (!this.prefillApplied) {
+      applyPrefill(formData, "active", this.prefill?.active);
+      applyPrefill(formData, "passive", this.prefill?.passive);
+      this.prefillApplied = true;
+    }
+
+    formData.augmentModifier ??= "0";
+    formData.meditateModifier ??= "0";
+    formData.otherModifier ??= "0";
+    formData.otherModifierDescription ??= localize("RQG.Dialog.Common.OtherModifier");
+    formData.actorUuid ??= this.actor.uuid ?? "";
+    formData.tokenUuid ??= this.token?.uuid ?? "";
+
+    const speaker = getSpeakerCompat({ actor: this.actor, token: this.token });
+    const totalChance = ResistanceRollDialogV2.computeTotalChance(formData);
+    const active = ResistanceRollDialogV2.resolveSide(formData, "active");
+    const passive = ResistanceRollDialogV2.resolveSide(formData, "passive");
+
+    return {
+      formData: formData,
+
+      speakerName: getSpeakerDisplayName(speaker),
+      activeTokenOrActorOptions: tokenOrActorOptions,
+      passiveTokenOrActorOptions: tokenOrActorOptions,
+      characteristicOptions: getCharacteristicOptions(),
+      augmentOptions: augmentOptions,
+      meditateOptions: meditateOptions,
+
+      // RollHeader
+      rollType: localize("RQG.Roll.ResistanceRoll.Title"),
+      rollName:
+        this.prefill?.description ??
+        `${active.label || "?"} ${localize("RQG.Roll.ResistanceRoll.Vs")} ${passive.label || "?"}`,
+      baseChance: "",
+
+      // RollFooter
+      totalChance: totalChance,
+      rollMode: this.rollMode,
+      rollModes: getConfiguredRollModeOptions(),
+    };
+  }
+
+  private static resolveSide(
+    formData: ResistanceRollDialogFormData,
+    side: Side,
+  ): { value: number; label: string; actorName?: string } {
+    const fields = getSideFields(formData, side);
+    const fallbackLabel = localize(
+      side === "active" ? "RQG.Dialog.ResistanceRoll.Active" : "RQG.Dialog.ResistanceRoll.Passive",
+    );
+    return resolveCharacteristicSide(
+      fields.tokenOrActorUuid,
+      fields.characteristics,
+      fields.manualLabel,
+      fields.manualValue,
+      fallbackLabel,
+    );
+  }
+
+  private static computeTotalChance(formData: ResistanceRollDialogFormData): number {
+    const active = ResistanceRollDialogV2.resolveSide(formData, "active");
+    const passive = ResistanceRollDialogV2.resolveSide(formData, "passive");
+    return computeResistanceTargetChance(active.value, passive.value, [
+      Number(formData.augmentModifier),
+      Number(formData.meditateModifier),
+      Number(formData.otherModifier),
+    ]);
+  }
+
+  private updateLivePreview(): void {
+    const formData = new foundry.applications.ux.FormDataExtended(this.element, {})
+      .object as ResistanceRollDialogFormData;
+    this.updateTotalChanceDisplay(ResistanceRollDialogV2.computeTotalChance(formData));
+  }
+
+  private static async onSubmit(
+    event: SubmitEvent | Event,
+    form: HTMLFormElement,
+    formData: foundry.applications.ux.FormDataExtended,
+  ): Promise<void> {
+    const formDataObject = formData.object as ResistanceRollDialogFormData;
+
+    const rollMode = resolveRollModeFromForm(form);
+
+    // Independent lookups from unrelated uuids - resolved concurrently.
+    const [actor, token] = (await Promise.all([
+      fromUuid(formDataObject.actorUuid),
+      formDataObject.tokenUuid ? fromUuid(formDataObject.tokenUuid) : undefined,
+    ])) as [RqgActor | undefined, TokenDocument | undefined];
+    if (!actor) {
+      ui.notifications?.error("Could not find an actor to roll a resistance roll for.");
+      return;
+    }
+
+    const active = ResistanceRollDialogV2.resolveSide(formDataObject, "active");
+    const passive = ResistanceRollDialogV2.resolveSide(formDataObject, "passive");
+    const isSideResolved = (uuid: string, label: string) => uuid === MANUAL_SOURCE_VALUE || !!label;
+    if (
+      !isSideResolved(formDataObject.activeTokenOrActorUuid, active.label) ||
+      !isSideResolved(formDataObject.passiveTokenOrActorUuid, passive.label)
+    ) {
+      ui.notifications?.error("Pick an Active and a Passive value to roll a resistance roll.");
+      return;
+    }
+
+    const options: ResistanceRollOptions = {
+      activeValue: active.value,
+      activeLabel: active.label,
+      passiveValue: passive.value,
+      passiveLabel: passive.label,
+      passiveActorName: passive.actorName,
+      modifiers: buildResistanceModifiers(
+        formDataObject.augmentModifier,
+        formDataObject.meditateModifier,
+        formDataObject.otherModifier,
+        formDataObject.otherModifierDescription,
+      ),
+      speaker: getSpeakerCompat({ actor, token }),
+      rollMode: rollMode,
+    };
+
+    const roll = await ResistanceRoll.rollAndShow(options);
+    if (roll.successLevel == null) {
+      throw new RqgError("Evaluated ResistanceRoll didn't give successLevel");
+    }
+
+    // Award POW-experience (or any other characteristic-use bookkeeping) to whichever actor's
+    // characteristic(s) were actually used as the active side, not necessarily the dialog's own
+    // actor - both characteristics of a combo (e.g. Knockback's STR+SIZ) get checked.
+    const activeCharacteristicNames = decodeCharacteristics(formDataObject.activeCharacteristics);
+    if (formDataObject.activeTokenOrActorUuid !== MANUAL_SOURCE_VALUE) {
+      const activeActor = resolveActorFromUuid(formDataObject.activeTokenOrActorUuid);
+      if (activeActor && isDocumentSubType<CharacterActor>(activeActor, ActorTypeEnum.Character)) {
+        for (const characteristicName of activeCharacteristicNames) {
+          await activeActor.checkExperience(characteristicName, roll.successLevel);
+        }
+      }
+    }
+  }
+}

--- a/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-dialog-v2.ts
@@ -297,16 +297,15 @@ export class ResistanceRollDialogV2 extends RqgInteractiveRollApplicationBase {
       throw new RqgError("Evaluated ResistanceRoll didn't give successLevel");
     }
 
-    // Award POW-experience (or any other characteristic-use bookkeeping) to whichever actor's
-    // characteristic(s) were actually used as the active side, not necessarily the dialog's own
-    // actor - both characteristics of a combo (e.g. Knockback's STR+SIZ) get checked.
-    const activeCharacteristicNames = decodeCharacteristics(formDataObject.activeCharacteristics);
-    if (formDataObject.activeTokenOrActorUuid !== MANUAL_SOURCE_VALUE) {
+    // Only POW earns an experience check from a resistance roll, credited to whichever actor
+    // supplied the active side.
+    if (
+      formDataObject.activeTokenOrActorUuid !== MANUAL_SOURCE_VALUE &&
+      decodeCharacteristics(formDataObject.activeCharacteristics).includes("power")
+    ) {
       const activeActor = resolveActorFromUuid(formDataObject.activeTokenOrActorUuid);
       if (activeActor && isDocumentSubType<CharacterActor>(activeActor, ActorTypeEnum.Character)) {
-        for (const characteristicName of activeCharacteristicNames) {
-          await activeActor.checkExperience(characteristicName, roll.successLevel);
-        }
+        await activeActor.checkExperience("power", roll.successLevel);
       }
     }
   }

--- a/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
+++ b/src/applications/resistance-roll-dialog/resistance-roll-shared.ts
@@ -1,0 +1,226 @@
+import { systemId } from "../../system/config";
+import { MANUAL_SOURCE_VALUE } from "./resistance-roll-dialog-data.types.ts";
+import {
+  getActorLinkDecoration,
+  localize,
+  normalizeOtherModifierDescriptionForRoll,
+  warnIfMultipleTargets,
+} from "../../system/util";
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import type { Characteristics } from "../../data-model/actor-data/characteristics";
+import type { Modifier } from "../../rolls/resistance-roll/resistance-roll.types.ts";
+
+export { augmentOptions, meditateOptions } from "../app-parts/augment-meditate-options";
+
+// Shared between ResistanceRollDialogV2, ResistanceRequestDialogV2 and
+// RespondToResistanceRequestDialogV2 - the token/actor + characteristic(s) picking logic is
+// identical no matter which of those dialogs is resolving a side's value.
+
+export const characteristicNames: (keyof Characteristics)[] = [
+  "strength",
+  "constitution",
+  "size",
+  "dexterity",
+  "intelligence",
+  "power",
+  "charisma",
+];
+
+export function encodeCharacteristics(names: (keyof Characteristics)[]): string {
+  return names.join("+");
+}
+
+export function decodeCharacteristics(value: string): (keyof Characteristics)[] {
+  return value ? (value.split("+") as (keyof Characteristics)[]) : [];
+}
+
+// The Characteristic dropdown also lists the only characteristic combinations the resistance
+// table is actually used for in RAW (Knockback: STR+SIZ vs SIZ+DEX; Grapple-throw: STR+DEX vs
+// SIZ+DEX) directly, instead of a separate "+ Characteristic" picker, since there are only ever
+// these three. Anything else goes through the Manual value entry.
+// Memoized (locale/actor-independent, only built once) since it's read on every render of every
+// resistance dialog, and each entry needs its label joined from a localize() call.
+let characteristicOptionsCache: SelectOptionData<string>[] | undefined;
+
+export function getCharacteristicOptions(): SelectOptionData<string>[] {
+  if (!characteristicOptionsCache) {
+    const shortLabel = (name: keyof Characteristics) =>
+      localize(`RQG.Actor.Characteristics.${name}`);
+    characteristicOptionsCache = [
+      ...characteristicNames.map((name) => ({ value: name, label: shortLabel(name) })),
+      ...(
+        [
+          ["strength", "size"],
+          ["strength", "dexterity"],
+          ["size", "dexterity"],
+        ] as [keyof Characteristics, keyof Characteristics][]
+      ).map(([a, b]) => ({
+        value: encodeCharacteristics([a, b]),
+        label: `${shortLabel(a)} + ${shortLabel(b)}`,
+      })),
+    ];
+  }
+  return characteristicOptionsCache;
+}
+
+/**
+ * The targeted-token/owned-token/owned-actor groups shared by every side of every resistance
+ * dialog - built once per render and reused for both the Active and Passive pickers (they only
+ * differ in which "self" entry and whether a Manual option gets added on top of this).
+ */
+export function getBaseTokenOrActorOptions(): SelectOptionData<string>[] {
+  warnIfMultipleTargets();
+
+  const targetedTokenOptions: SelectOptionData<string>[] =
+    game.user?.targets.size === 1
+      ? Array.from(game.user.targets).map((t) => ({
+          value: t.document?.uuid ?? "",
+          label: (t.document?.name ?? "") + getActorLinkDecoration(t.actor),
+          group: localize("RQG.Dialog.Common.TargetedToken"),
+        }))
+      : [];
+
+  const ownedTokens = game.scenes?.current?.tokens.filter((t) => t.isOwner) ?? [];
+  const ownedTokenOptions: SelectOptionData<string>[] = ownedTokens.map((tokenDocument) => ({
+    value: tokenDocument?.uuid ?? "",
+    label: (tokenDocument?.name ?? "") + getActorLinkDecoration(tokenDocument.actor),
+    group: localize("RQG.Dialog.Common.Tokens"),
+  }));
+
+  const allowCombatWithoutToken = game.settings?.get(systemId, "allowCombatWithoutToken");
+  let ownedActorOptions: SelectOptionData<string>[] = [];
+  if (allowCombatWithoutToken) {
+    const ownedTokenActorIds = ownedTokens.map((t) => t.actor?.id);
+    ownedActorOptions =
+      game.actors
+        ?.filter((a) => a.isOwner && !ownedTokenActorIds.includes(a.id))
+        .map((actor) => ({
+          value: actor.uuid ?? "",
+          label: (actor.name ?? "") + getActorLinkDecoration(actor),
+          group: localize("RQG.Dialog.Common.Actors"),
+        })) ?? [];
+  }
+
+  return [...targetedTokenOptions, ...ownedTokenOptions, ...ownedActorOptions];
+}
+
+/**
+ * Build one side's token/actor dropdown options, mirroring the attack/defence dialogs'
+ * attacker/defender pickers: the current single target (if any) first, then the user's own
+ * tokens on the scene, then the user's own actors without a scene token, then a manual entry.
+ * `selfUuid`/`selfName`/`selfActor` are an actor/token that should always appear (even if not
+ * otherwise owned/on-scene/allowed) so a dialog can default to whoever's sheet it was opened
+ * from - pass empty strings to skip this (e.g. the GM's request dialog has no "self").
+ * `baseOptions` lets a caller building both the Active and Passive dropdowns in one render pass
+ * the shared token/actor scan in once instead of repeating it per side.
+ */
+export function getTokenOrActorOptions(
+  selfUuid: string,
+  selfName: string,
+  selfActor: RqgActor | undefined,
+  includeManual = true,
+  baseOptions: SelectOptionData<string>[] = getBaseTokenOrActorOptions(),
+): SelectOptionData<string>[] {
+  const options = [...baseOptions];
+  const selfIsMissing = !!selfUuid && !options.some((o) => o.value === selfUuid);
+  if (selfIsMissing) {
+    options.unshift({
+      value: selfUuid,
+      label: selfName + getActorLinkDecoration(selfActor),
+      group: localize("RQG.Dialog.Common.Character"),
+    });
+  }
+
+  if (includeManual) {
+    const manualOption: SelectOptionData<string> = {
+      value: MANUAL_SOURCE_VALUE,
+      label: localize("RQG.Dialog.ResistanceRoll.SourceManual"),
+      group: localize("RQG.Dialog.Common.Other"),
+    };
+    // Manual sits right after the self entry rather than at the end: the Tokens/Actors groups
+    // can grow long, and Manual shouldn't get buried below them.
+    options.splice(selfIsMissing ? 1 : 0, 0, manualOption);
+  }
+
+  return options;
+}
+
+export function resolveActorFromUuid(uuid: string): RqgActor | undefined {
+  const doc = fromUuidSync(uuid) as TokenDocument | RqgActor | undefined;
+  return (doc instanceof TokenDocument ? doc.actor : doc) as RqgActor | undefined;
+}
+
+export function resolveCharacteristicValue(actor: RqgActor, name: keyof Characteristics): number {
+  const characteristics = (actor.system as unknown as { characteristics: Characteristics })
+    .characteristics;
+  return characteristics?.[name]?.value ?? 0;
+}
+
+export function resolveCharacteristicLabel(name: keyof Characteristics): string {
+  return localize(`RQG.Actor.Characteristics.${name}`);
+}
+
+/**
+ * Resolve a side's numeric value + display label, either from an actor/token's characteristic(s)
+ * (summed for the two-characteristic combos) or from a manual label/value pair. `manualName`
+ * lets a manual entry play the same role an actor-sourced passive's name does (the "opposes X"
+ * flavor line) - e.g. naming a disease or obstacle instead of leaving it anonymous.
+ */
+export function resolveCharacteristicSide(
+  tokenOrActorUuid: string,
+  characteristicsEncoded: string,
+  manualLabel: string,
+  manualValue: number,
+  fallbackLabel: string,
+  manualName?: string,
+): { value: number; label: string; actorName?: string } {
+  if (tokenOrActorUuid === MANUAL_SOURCE_VALUE) {
+    return {
+      value: Number(manualValue) || 0,
+      label: manualLabel || fallbackLabel,
+      actorName: manualName || undefined,
+    };
+  }
+
+  const sourceActor = tokenOrActorUuid ? resolveActorFromUuid(tokenOrActorUuid) : undefined;
+  const names = decodeCharacteristics(characteristicsEncoded);
+  if (!sourceActor || names.length === 0) {
+    return { value: 0, label: "" };
+  }
+
+  const value = names.reduce((sum, name) => sum + resolveCharacteristicValue(sourceActor, name), 0);
+  const label = names.map((name) => resolveCharacteristicLabel(name)).join(" + ");
+  return { value, label, actorName: sourceActor.name ?? undefined };
+}
+
+/**
+ * Restrict token/actor options to ones with an actual player owner. A GM owns every token, so the
+ * unfiltered list would let them pick an NPC/monster as who should roll a resistance *request* -
+ * nobody but the GM could ever click that card's Roll button. Only meant for the request dialog's
+ * Active picker; every other use of `getTokenOrActorOptions` legitimately wants any owned token.
+ */
+export function filterToPlayerOwnedOptions(
+  options: SelectOptionData<string>[],
+): SelectOptionData<string>[] {
+  return options.filter((option) => resolveActorFromUuid(option.value)?.hasPlayerOwner);
+}
+
+/**
+ * Build the Augment/Meditate/Other modifier list from a roll dialog's form fields, in the shape
+ * `ResistanceRoll` expects - shared by every dialog that actually performs the roll.
+ */
+export function buildResistanceModifiers(
+  augmentModifier: unknown,
+  meditateModifier: unknown,
+  otherModifier: unknown,
+  otherModifierDescription: string,
+): Modifier[] {
+  return [
+    { value: Number(augmentModifier), description: localize("RQG.Roll.Common.Augment") },
+    { value: Number(meditateModifier), description: localize("RQG.Roll.Common.Meditate") },
+    {
+      value: Number(otherModifier),
+      description: normalizeOtherModifierDescriptionForRoll(otherModifierDescription),
+    },
+  ];
+}

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-data.types.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-data.types.ts
@@ -1,0 +1,21 @@
+import type { RollHeaderData } from "../app-parts/roll-header.types.ts";
+import type { RollFooterData } from "../app-parts/roll-footer.types.ts";
+
+export type RespondToResistanceRequestDialogContext = RollHeaderData &
+  RollFooterData & {
+    formData: RespondToResistanceRequestDialogFormData;
+    speakerName: string;
+    activeLabel: string;
+    passiveLabel: string;
+    augmentOptions: SelectOptionData<number>[];
+    meditateOptions: SelectOptionData<number>[];
+  };
+
+export type RespondToResistanceRequestDialogFormData = {
+  augmentModifier: string;
+  meditateModifier: string;
+  otherModifier: string;
+  otherModifierDescription: string;
+
+  chatMessageUuid: string; // hidden field - the resistanceRequest chat message being answered
+};

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.hbs
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.hbs
@@ -1,0 +1,31 @@
+<div class="scrollable">
+  <div class="key-value-grid p-0">
+    <label>{{localize "RQG.Dialog.Common.Character"}}</label>
+    <div>{{speakerName}}</div>
+
+    <label>{{localize "RQG.Dialog.ResistanceRoll.Active"}}</label>
+    <div>{{activeLabel}}</div>
+
+    <label>{{localize "RQG.Dialog.ResistanceRoll.Passive"}}</label>
+    <div>{{passiveLabel}}</div>
+  </div>
+
+  <div class="key-value-grid p-0">
+    <label>{{localize "RQG.Dialog.CharacteristicRoll.Augment"}}</label>
+    <select name="augmentModifier">
+      {{selectOptions augmentOptions selected=formData.augmentModifier localize=true}}
+    </select>
+
+    <label>{{localize "RQG.Dialog.CharacteristicRoll.Meditate"}}</label>
+    <select name="meditateModifier">
+      {{selectOptions meditateOptions selected=formData.meditateModifier localize=true}}
+    </select>
+
+    <input type="text" style="text-align:end;font-weight:bold;" value="{{formData.otherModifierDescription}}" name="otherModifierDescription">
+    <div>
+      <input type="number" value="{{formData.otherModifier}}" name="otherModifier"> %
+    </div>
+  </div>
+
+  <input type="hidden" value="{{formData.chatMessageUuid}}" name="chatMessageUuid">
+</div>

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -1,0 +1,277 @@
+import { systemId } from "../../system/config";
+import { templatePaths } from "../../system/load-handlebars-templates";
+import type {
+  RespondToResistanceRequestDialogContext,
+  RespondToResistanceRequestDialogFormData,
+} from "./respond-to-resistance-request-dialog-data.types.ts";
+import {
+  activateChatTab,
+  getSpeakerDisplayName,
+  isDocumentSubType,
+  localize,
+} from "../../system/util";
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import { ActorTypeEnum, type CharacterActor } from "../../data-model/actor-data/rqg-actor-data";
+import type { ResistanceRollOptions } from "../../rolls/resistance-roll/resistance-roll.types";
+import { ResistanceRoll } from "../../rolls/resistance-roll/resistance-roll";
+import { computeResistanceTargetChance } from "../../rolls/resistance-roll/resistance-roll-formula.ts";
+import {
+  augmentOptions,
+  buildResistanceModifiers,
+  decodeCharacteristics,
+  meditateOptions,
+  resolveCharacteristicLabel,
+  resolveCharacteristicValue,
+} from "./resistance-roll-shared.ts";
+import { getConfiguredRollModeOptions, resolveRollModeFromForm } from "../app-parts/roll-mode";
+import { RqgInteractiveRollApplicationBase } from "../app-parts/rqg-interactive-roll-application-base";
+import { getSpeakerCompat } from "../../system/fvtt-type-compat";
+import { updateChatMessage } from "../../sockets/socketable-requests";
+import type { ResistanceRequestChatMessage } from "../../chat/data-model/resistance-request-chat-message.types.ts";
+import { RqgLogger } from "../../system/logging/rqg-logger";
+
+const logger = new RqgLogger("RespondToResistanceRequestDialogV2");
+
+/**
+ * Recipient-facing dialog (#758 option C): answers a GM-posted resistance-request chat card. The
+ * Active side (who rolls, with what characteristic(s)) and the Passive side's value are both
+ * fixed by the request - the recipient only picks their own Augment/Meditate/Other modifiers,
+ * same as ResistanceRollDialogV2, before rolling. On submit the roll is written back onto the
+ * original chat message (via a socket update if the GM, not the recipient, authored it) instead
+ * of creating a new one.
+ */
+export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplicationBase {
+  protected override getLivePreviewFormBehaviorConfig() {
+    return {
+      submitButtonSelectorForBlurGuard: "button[data-ability-roll]",
+      updateLivePreview: () => this.updateLivePreview(),
+    };
+  }
+
+  private requestChatMessage: ResistanceRequestChatMessage;
+  private activeValue = 0;
+  private passiveValue = 0;
+
+  constructor(
+    chatMessageId: string,
+    options?: Partial<foundry.applications.types.ApplicationConfiguration>,
+  ) {
+    super(options);
+    const requestChatMessage = game.messages?.get(chatMessageId ?? "") as
+      ResistanceRequestChatMessage | undefined;
+    if (!requestChatMessage) {
+      logger.throw("No resistance request chat message found", { chatMessageId });
+    }
+    this.requestChatMessage = requestChatMessage!;
+  }
+
+  static override DEFAULT_OPTIONS = {
+    id: `resistance-request-respond-{id}`,
+    tag: "form",
+    classes: [systemId, "form", "roll-dialog", "resistance-roll-dialog"],
+    form: {
+      handler: RespondToResistanceRequestDialogV2.onSubmit,
+      submitOnChange: false,
+      closeOnSubmit: true,
+    },
+    position: {
+      width: "auto" as const,
+      height: "auto" as const,
+      left: 35,
+      top: 15,
+    },
+    window: {
+      contentClasses: ["standard-form"],
+      icon: "fa-solid fa-scale-unbalanced",
+      title: "RQG.Dialog.ResistanceRoll.Title",
+      resizable: false,
+    },
+  };
+
+  static override PARTS = {
+    header: { template: templatePaths.rollHeader },
+    form: { template: templatePaths.respondToResistanceRequestDialogV2, scrollable: [""] },
+    footer: { template: templatePaths.rollFooter },
+  };
+
+  private static resolveTarget(requestChatMessage: ResistanceRequestChatMessage): {
+    actor: RqgActor | undefined;
+    token: TokenDocument | undefined;
+  } {
+    const tokenOrActor = fromUuidSync(requestChatMessage.system.targetTokenOrActorUuid) as
+      TokenDocument | RqgActor | undefined;
+    return {
+      actor: (tokenOrActor instanceof TokenDocument ? tokenOrActor.actor : tokenOrActor) as
+        RqgActor | undefined,
+      token: tokenOrActor instanceof TokenDocument ? tokenOrActor : undefined,
+    };
+  }
+
+  // Takes the already-resolved actor rather than re-deriving it via resolveTarget() itself, so
+  // callers that need both only look the target up once.
+  private static resolveActive(
+    actor: RqgActor | undefined,
+    activeCharacteristics: string,
+  ): { value: number; label: string } {
+    const names = decodeCharacteristics(activeCharacteristics);
+    if (!actor || names.length === 0) {
+      return { value: 0, label: "" };
+    }
+    return {
+      value: names.reduce((sum, name) => sum + resolveCharacteristicValue(actor, name), 0),
+      label: names.map((name) => resolveCharacteristicLabel(name)).join(" + "),
+    };
+  }
+
+  override async _prepareContext(): Promise<RespondToResistanceRequestDialogContext> {
+    const formData = ((this.element &&
+      new foundry.applications.ux.FormDataExtended(this.form!, {}).object) ??
+      {}) as RespondToResistanceRequestDialogFormData;
+
+    const { actor, token } = RespondToResistanceRequestDialogV2.resolveTarget(
+      this.requestChatMessage,
+    );
+    const active = RespondToResistanceRequestDialogV2.resolveActive(
+      actor,
+      this.requestChatMessage.system.activeCharacteristics,
+    );
+    this.activeValue = active.value;
+    this.passiveValue = this.requestChatMessage.system.passiveValue;
+
+    // Defaults come from the GM's request, but the recipient can still change them before rolling.
+    formData.augmentModifier ??= String(this.requestChatMessage.system.augmentModifier ?? 0);
+    formData.meditateModifier ??= String(this.requestChatMessage.system.meditateModifier ?? 0);
+    formData.otherModifier ??= String(this.requestChatMessage.system.otherModifier ?? 0);
+    formData.otherModifierDescription ??=
+      this.requestChatMessage.system.otherModifierDescription ||
+      localize("RQG.Dialog.Common.OtherModifier");
+    formData.chatMessageUuid ??= this.requestChatMessage.uuid ?? "";
+
+    const speaker = getSpeakerCompat({ actor: actor, token: token });
+    const passiveLabel = this.requestChatMessage.system.passiveLabel;
+
+    return {
+      formData: formData,
+      speakerName: getSpeakerDisplayName(speaker),
+      activeLabel: active.label,
+      passiveLabel: passiveLabel,
+      augmentOptions: augmentOptions,
+      meditateOptions: meditateOptions,
+
+      // RollHeader
+      rollType: localize("RQG.Roll.ResistanceRoll.Title"),
+      rollName: `${active.label || "?"} ${localize("RQG.Roll.ResistanceRoll.Vs")} ${passiveLabel || "?"}`,
+      baseChance: "",
+
+      // RollFooter
+      totalChance: RespondToResistanceRequestDialogV2.computeTotalChance(
+        this.activeValue,
+        this.passiveValue,
+        formData,
+      ),
+      rollMode: this.rollMode,
+      rollModes: getConfiguredRollModeOptions(),
+    };
+  }
+
+  private static computeTotalChance(
+    activeValue: number,
+    passiveValue: number,
+    formData: RespondToResistanceRequestDialogFormData,
+  ): number {
+    return computeResistanceTargetChance(activeValue, passiveValue, [
+      Number(formData.augmentModifier),
+      Number(formData.meditateModifier),
+      Number(formData.otherModifier),
+    ]);
+  }
+
+  private updateLivePreview(): void {
+    const formData = new foundry.applications.ux.FormDataExtended(this.element, {})
+      .object as RespondToResistanceRequestDialogFormData;
+    this.updateTotalChanceDisplay(
+      RespondToResistanceRequestDialogV2.computeTotalChance(
+        this.activeValue,
+        this.passiveValue,
+        formData,
+      ),
+    );
+  }
+
+  private static async onSubmit(
+    event: SubmitEvent | Event,
+    form: HTMLFormElement,
+    formData: foundry.applications.ux.FormDataExtended,
+  ): Promise<void> {
+    const formDataObject = formData.object as RespondToResistanceRequestDialogFormData;
+
+    // @ts-expect-error close - close immediately instead of waiting for the roll animation
+    this.close();
+
+    const requestChatMessage = (await fromUuid(formDataObject.chatMessageUuid)) as
+      ResistanceRequestChatMessage | undefined;
+    if (!requestChatMessage) {
+      logger.throw("Resistance request chat message not found", formDataObject);
+    }
+
+    const { actor, token } = RespondToResistanceRequestDialogV2.resolveTarget(requestChatMessage!);
+    const activeCharacteristicNames = decodeCharacteristics(
+      requestChatMessage!.system.activeCharacteristics,
+    );
+    const active = RespondToResistanceRequestDialogV2.resolveActive(
+      actor,
+      requestChatMessage!.system.activeCharacteristics,
+    );
+    if (!actor || !active.label) {
+      ui.notifications?.error("Could not find who this resistance request is for.");
+      return;
+    }
+
+    const options: ResistanceRollOptions = {
+      activeValue: active.value,
+      activeLabel: active.label,
+      passiveValue: requestChatMessage!.system.passiveValue,
+      passiveLabel: requestChatMessage!.system.passiveLabel,
+      passiveActorName: requestChatMessage!.system.passiveActorName,
+      modifiers: buildResistanceModifiers(
+        formDataObject.augmentModifier,
+        formDataObject.meditateModifier,
+        formDataObject.otherModifier,
+        formDataObject.otherModifierDescription,
+      ),
+      speaker: getSpeakerCompat({ actor: actor, token: token }),
+      rollMode: resolveRollModeFromForm(form),
+    };
+
+    const roll = new ResistanceRoll(undefined, {}, options);
+    await roll.evaluate();
+
+    if (game.dice3d) {
+      await game.dice3d.showForRoll(roll, game.user, true, null, false);
+    }
+
+    const messageData = requestChatMessage!.toObject();
+    foundry.utils.mergeObject(
+      messageData,
+      { system: { state: "Rolled", resistanceRoll: roll.toJSON() } },
+      { overwrite: true },
+    );
+    messageData.content = await foundry.applications.handlebars.renderTemplate(
+      templatePaths.resistanceRequestChatMessage,
+      messageData.system,
+    );
+
+    activateChatTab();
+    await updateChatMessage(requestChatMessage!, messageData);
+
+    // Both characteristics of a combo (e.g. Knockback's STR+SIZ) get checked, not just the first.
+    if (
+      isDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character) &&
+      roll.successLevel != null
+    ) {
+      for (const characteristicName of activeCharacteristicNames) {
+        await actor.checkExperience(characteristicName, roll.successLevel);
+      }
+    }
+  }
+}

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -138,9 +138,10 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
     this.activeValue = active.value;
     this.passiveValue = this.requestChatMessage.system.passiveValue;
 
-    // Defaults come from the GM's request, but the recipient can still change them before rolling.
-    formData.augmentModifier ??= String(this.requestChatMessage.system.augmentModifier ?? 0);
-    formData.meditateModifier ??= String(this.requestChatMessage.system.meditateModifier ?? 0);
+    // Augment/Meditate are the roller's own tactical choices. Only the situational Other modifier
+    // is seeded from the GM's request; the recipient can still change it before rolling.
+    formData.augmentModifier ??= "0";
+    formData.meditateModifier ??= "0";
     formData.otherModifier ??= String(this.requestChatMessage.system.otherModifier ?? 0);
     formData.otherModifierDescription ??=
       this.requestChatMessage.system.otherModifierDescription ||

--- a/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
+++ b/src/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.ts
@@ -215,9 +215,6 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
     }
 
     const { actor, token } = RespondToResistanceRequestDialogV2.resolveTarget(requestChatMessage!);
-    const activeCharacteristicNames = decodeCharacteristics(
-      requestChatMessage!.system.activeCharacteristics,
-    );
     const active = RespondToResistanceRequestDialogV2.resolveActive(
       actor,
       requestChatMessage!.system.activeCharacteristics,
@@ -264,14 +261,13 @@ export class RespondToResistanceRequestDialogV2 extends RqgInteractiveRollApplic
     activateChatTab();
     await updateChatMessage(requestChatMessage!, messageData);
 
-    // Both characteristics of a combo (e.g. Knockback's STR+SIZ) get checked, not just the first.
+    // Only POW earns an experience check from a resistance roll.
     if (
       isDocumentSubType<CharacterActor>(actor, ActorTypeEnum.Character) &&
-      roll.successLevel != null
+      roll.successLevel != null &&
+      decodeCharacteristics(requestChatMessage!.system.activeCharacteristics).includes("power")
     ) {
-      for (const characteristicName of activeCharacteristicNames) {
-        await actor.checkExperience(characteristicName, roll.successLevel);
-      }
+      await actor.checkExperience("power", roll.successLevel);
     }
   }
 }

--- a/src/chat/data-model/resistance-request-chat-message.data-model.ts
+++ b/src/chat/data-model/resistance-request-chat-message.data-model.ts
@@ -1,0 +1,57 @@
+import { resistanceRequestState } from "./resistance-request-chat-message.defs.ts";
+import { enumChoices } from "../../data-model/shared/enum-choices";
+
+const { NumberField, StringField, DocumentUUIDField, JSONField } = foundry.data.fields;
+
+const resistanceRequestChatMessageSchema = {
+  state: new StringField({
+    blank: false,
+    nullable: false,
+    initial: resistanceRequestState[0],
+    choices: enumChoices(resistanceRequestState, "RQG.Chat.ResistanceRequest.State."),
+  }),
+  targetTokenOrActorUuid: new DocumentUUIDField({
+    blank: false,
+    nullable: false,
+    required: true,
+  }),
+  activeCharacteristics: new StringField({ blank: false, nullable: false, required: true }),
+  passiveValue: new NumberField({ nullable: false, required: true, initial: 0 }),
+  passiveLabel: new StringField({ blank: false, nullable: false, required: true }),
+  // The obstacle/disease/passive character's name, if any - either an actor's own name, or a
+  // GM-typed one for a Manual passive value. Feeds the roll's "opposes X" flavor line.
+  passiveActorName: new StringField({
+    blank: true,
+    nullable: true,
+    initial: undefined,
+    required: false,
+  }),
+  // GM-prefilled defaults for the recipient's Augment/Meditate/Other modifiers - the recipient can
+  // still change them before rolling, same as ResistanceRollDialogV2.
+  augmentModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
+  meditateModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
+  otherModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
+  otherModifierDescription: new StringField({
+    blank: true,
+    nullable: true,
+    initial: undefined,
+    required: false,
+  }),
+  resistanceRoll: new JSONField({
+    blank: false,
+    nullable: true,
+    required: false,
+    initial: undefined,
+  }),
+} as const;
+
+type resistanceRequestDataType = typeof resistanceRequestChatMessageSchema;
+
+export class ResistanceRequestChatMessageData extends foundry.abstract.TypeDataModel<
+  resistanceRequestDataType,
+  any
+> {
+  static override defineSchema() {
+    return resistanceRequestChatMessageSchema;
+  }
+}

--- a/src/chat/data-model/resistance-request-chat-message.data-model.ts
+++ b/src/chat/data-model/resistance-request-chat-message.data-model.ts
@@ -26,10 +26,8 @@ const resistanceRequestChatMessageSchema = {
     initial: undefined,
     required: false,
   }),
-  // GM-prefilled defaults for the recipient's Augment/Meditate/Other modifiers - the recipient can
-  // still change them before rolling, same as ResistanceRollDialogV2.
-  augmentModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
-  meditateModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
+  // The GM's situational modifier for the contest - seeds the roller's Other modifier, which they
+  // can still change before rolling.
   otherModifier: new NumberField({ nullable: false, required: false, initial: 0 }),
   otherModifierDescription: new StringField({
     blank: true,

--- a/src/chat/data-model/resistance-request-chat-message.defs.ts
+++ b/src/chat/data-model/resistance-request-chat-message.defs.ts
@@ -1,0 +1,1 @@
+export const resistanceRequestState = ["Requested", "Rolled"] as const;

--- a/src/chat/data-model/resistance-request-chat-message.types.ts
+++ b/src/chat/data-model/resistance-request-chat-message.types.ts
@@ -1,0 +1,38 @@
+import type { resistanceRequestState } from "./resistance-request-chat-message.defs";
+
+export type ResistanceRequestState = (typeof resistanceRequestState)[number];
+
+// Narrowed actor type for subtype "resistanceRequest"
+export type ResistanceRequestChatMessage = ChatMessage & {
+  system: ResistanceRequestDataPropertiesData;
+};
+
+export interface ResistanceRequestDataSourceData {
+  state: ResistanceRequestState;
+  targetTokenOrActorUuid: string;
+  /** One characteristic name, or two joined by "+" (e.g. "strength+size") - what the target rolls. */
+  activeCharacteristics: string;
+  /** Snapshotted passive value/label set by the GM when the request was sent (e.g. a disease's POT). */
+  passiveValue: number;
+  passiveLabel: string;
+  /** The obstacle/disease/passive character's name, if any - feeds the "opposes X" flavor line. */
+  passiveActorName: string | undefined;
+  /** GM-prefilled defaults for the recipient's modifiers - still editable before rolling. */
+  augmentModifier: number;
+  meditateModifier: number;
+  otherModifier: number;
+  otherModifierDescription: string | undefined;
+  resistanceRoll: string | object | undefined; // JSONField can be string or parsed object
+}
+
+export interface ResistanceRequestDataPropertiesData extends ResistanceRequestDataSourceData {}
+
+export interface ResistanceRequestDataSource {
+  type: "resistanceRequest";
+  system: ResistanceRequestDataSourceData;
+}
+
+export interface ResistanceRequestDataProperties {
+  type: "resistanceRequest";
+  system: ResistanceRequestDataPropertiesData;
+}

--- a/src/chat/data-model/resistance-request-chat-message.types.ts
+++ b/src/chat/data-model/resistance-request-chat-message.types.ts
@@ -17,9 +17,7 @@ export interface ResistanceRequestDataSourceData {
   passiveLabel: string;
   /** The obstacle/disease/passive character's name, if any - feeds the "opposes X" flavor line. */
   passiveActorName: string | undefined;
-  /** GM-prefilled defaults for the recipient's modifiers - still editable before rolling. */
-  augmentModifier: number;
-  meditateModifier: number;
+  /** The GM's situational modifier for the contest - seeds the roller's Other modifier. */
   otherModifier: number;
   otherModifierDescription: string | undefined;
   resistanceRoll: string | object | undefined; // JSONField can be string or parsed object

--- a/src/chat/resistance-request-chat-template.hbs
+++ b/src/chat/resistance-request-chat-template.hbs
@@ -1,0 +1,9 @@
+<div class="rqg chat-card">
+  {{#if (eq state 'Requested')}}
+    <button class="resistance-request-roll" data-only-owner-visible-uuid="{{targetTokenOrActorUuid}}"
+            data-roll-resistance-request>{{localize "RQG.ChatMessage.ResistanceRequest.Roll"}}
+    </button>
+  {{else}}
+    <span data-resistance-roll-html></span>
+  {{/if}}
+</div>

--- a/src/chat/resistance-request-handlers.ts
+++ b/src/chat/resistance-request-handlers.ts
@@ -1,0 +1,12 @@
+import { getRequiredDomDataset } from "../system/util";
+
+/**
+ * Open the dialog to respond to (and roll) a GM-posted resistance-request chat card (#758
+ * option C).
+ */
+export async function handleRollResistanceRequest(clickedButton: HTMLButtonElement): Promise<void> {
+  const chatMessageId = getRequiredDomDataset(clickedButton, "message-id");
+  const { RespondToResistanceRequestDialogV2 } =
+    await import("../applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2");
+  await new RespondToResistanceRequestDialogV2(chatMessageId).render({ force: true });
+}

--- a/src/chat/rqg-chat-message.ts
+++ b/src/chat/rqg-chat-message.ts
@@ -5,14 +5,18 @@ import {
   handleRollDamageAndHitLocation,
   handleRollFumble,
 } from "./attack-flow-handlers";
+import { handleRollResistanceRequest } from "./resistance-request-handlers";
 import { AbilityRoll } from "../rolls/ability-roll/ability-roll";
 import { isFoundryElementInstanceOf, localize, safeFromJSON } from "../system/util";
 import { DamageRoll } from "../rolls/damage-roll/damage-roll";
 import { HitLocationRoll } from "../rolls/hit-location-roll/hit-location-roll";
+import { ResistanceRoll } from "../rolls/resistance-roll/resistance-roll";
 
 import { templatePaths } from "../system/load-handlebars-templates";
 import { CombatChatMessageData } from "./data-model/combat-chat-message.data-model.ts";
 import type { CombatDataProperties } from "./data-model/combat-chat-message.types.ts";
+import { ResistanceRequestChatMessageData } from "./data-model/resistance-request-chat-message.data-model.ts";
+import type { ResistanceRequestDataProperties } from "./data-model/resistance-request-chat-message.types.ts";
 
 // TODO how to type this so combat subtype data is typed?
 export class RqgChatMessage extends ChatMessage {
@@ -21,6 +25,7 @@ export class RqgChatMessage extends ChatMessage {
     CONFIG.ChatMessage.template = templatePaths.chatMessage;
 
     CONFIG.ChatMessage.dataModels["combat"] = CombatChatMessageData;
+    CONFIG.ChatMessage.dataModels["resistanceRequest"] = ResistanceRequestChatMessageData;
 
     Hooks.on("ready", () => {
       // one listener for sidebar chat, popped out chat & chat notification
@@ -94,6 +99,11 @@ export class RqgChatMessage extends ChatMessage {
     // *************************
     // *** END - Attack Flow ***
     // *************************
+
+    if (clickedButton?.dataset["rollResistanceRequest"] != null) {
+      RqgChatMessage.commonClickHandling(clickEvent, clickedButton);
+      await handleRollResistanceRequest(clickedButton); // Open the resistance request response dialog
+    }
   }
 
   private static commonClickHandling(clickEvent: MouseEvent, clickedButton: HTMLButtonElement) {
@@ -115,6 +125,12 @@ export class RqgChatMessage extends ChatMessage {
     await this.#enrichHtmlWithRoll(html, "defenceRoll", "[data-defence-roll-html]");
     await this.#enrichHtmlWithRoll(html, "damageRoll", "[data-damage-roll-html]");
     await this.#enrichHtmlWithRoll(html, "hitLocationRoll", "[data-hit-location-roll-html]");
+    await this.#enrichHtmlWithRoll(
+      html,
+      "resistanceRoll",
+      "[data-resistance-roll-html]",
+      ResistanceRoll,
+    );
 
     this.#hideHtmlElementsByOwnership(html);
 
@@ -165,9 +181,10 @@ export class RqgChatMessage extends ChatMessage {
     html: HTMLElement,
     systemDataRollName: string,
     domSelector: string,
+    RollClass: any = AbilityRoll,
   ): Promise<void> {
     const rollJson = (this.system as any)[systemDataRollName];
-    const roll = safeFromJSON<AbilityRoll>(AbilityRoll, rollJson);
+    const roll = safeFromJSON<AbilityRoll | ResistanceRoll>(RollClass, rollJson);
     if (roll?.isEvaluated) {
       const element = html.querySelector<HTMLElement>(domSelector);
       if (element) {
@@ -243,6 +260,16 @@ export class RqgChatMessage extends ChatMessage {
           `HitLocationRoll: ${hitLocationRoll.formula} = ${hitLocationRoll.total} = ${hitLocationRoll.hitLocationName}`,
         );
       }
+    } else if (this.isResistanceRequestMessage()) {
+      const resistanceRoll = safeFromJSON<ResistanceRoll>(
+        ResistanceRoll,
+        this.system.resistanceRoll,
+      );
+      if (resistanceRoll?.isEvaluated) {
+        content.push(
+          `ResistanceRoll: ${resistanceRoll.total} / ${resistanceRoll.targetChance} = ${localize(`RQG.Game.AbilityResultEnum.${resistanceRoll.successLevel}`)}`,
+        );
+      }
     }
 
     // Author and timestamp TODO users locale (don't have that), or maybe Gloranthan time formatting?
@@ -258,5 +285,9 @@ export class RqgChatMessage extends ChatMessage {
 
   isCombatMessage(): this is CombatDataProperties {
     return this.type === "combat";
+  }
+
+  isResistanceRequestMessage(): this is ResistanceRequestDataProperties {
+    return this.type === "resistanceRequest";
   }
 }

--- a/src/combat/rqg-combat-tracker.ts
+++ b/src/combat/rqg-combat-tracker.ts
@@ -141,6 +141,21 @@ export class RqgCombatTracker<
           }
         },
       },
+      {
+        label: "RQG.Game.RequestResistanceRoll",
+        icon: '<i class="fa-solid fa-scale-unbalanced fa-fw"></i>',
+        visible: () => game.user?.isGM ?? false,
+        onClick: async (_event: Event, li: HTMLElement) => {
+          const combatant = getCombatant(li);
+          const uuid = combatant?.token?.uuid ?? combatant?.actor?.uuid;
+          if (!uuid) {
+            return;
+          }
+          const { openResistanceRequest } =
+            await import("../applications/resistance-roll-dialog/open-resistance-request");
+          await openResistanceRequest(uuid);
+        },
+      },
     ];
     return entries as unknown as ContextMenu.Entry<HTMLElement>[];
   }

--- a/src/data-model/item-data/rune-magic-data-model.ts
+++ b/src/data-model/item-data/rune-magic-data-model.ts
@@ -2,7 +2,7 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
-import { promptResistanceRollForSuccessfulCast } from "../shared/spell-resistance-check";
+import { maybePromptResistanceRollForCast } from "../shared/spell-resistance-check";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { rqidLinkArraySchemaField } from "../shared/rqid-link-field";
@@ -33,7 +33,6 @@ import {
   spellItemTypes,
   SpellDurationEnum,
   SpellRangeEnum,
-  SpellResistanceCheckEnum,
 } from "./spell";
 
 export type RuneMagicItem = RqgItem & { system: Item.SystemOfType<"runeMagic"> };
@@ -353,16 +352,13 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
       boundSpiritDrainDecision.avoidRelease,
     );
 
-    if (
-      this.resistanceCheck === SpellResistanceCheckEnum.Single &&
-      runeMagicRoll.successLevel <= AbilitySuccessLevelEnum.Success
-    ) {
-      await promptResistanceRollForSuccessfulCast(
-        casterActor,
-        token,
-        runeMagicItemTyped.name ?? undefined,
-      );
-    }
+    await maybePromptResistanceRollForCast(
+      this.resistanceCheck,
+      runeMagicRoll.successLevel,
+      casterActor,
+      token,
+      runeMagicItemTyped.name ?? undefined,
+    );
   }
 
   /**

--- a/src/data-model/item-data/rune-magic-data-model.ts
+++ b/src/data-model/item-data/rune-magic-data-model.ts
@@ -2,7 +2,7 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
-import { maybePromptResistanceRollForCast } from "../shared/spell-resistance-check";
+import { maybePromptResistanceRollForCast } from "../shared/spell-resisted-by";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { rqidLinkArraySchemaField } from "../shared/rqid-link-field";
@@ -353,7 +353,7 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
     );
 
     await maybePromptResistanceRollForCast(
-      this.resistanceCheck,
+      this.resistedBy,
       runeMagicRoll.successLevel,
       casterActor,
       token,

--- a/src/data-model/item-data/rune-magic-data-model.ts
+++ b/src/data-model/item-data/rune-magic-data-model.ts
@@ -2,6 +2,7 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
+import { promptResistanceRollForSuccessfulCast } from "../shared/spell-resistance-check";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { rqidLinkArraySchemaField } from "../shared/rqid-link-field";
@@ -32,6 +33,7 @@ import {
   spellItemTypes,
   SpellDurationEnum,
   SpellRangeEnum,
+  SpellResistanceCheckEnum,
 } from "./spell";
 
 export type RuneMagicItem = RqgItem & { system: Item.SystemOfType<"runeMagic"> };
@@ -350,6 +352,17 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
       casterActor,
       boundSpiritDrainDecision.avoidRelease,
     );
+
+    if (
+      this.resistanceCheck === SpellResistanceCheckEnum.Single &&
+      runeMagicRoll.successLevel <= AbilitySuccessLevelEnum.Success
+    ) {
+      await promptResistanceRollForSuccessfulCast(
+        casterActor,
+        token,
+        runeMagicItemTyped.name ?? undefined,
+      );
+    }
   }
 
   /**

--- a/src/data-model/item-data/spell.ts
+++ b/src/data-model/item-data/spell.ts
@@ -32,14 +32,23 @@ export const SpellConcentrationEnum = {
 export type SpellConcentrationEnum =
   (typeof SpellConcentrationEnum)[keyof typeof SpellConcentrationEnum];
 
-// Only None/Single are handled; areaOneRoll (Harmony/Inviolable) and perTarget (Turn Undead etc.)
-// are planned - see #1066.
-export const SpellResistanceCheckEnum = {
+// How an unwilling target can stop a spell taking effect. Only `None` and `ResistanceRoll` are
+// implemented; the rest are declared so content is authored once, and are inert (treated as "no
+// automated step") until their own issues wire them up - see #1068.
+export const SpellResistedByEnum = {
   None: "none",
-  Single: "single",
+  // one resistance roll, single target
+  ResistanceRoll: "resistanceRoll",
+  // caster rolls one d100; every target in the radius is checked against that one roll
+  ResistanceRollArea: "resistanceRollArea",
+  // a separate resistance roll per target in the area
+  ResistanceRollPerTarget: "resistanceRollPerTarget",
+  // gated on winning one round of spirit combat (target typically willing/weak - e.g. Bind Ghost)
+  SpiritCombatRound: "spiritCombatRound",
+  // gated on driving the target to 0 magic points in spirit combat (e.g. Spirit Binding, Control X)
+  SpiritCombatDefeat: "spiritCombatDefeat",
 } as const;
-export type SpellResistanceCheckEnum =
-  (typeof SpellResistanceCheckEnum)[keyof typeof SpellResistanceCheckEnum];
+export type SpellResistedByEnum = (typeof SpellResistedByEnum)[keyof typeof SpellResistedByEnum];
 
 // Se core book p247
 export interface Spell {
@@ -51,7 +60,7 @@ export interface Spell {
   isRitual: boolean;
   /** Requires POW sacrifice by caster (possibly from others see core book p249) */
   isEnchantment: boolean;
-  /** POW vs POW resistance roll against the caster's target after a successful cast (p.145-147, 254) */
-  resistanceCheck: SpellResistanceCheckEnum;
+  /** How an unwilling target can resist the spell after a successful cast (p.145-147, 254) */
+  resistedBy: SpellResistedByEnum;
   descriptionRqidLink: RqidLink | undefined;
 }

--- a/src/data-model/item-data/spell.ts
+++ b/src/data-model/item-data/spell.ts
@@ -32,6 +32,15 @@ export const SpellConcentrationEnum = {
 export type SpellConcentrationEnum =
   (typeof SpellConcentrationEnum)[keyof typeof SpellConcentrationEnum];
 
+// Only None/Single are handled; areaOneRoll (Harmony/Inviolable) and perTarget (Turn Undead etc.)
+// are planned - see #1066.
+export const SpellResistanceCheckEnum = {
+  None: "none",
+  Single: "single",
+} as const;
+export type SpellResistanceCheckEnum =
+  (typeof SpellResistanceCheckEnum)[keyof typeof SpellResistanceCheckEnum];
+
 // Se core book p247
 export interface Spell {
   /** Learned strength */
@@ -42,5 +51,7 @@ export interface Spell {
   isRitual: boolean;
   /** Requires POW sacrifice by caster (possibly from others see core book p249) */
   isEnchantment: boolean;
+  /** POW vs POW resistance roll against the caster's target after a successful cast (p.145-147, 254) */
+  resistanceCheck: SpellResistanceCheckEnum;
   descriptionRqidLink: RqidLink | undefined;
 }

--- a/src/data-model/item-data/spirit-magic-data-model.ts
+++ b/src/data-model/item-data/spirit-magic-data-model.ts
@@ -2,9 +2,11 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
+import { promptResistanceRollForSuccessfulCast } from "../shared/spell-resistance-check";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { RqgError, localize, assertDocumentSubType } from "../../system/util";
+import { AbilitySuccessLevelEnum } from "../../rolls/ability-roll/ability-roll.defs";
 import { getSpeakerCompat } from "../../system/fvtt-type-compat";
 import type { SpiritMagicRollOptions } from "../../rolls/spirit-magic-roll/spirit-magic-roll.types";
 import { ActorTypeEnum, type CharacterActor } from "../actor-data/rqg-actor-data";
@@ -20,6 +22,7 @@ import {
   spellItemTypes,
   SpellDurationEnum,
   SpellRangeEnum,
+  SpellResistanceCheckEnum,
 } from "./spell";
 
 export type SpiritMagicItem = RqgItem & { system: Item.SystemOfType<"spiritMagic"> };
@@ -167,6 +170,13 @@ export class SpiritMagicDataModel extends RqgItemDataModel<SpiritMagicSchema> {
       magicPointSource,
       boundSpiritDrainDecision.avoidRelease,
     );
+
+    if (
+      this.resistanceCheck === SpellResistanceCheckEnum.Single &&
+      spiritMagicRoll.successLevel <= AbilitySuccessLevelEnum.Success
+    ) {
+      await promptResistanceRollForSuccessfulCast(casterActor, token, item?.name ?? undefined);
+    }
   }
 
   /**

--- a/src/data-model/item-data/spirit-magic-data-model.ts
+++ b/src/data-model/item-data/spirit-magic-data-model.ts
@@ -2,11 +2,10 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
-import { promptResistanceRollForSuccessfulCast } from "../shared/spell-resistance-check";
+import { maybePromptResistanceRollForCast } from "../shared/spell-resistance-check";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { RqgError, localize, assertDocumentSubType } from "../../system/util";
-import { AbilitySuccessLevelEnum } from "../../rolls/ability-roll/ability-roll.defs";
 import { getSpeakerCompat } from "../../system/fvtt-type-compat";
 import type { SpiritMagicRollOptions } from "../../rolls/spirit-magic-roll/spirit-magic-roll.types";
 import { ActorTypeEnum, type CharacterActor } from "../actor-data/rqg-actor-data";
@@ -22,7 +21,6 @@ import {
   spellItemTypes,
   SpellDurationEnum,
   SpellRangeEnum,
-  SpellResistanceCheckEnum,
 } from "./spell";
 
 export type SpiritMagicItem = RqgItem & { system: Item.SystemOfType<"spiritMagic"> };
@@ -171,12 +169,13 @@ export class SpiritMagicDataModel extends RqgItemDataModel<SpiritMagicSchema> {
       boundSpiritDrainDecision.avoidRelease,
     );
 
-    if (
-      this.resistanceCheck === SpellResistanceCheckEnum.Single &&
-      spiritMagicRoll.successLevel <= AbilitySuccessLevelEnum.Success
-    ) {
-      await promptResistanceRollForSuccessfulCast(casterActor, token, item?.name ?? undefined);
-    }
+    await maybePromptResistanceRollForCast(
+      this.resistanceCheck,
+      spiritMagicRoll.successLevel,
+      casterActor,
+      token,
+      item?.name ?? undefined,
+    );
   }
 
   /**

--- a/src/data-model/item-data/spirit-magic-data-model.ts
+++ b/src/data-model/item-data/spirit-magic-data-model.ts
@@ -2,7 +2,7 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
-import { maybePromptResistanceRollForCast } from "../shared/spell-resistance-check";
+import { maybePromptResistanceRollForCast } from "../shared/spell-resisted-by";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { RqgError, localize, assertDocumentSubType } from "../../system/util";
@@ -170,7 +170,7 @@ export class SpiritMagicDataModel extends RqgItemDataModel<SpiritMagicSchema> {
     );
 
     await maybePromptResistanceRollForCast(
-      this.resistanceCheck,
+      this.resistedBy,
       spiritMagicRoll.successLevel,
       casterActor,
       token,

--- a/src/data-model/json-schemas/generated/item/runeMagic.schema.json
+++ b/src/data-model/json-schemas/generated/item/runeMagic.schema.json
@@ -50,6 +50,15 @@
       "type": "boolean",
       "default": false
     },
+    "resistanceCheck": {
+      "type": "string",
+      "enum": [
+        "none",
+        "single"
+      ],
+      "minLength": 1,
+      "default": "none"
+    },
     "descriptionRqidLink": {
       "type": [
         "object",
@@ -125,6 +134,7 @@
     "concentration",
     "isRitual",
     "isEnchantment",
+    "resistanceCheck",
     "cultId",
     "runeRqidLinks",
     "isStackable",

--- a/src/data-model/json-schemas/generated/item/runeMagic.schema.json
+++ b/src/data-model/json-schemas/generated/item/runeMagic.schema.json
@@ -50,11 +50,15 @@
       "type": "boolean",
       "default": false
     },
-    "resistanceCheck": {
+    "resistedBy": {
       "type": "string",
       "enum": [
         "none",
-        "single"
+        "resistanceRoll",
+        "resistanceRollArea",
+        "resistanceRollPerTarget",
+        "spiritCombatRound",
+        "spiritCombatDefeat"
       ],
       "minLength": 1,
       "default": "none"
@@ -134,7 +138,7 @@
     "concentration",
     "isRitual",
     "isEnchantment",
-    "resistanceCheck",
+    "resistedBy",
     "cultId",
     "runeRqidLinks",
     "isStackable",

--- a/src/data-model/json-schemas/generated/item/spiritMagic.schema.json
+++ b/src/data-model/json-schemas/generated/item/spiritMagic.schema.json
@@ -50,11 +50,15 @@
       "type": "boolean",
       "default": false
     },
-    "resistanceCheck": {
+    "resistedBy": {
       "type": "string",
       "enum": [
         "none",
-        "single"
+        "resistanceRoll",
+        "resistanceRollArea",
+        "resistanceRollPerTarget",
+        "spiritCombatRound",
+        "spiritCombatDefeat"
       ],
       "minLength": 1,
       "default": "none"
@@ -114,7 +118,7 @@
     "concentration",
     "isRitual",
     "isEnchantment",
-    "resistanceCheck",
+    "resistedBy",
     "isVariable",
     "incompatibleWith",
     "spellFocus",

--- a/src/data-model/json-schemas/generated/item/spiritMagic.schema.json
+++ b/src/data-model/json-schemas/generated/item/spiritMagic.schema.json
@@ -50,6 +50,15 @@
       "type": "boolean",
       "default": false
     },
+    "resistanceCheck": {
+      "type": "string",
+      "enum": [
+        "none",
+        "single"
+      ],
+      "minLength": 1,
+      "default": "none"
+    },
     "descriptionRqidLink": {
       "type": [
         "object",
@@ -105,6 +114,7 @@
     "concentration",
     "isRitual",
     "isEnchantment",
+    "resistanceCheck",
     "isVariable",
     "incompatibleWith",
     "spellFocus",

--- a/src/data-model/shared/spell-resistance-check.ts
+++ b/src/data-model/shared/spell-resistance-check.ts
@@ -1,0 +1,49 @@
+import type { RqgActor } from "@actors/rqg-actor.ts";
+import { warnIfMultipleTargets } from "../../system/util";
+
+/**
+ * After a spell with `resistanceCheck === "single"` is cast successfully, open a POW vs POW
+ * ResistanceRollDialogV2 pre-filled against the caster's current single target (#757).
+ * Shared between Rune Magic and Spirit Magic post-cast hooks. This is deliberately a standalone
+ * step (not folded into point-spending/experience bookkeeping) so it stays a clean pass/fail
+ * "gate" that a future spell-effect trigger (#443) can sit behind.
+ *
+ * Silently does nothing with zero targets (not every spell targets someone), and warns (without
+ * rolling) on more than one target - the caster should pick a single target before casting.
+ */
+export async function promptResistanceRollForSuccessfulCast(
+  casterActor: RqgActor,
+  token: TokenDocument | null | undefined,
+  spellName: string | undefined,
+): Promise<void> {
+  const targetCount = game.user?.targets.size ?? 0;
+  if (targetCount > 1) {
+    warnIfMultipleTargets();
+    return;
+  }
+  if (targetCount === 0) {
+    return;
+  }
+  const targetTokenUuid = game.user?.targets.first()?.document?.uuid;
+  if (!targetTokenUuid) {
+    return;
+  }
+
+  // Dynamic import to avoid circular dependencies through rqgItem.ts, mirroring the other
+  // dynamic imports in the rune/spirit magic data models.
+  const { ResistanceRollDialogV2 } =
+    await import("../../applications/resistance-roll-dialog/resistance-roll-dialog-v2");
+  await new ResistanceRollDialogV2(casterActor, token, {
+    active: {
+      source: "tokenOrActor",
+      tokenOrActorUuid: token?.uuid ?? casterActor.uuid ?? "",
+      characteristicNames: ["power"],
+    },
+    passive: {
+      source: "tokenOrActor",
+      tokenOrActorUuid: targetTokenUuid,
+      characteristicNames: ["power"],
+    },
+    description: spellName,
+  }).render({ force: true });
+}

--- a/src/data-model/shared/spell-resistance-check.ts
+++ b/src/data-model/shared/spell-resistance-check.ts
@@ -1,31 +1,42 @@
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import { warnIfMultipleTargets } from "../../system/util";
+import { AbilitySuccessLevelEnum } from "../../rolls/ability-roll/ability-roll.defs";
+import { SpellResistanceCheckEnum } from "../item-data/spell";
 
 /**
- * After a spell with `resistanceCheck === "single"` is cast successfully, open a POW vs POW
- * ResistanceRollDialogV2 pre-filled against the caster's current single target (#757).
- * Shared between Rune Magic and Spirit Magic post-cast hooks. This is deliberately a standalone
- * step (not folded into point-spending/experience bookkeeping) so it stays a clean pass/fail
- * "gate" that a future spell-effect trigger (#443) can sit behind.
+ * Post-cast hook shared by Rune Magic and Spirit Magic. When a resisted spell is cast
+ * successfully, open a POW vs POW ResistanceRollDialogV2 pre-filled caster-vs-target (#757).
+ * Deliberately a standalone step (not folded into point-spending/experience bookkeeping) so a
+ * future spell-effect trigger (#443) can sit behind it.
+ *
+ * The resistance roll yields a graded success level (critical … fumble), not a bare pass/fail:
+ * some spells key effects off the degree, and even a failed roll can carry an effect. Whatever
+ * consumes the outcome must read `ResistanceRoll.successLevel`.
  *
  * Silently does nothing with zero targets (not every spell targets someone), and warns (without
  * rolling) on more than one target - the caster should pick a single target before casting.
  */
-export async function promptResistanceRollForSuccessfulCast(
+export async function maybePromptResistanceRollForCast(
+  resistanceCheck: SpellResistanceCheckEnum,
+  castSuccessLevel: AbilitySuccessLevelEnum,
   casterActor: RqgActor,
   token: TokenDocument | null | undefined,
   spellName: string | undefined,
 ): Promise<void> {
+  if (
+    resistanceCheck !== SpellResistanceCheckEnum.Single ||
+    castSuccessLevel > AbilitySuccessLevelEnum.Success
+  ) {
+    return;
+  }
+
   const targetCount = game.user?.targets.size ?? 0;
   if (targetCount > 1) {
     warnIfMultipleTargets();
     return;
   }
-  if (targetCount === 0) {
-    return;
-  }
   const targetTokenUuid = game.user?.targets.first()?.document?.uuid;
-  if (!targetTokenUuid) {
+  if (targetCount === 0 || !targetTokenUuid) {
     return;
   }
 

--- a/src/data-model/shared/spell-resisted-by.ts
+++ b/src/data-model/shared/spell-resisted-by.ts
@@ -1,7 +1,7 @@
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import { warnIfMultipleTargets } from "../../system/util";
 import { AbilitySuccessLevelEnum } from "../../rolls/ability-roll/ability-roll.defs";
-import { SpellResistanceCheckEnum } from "../item-data/spell";
+import { SpellResistedByEnum } from "../item-data/spell";
 
 /**
  * Post-cast hook shared by Rune Magic and Spirit Magic. When a resisted spell is cast
@@ -13,18 +13,20 @@ import { SpellResistanceCheckEnum } from "../item-data/spell";
  * some spells key effects off the degree, and even a failed roll can carry an effect. Whatever
  * consumes the outcome must read `ResistanceRoll.successLevel`.
  *
- * Silently does nothing with zero targets (not every spell targets someone), and warns (without
- * rolling) on more than one target - the caster should pick a single target before casting.
+ * Only `ResistanceRoll` is handled; the area / spirit-combat `resistedBy` modes are inert here
+ * until their own issues wire them up (#1068). Silently does nothing with zero targets (not every
+ * spell targets someone), and warns (without rolling) on more than one target - the caster should
+ * pick a single target before casting.
  */
 export async function maybePromptResistanceRollForCast(
-  resistanceCheck: SpellResistanceCheckEnum,
+  resistedBy: SpellResistedByEnum,
   castSuccessLevel: AbilitySuccessLevelEnum,
   casterActor: RqgActor,
   token: TokenDocument | null | undefined,
   spellName: string | undefined,
 ): Promise<void> {
   if (
-    resistanceCheck !== SpellResistanceCheckEnum.Single ||
+    resistedBy !== SpellResistedByEnum.ResistanceRoll ||
     castSuccessLevel > AbilitySuccessLevelEnum.Success
   ) {
     return;

--- a/src/data-model/shared/spell-schema-fields.ts
+++ b/src/data-model/shared/spell-schema-fields.ts
@@ -1,5 +1,10 @@
 import { rqidLinkSchemaField } from "./rqid-link-field";
-import { SpellConcentrationEnum, SpellDurationEnum, SpellRangeEnum } from "../item-data/spell";
+import {
+  SpellConcentrationEnum,
+  SpellDurationEnum,
+  SpellRangeEnum,
+  SpellResistanceCheckEnum,
+} from "../item-data/spell";
 import { enumChoices } from "./enum-choices";
 
 const { BooleanField, NumberField, StringField } = foundry.data.fields;
@@ -31,6 +36,12 @@ export function spellSchemaFields() {
     }),
     isRitual: new BooleanField({ nullable: false, initial: false }),
     isEnchantment: new BooleanField({ nullable: false, initial: false }),
+    resistanceCheck: new StringField({
+      blank: false,
+      nullable: false,
+      initial: SpellResistanceCheckEnum.None,
+      choices: enumChoices(SpellResistanceCheckEnum, "RQG.Item.Spell.ResistanceCheckEnum."),
+    }),
     descriptionRqidLink: rqidLinkSchemaField({ nullable: true }),
   } as const;
 }

--- a/src/data-model/shared/spell-schema-fields.ts
+++ b/src/data-model/shared/spell-schema-fields.ts
@@ -3,7 +3,7 @@ import {
   SpellConcentrationEnum,
   SpellDurationEnum,
   SpellRangeEnum,
-  SpellResistanceCheckEnum,
+  SpellResistedByEnum,
 } from "../item-data/spell";
 import { enumChoices } from "./enum-choices";
 
@@ -36,11 +36,11 @@ export function spellSchemaFields() {
     }),
     isRitual: new BooleanField({ nullable: false, initial: false }),
     isEnchantment: new BooleanField({ nullable: false, initial: false }),
-    resistanceCheck: new StringField({
+    resistedBy: new StringField({
       blank: false,
       nullable: false,
-      initial: SpellResistanceCheckEnum.None,
-      choices: enumChoices(SpellResistanceCheckEnum, "RQG.Item.Spell.ResistanceCheckEnum."),
+      initial: SpellResistedByEnum.None,
+      choices: enumChoices(SpellResistedByEnum, "RQG.Item.Spell.ResistedByEnum."),
     }),
     descriptionRqidLink: rqidLinkSchemaField({ nullable: true }),
   } as const;

--- a/src/foundry-ui/rqg-actor-directory.ts
+++ b/src/foundry-ui/rqg-actor-directory.ts
@@ -1,0 +1,38 @@
+import type { RqgContextMenuEntry } from "./rqg-context-menu";
+
+import ActorDirectory = foundry.applications.sidebar.tabs.ActorDirectory;
+import ContextMenu = foundry.applications.ux.ContextMenu;
+
+/**
+ * Actors sidebar with an extra GM-only "Request Resistance Roll" context-menu entry, so the GM
+ * can start a resistance request without a token on the scene or opening the actor sheet.
+ */
+export class RqgActorDirectory<
+  RenderContext extends ActorDirectory.RenderContext = ActorDirectory.RenderContext,
+  Configuration extends ActorDirectory.Configuration = ActorDirectory.Configuration,
+  RenderOptions extends ActorDirectory.RenderOptions = ActorDirectory.RenderOptions,
+> extends ActorDirectory<RenderContext, Configuration, RenderOptions> {
+  static init() {
+    CONFIG.ui.actors = RqgActorDirectory;
+  }
+
+  override _getEntryContextOptions(): ContextMenu.Entry<HTMLElement>[] {
+    const entries = super._getEntryContextOptions() as unknown as RqgContextMenuEntry[];
+    entries.push({
+      label: "RQG.Game.RequestResistanceRoll",
+      icon: '<i class="fa-solid fa-scale-unbalanced fa-fw"></i>',
+      visible: () => game.user?.isGM ?? false,
+      onClick: async (_event: Event, li: HTMLElement) => {
+        const actorId = li.dataset["entryId"];
+        const actor = actorId ? game.actors?.get(actorId) : undefined;
+        if (!actor?.uuid) {
+          return;
+        }
+        const { openResistanceRequest } =
+          await import("../applications/resistance-roll-dialog/open-resistance-request");
+        await openResistanceRequest(actor.uuid);
+      },
+    });
+    return entries as unknown as ContextMenu.Entry<HTMLElement>[];
+  }
+}

--- a/src/foundry-ui/rqg-token-hud.ts
+++ b/src/foundry-ui/rqg-token-hud.ts
@@ -1,0 +1,43 @@
+import { systemId } from "../system/config";
+import { localize } from "../system/util";
+
+/**
+ * Adds a GM-only "Request Resistance Roll" button to the Token HUD's left column, so the GM can
+ * start a resistance request straight from a token on the canvas. Hidden when the
+ * `showResistanceRequestTokenHudButton` client setting is off.
+ */
+export class RqgTokenHud {
+  static init() {
+    Hooks.on("renderTokenHUD", RqgTokenHud.onRenderTokenHUD);
+  }
+
+  private static onRenderTokenHUD(
+    hud: foundry.applications.hud.TokenHUD,
+    element: HTMLElement,
+  ): void {
+    if (!game.user?.isGM || !game.settings?.get(systemId, "showResistanceRequestTokenHudButton")) {
+      return;
+    }
+    const leftColumn = element.querySelector<HTMLElement>(".col.left");
+    const tokenUuid = hud.document?.uuid;
+    if (!leftColumn || !tokenUuid) {
+      return;
+    }
+
+    const label = localize("RQG.Game.RequestResistanceRoll");
+    // No data-action - AppV2 would warn about an unregistered handler; the click listener below
+    // drives it directly instead.
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "control-icon";
+    button.setAttribute("data-tooltip", label);
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<i class="fa-solid fa-scale-unbalanced" inert></i>';
+    button.addEventListener("click", async () => {
+      const { openResistanceRequest } =
+        await import("../applications/resistance-roll-dialog/open-resistance-request");
+      await openResistanceRequest(tokenUuid);
+    });
+    leftColumn.appendChild(button);
+  }
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -33,6 +33,7 @@ import type { SpiritMagicDataModel } from "./data-model/item-data/spirit-magic-d
 import type { WeaponDataModel } from "./data-model/item-data/weapon-data-model";
 import type { CharacterDataModel } from "./data-model/actor-data/character-data-model";
 import type { CombatChatMessageData } from "./chat/data-model/combat-chat-message.data-model.ts";
+import type { ResistanceRequestChatMessageData } from "./chat/data-model/resistance-request-chat-message.data-model.ts";
 import type { Dice3D } from "./module-integrations/dice-so-nice";
 
 // Namespace imports for Foundry document types (from fvtt-types)
@@ -105,6 +106,7 @@ declare global {
     };
     ChatMessage: {
       combat: typeof CombatChatMessageData;
+      resistanceRequest: typeof ResistanceRequestChatMessageData;
     };
     RegionBehavior: {
       clickableScripts: typeof ClickableScriptsRegionBehavior;
@@ -150,6 +152,7 @@ declare global {
     "rqg.showActorActiveEffectsTab": boolean;
     "rqg.naturalHealingEnabled": boolean;
     "rqg.magicPointRecoveryEnabled": boolean;
+    "rqg.showResistanceRequestTokenHudButton": boolean;
   }
 
   interface ConfiguredCombatant {

--- a/src/items/rune-magic-item/rune-magic-sheet-v2-rune-magic.hbs
+++ b/src/items/rune-magic-item/rune-magic-sheet-v2-rune-magic.hbs
@@ -18,9 +18,9 @@
     <input type="checkbox" id="is-enchantment-{{id}}" name="system.isEnchantment" {{checked
       system.isEnchantment}}>
 
-    <label for="resistance-check-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistanceCheck"}}</label>
-    <select id="resistance-check-{{id}}" name="system.resistanceCheck">
-      {{selectOptions resistanceCheckOptions selected=system.resistanceCheck localize=true}}
+    <label for="resisted-by-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistedBy"}}</label>
+    <select id="resisted-by-{{id}}" name="system.resistedBy">
+      {{selectOptions resistedByOptions selected=system.resistedBy localize=true}}
     </select>
 
     <label for="is-stackable-{{id}}">{{localize "RQG.Item.RuneMagic.Stackable"}}</label>

--- a/src/items/rune-magic-item/rune-magic-sheet-v2-rune-magic.hbs
+++ b/src/items/rune-magic-item/rune-magic-sheet-v2-rune-magic.hbs
@@ -18,6 +18,11 @@
     <input type="checkbox" id="is-enchantment-{{id}}" name="system.isEnchantment" {{checked
       system.isEnchantment}}>
 
+    <label for="resistance-check-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistanceCheck"}}</label>
+    <select id="resistance-check-{{id}}" name="system.resistanceCheck">
+      {{selectOptions resistanceCheckOptions selected=system.resistanceCheck localize=true}}
+    </select>
+
     <label for="is-stackable-{{id}}">{{localize "RQG.Item.RuneMagic.Stackable"}}</label>
     <input type="checkbox" id="is-stackable-{{id}}" name="system.isStackable" {{checked system.isStackable}}>
 

--- a/src/items/rune-magic-item/rune-magic-sheet-v2.ts
+++ b/src/items/rune-magic-item/rune-magic-sheet-v2.ts
@@ -1,7 +1,7 @@
 import { ItemTypeEnum } from "@item-model/item-types.ts";
 import { getSelectRuneOptions, isDocumentSubType } from "../../system/util";
 import { RqgItemSheetV2, type RqgItemSheetContext } from "../rqg-item-sheet-v2";
-import { SpellDurationEnum, SpellRangeEnum, SpellResistanceCheckEnum } from "@item-model/spell.ts";
+import { SpellDurationEnum, SpellRangeEnum, SpellResistedByEnum } from "@item-model/spell.ts";
 import { systemId } from "../../system/config";
 import { templatePaths } from "../../system/load-handlebars-templates";
 import type { CultItem } from "@item-model/cult-data-model.ts";
@@ -12,7 +12,7 @@ interface RuneMagicSheetContext extends RqgItemSheetContext {
   allRuneOptions: SelectOptionData<string>[];
   rangeOptions: SelectOptionData<SpellRangeEnum>[];
   durationOptions: SelectOptionData<SpellDurationEnum>[];
-  resistanceCheckOptions: SelectOptionData<SpellResistanceCheckEnum>[];
+  resistedByOptions: SelectOptionData<SpellResistedByEnum>[];
   actorCultOptions: SelectOptionData<string>[];
 }
 
@@ -59,9 +59,9 @@ export class RuneMagicSheetV2 extends RqgItemSheetV2 {
         value: range,
         label: "RQG.Item.Spell.DurationEnum." + (range || "undefined"),
       })),
-      resistanceCheckOptions: Object.values(SpellResistanceCheckEnum).map((value) => ({
+      resistedByOptions: Object.values(SpellResistedByEnum).map((value) => ({
         value: value,
-        label: "RQG.Item.Spell.ResistanceCheckEnum." + value,
+        label: "RQG.Item.Spell.ResistedByEnum." + value,
       })),
       actorCultOptions: this.getActorCultOptions(),
       allRuneOptions: getSelectRuneOptions("RQG.Item.RuneMagic.AddRuneMagicRunePlaceholder"),

--- a/src/items/rune-magic-item/rune-magic-sheet-v2.ts
+++ b/src/items/rune-magic-item/rune-magic-sheet-v2.ts
@@ -1,7 +1,7 @@
 import { ItemTypeEnum } from "@item-model/item-types.ts";
 import { getSelectRuneOptions, isDocumentSubType } from "../../system/util";
 import { RqgItemSheetV2, type RqgItemSheetContext } from "../rqg-item-sheet-v2";
-import { SpellDurationEnum, SpellRangeEnum } from "@item-model/spell.ts";
+import { SpellDurationEnum, SpellRangeEnum, SpellResistanceCheckEnum } from "@item-model/spell.ts";
 import { systemId } from "../../system/config";
 import { templatePaths } from "../../system/load-handlebars-templates";
 import type { CultItem } from "@item-model/cult-data-model.ts";
@@ -12,6 +12,7 @@ interface RuneMagicSheetContext extends RqgItemSheetContext {
   allRuneOptions: SelectOptionData<string>[];
   rangeOptions: SelectOptionData<SpellRangeEnum>[];
   durationOptions: SelectOptionData<SpellDurationEnum>[];
+  resistanceCheckOptions: SelectOptionData<SpellResistanceCheckEnum>[];
   actorCultOptions: SelectOptionData<string>[];
 }
 
@@ -57,6 +58,10 @@ export class RuneMagicSheetV2 extends RqgItemSheetV2 {
       durationOptions: Object.values(SpellDurationEnum).map((range) => ({
         value: range,
         label: "RQG.Item.Spell.DurationEnum." + (range || "undefined"),
+      })),
+      resistanceCheckOptions: Object.values(SpellResistanceCheckEnum).map((value) => ({
+        value: value,
+        label: "RQG.Item.Spell.ResistanceCheckEnum." + value,
       })),
       actorCultOptions: this.getActorCultOptions(),
       allRuneOptions: getSelectRuneOptions("RQG.Item.RuneMagic.AddRuneMagicRunePlaceholder"),

--- a/src/items/spirit-magic-item/spirit-magic-sheet-v2-spirit-magic.hbs
+++ b/src/items/spirit-magic-item/spirit-magic-sheet-v2-spirit-magic.hbs
@@ -28,6 +28,11 @@
     <label for="is-enchantment-{{id}}">{{localize "RQG.Item.Spell.Enchantment"}}</label>
     <input type="checkbox" id="is-enchantment-{{id}}" name="system.isEnchantment" {{checked system.isEnchantment}}>
 
+    <label for="resistance-check-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistanceCheck"}}</label>
+    <select id="resistance-check-{{id}}" name="system.resistanceCheck">
+      {{selectOptions resistanceCheckOptions selected=system.resistanceCheck localize=true}}
+    </select>
+
     <label for="is-matrix-{{id}}">{{localize "RQG.Item.SpiritMagic.MatrixQ"}}</label>
     <input type="checkbox" id="is-matrix-{{id}}" name="system.isMatrix" {{checked system.isMatrix}}>
 

--- a/src/items/spirit-magic-item/spirit-magic-sheet-v2-spirit-magic.hbs
+++ b/src/items/spirit-magic-item/spirit-magic-sheet-v2-spirit-magic.hbs
@@ -28,9 +28,9 @@
     <label for="is-enchantment-{{id}}">{{localize "RQG.Item.Spell.Enchantment"}}</label>
     <input type="checkbox" id="is-enchantment-{{id}}" name="system.isEnchantment" {{checked system.isEnchantment}}>
 
-    <label for="resistance-check-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistanceCheck"}}</label>
-    <select id="resistance-check-{{id}}" name="system.resistanceCheck">
-      {{selectOptions resistanceCheckOptions selected=system.resistanceCheck localize=true}}
+    <label for="resisted-by-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistedBy"}}</label>
+    <select id="resisted-by-{{id}}" name="system.resistedBy">
+      {{selectOptions resistedByOptions selected=system.resistedBy localize=true}}
     </select>
 
     <label for="is-matrix-{{id}}">{{localize "RQG.Item.SpiritMagic.MatrixQ"}}</label>

--- a/src/items/spirit-magic-item/spirit-magic-sheet-v2.ts
+++ b/src/items/spirit-magic-item/spirit-magic-sheet-v2.ts
@@ -1,5 +1,10 @@
 import { RqgItemSheetV2, type RqgItemSheetContext } from "../rqg-item-sheet-v2";
-import { SpellConcentrationEnum, SpellDurationEnum, SpellRangeEnum } from "@item-model/spell.ts";
+import {
+  SpellConcentrationEnum,
+  SpellDurationEnum,
+  SpellRangeEnum,
+  SpellResistanceCheckEnum,
+} from "@item-model/spell.ts";
 import { systemId } from "../../system/config";
 import { templatePaths } from "../../system/load-handlebars-templates";
 import type { SpiritMagicItem } from "@item-model/spirit-magic-data-model.ts";
@@ -8,6 +13,7 @@ interface SpiritMagicSheetContext extends RqgItemSheetContext {
   rangeOptions: SelectOptionData<SpellRangeEnum>[];
   durationOptions: SelectOptionData<SpellDurationEnum>[];
   concentrationOptions: SelectOptionData<SpellConcentrationEnum>[];
+  resistanceCheckOptions: SelectOptionData<SpellResistanceCheckEnum>[];
 }
 
 export class SpiritMagicSheetV2 extends RqgItemSheetV2 {
@@ -56,6 +62,10 @@ export class SpiritMagicSheetV2 extends RqgItemSheetV2 {
       concentrationOptions: Object.values(SpellConcentrationEnum).map((range) => ({
         value: range,
         label: "RQG.Item.Spell.ConcentrationEnum." + (range || "undefined"),
+      })),
+      resistanceCheckOptions: Object.values(SpellResistanceCheckEnum).map((value) => ({
+        value: value,
+        label: "RQG.Item.Spell.ResistanceCheckEnum." + value,
       })),
     };
 

--- a/src/items/spirit-magic-item/spirit-magic-sheet-v2.ts
+++ b/src/items/spirit-magic-item/spirit-magic-sheet-v2.ts
@@ -3,7 +3,7 @@ import {
   SpellConcentrationEnum,
   SpellDurationEnum,
   SpellRangeEnum,
-  SpellResistanceCheckEnum,
+  SpellResistedByEnum,
 } from "@item-model/spell.ts";
 import { systemId } from "../../system/config";
 import { templatePaths } from "../../system/load-handlebars-templates";
@@ -13,7 +13,7 @@ interface SpiritMagicSheetContext extends RqgItemSheetContext {
   rangeOptions: SelectOptionData<SpellRangeEnum>[];
   durationOptions: SelectOptionData<SpellDurationEnum>[];
   concentrationOptions: SelectOptionData<SpellConcentrationEnum>[];
-  resistanceCheckOptions: SelectOptionData<SpellResistanceCheckEnum>[];
+  resistedByOptions: SelectOptionData<SpellResistedByEnum>[];
 }
 
 export class SpiritMagicSheetV2 extends RqgItemSheetV2 {
@@ -63,9 +63,9 @@ export class SpiritMagicSheetV2 extends RqgItemSheetV2 {
         value: range,
         label: "RQG.Item.Spell.ConcentrationEnum." + (range || "undefined"),
       })),
-      resistanceCheckOptions: Object.values(SpellResistanceCheckEnum).map((value) => ({
+      resistedByOptions: Object.values(SpellResistedByEnum).map((value) => ({
         value: value,
-        label: "RQG.Item.Spell.ResistanceCheckEnum." + value,
+        label: "RQG.Item.Spell.ResistedByEnum." + value,
       })),
     };
 

--- a/src/rolls/resistance-roll/resistance-roll-flavor.ts
+++ b/src/rolls/resistance-roll/resistance-roll-flavor.ts
@@ -1,0 +1,19 @@
+import { localize } from "../../system/util";
+
+/**
+ * The "opposes X" / "active vs passive" / "Resistance Roll" header markup, shared between an
+ * actual ResistanceRoll's flavor and a resistance-request chat card's flavor, so both look the
+ * same whether the roll happened directly or via a GM request.
+ */
+export function buildResistanceRollFlavor(
+  activeLabel: string,
+  passiveLabel: string,
+  passiveActorName?: string,
+): string {
+  const resistanceTranslation = localize("RQG.Roll.ResistanceRoll.Title");
+  const opposesLine = passiveActorName
+    ? `<span>${localize("RQG.Roll.ResistanceRoll.Opposes", { targetName: `<b>${passiveActorName}</b>` })}</span><br>`
+    : "";
+  return `${opposesLine}<span class="roll-action">${activeLabel} ${localize("RQG.Roll.ResistanceRoll.Vs")} ${passiveLabel}</span>
+          <span>${resistanceTranslation}</span><br>`;
+}

--- a/src/rolls/resistance-roll/resistance-roll-formula.ts
+++ b/src/rolls/resistance-roll/resistance-roll-formula.ts
@@ -1,0 +1,14 @@
+/**
+ * The resistance-table formula (core rulebook p.145-147): active vs passive characteristic (or
+ * sum of characteristics), plus any modifiers, folded into a single d100 target%. Shared by
+ * `ResistanceRoll.targetChance` and every dialog's live target-% preview, so a future RAW tweak
+ * only needs to change one place.
+ */
+export function computeResistanceTargetChance(
+  activeValue: number,
+  passiveValue: number,
+  modifierValues: number[] = [],
+): number {
+  const modifiersSum = modifierValues.reduce((sum, value) => sum + (Number(value) || 0), 0);
+  return Math.ceil(50 + (activeValue - passiveValue) * 5 + modifiersSum);
+}

--- a/src/rolls/resistance-roll/resistance-roll-tooltip.hbs
+++ b/src/rolls/resistance-roll/resistance-roll-tooltip.hbs
@@ -1,0 +1,7 @@
+<div class="dice-tooltip" data-only-owner-visible-uuid="{{speakerUuid}}">
+  <b>{{activeValue}}</b><sub><i>{{activeLabel}}</i></sub> {{localize "RQG.Roll.ResistanceRoll.Vs"}}
+  <b>{{passiveValue}}</b><sub><i>{{passiveLabel}}</i></sub>
+  {{#each modifiers}}
+    <b>{{value}}</b><sub><i>{{description}}</i></sub>
+  {{/each}}
+</div>

--- a/src/rolls/resistance-roll/resistance-roll.hbs
+++ b/src/rolls/resistance-roll/resistance-roll.hbs
@@ -1,0 +1,14 @@
+<div class="dice-roll">
+  <div class="dice-result">
+    <div class="dice-total success-level-{{successLevel}}">
+      {{#if successLevelText}}
+        <div class="outcome">{{successLevelText}}</div>
+      {{/if}}
+      <div data-tooltip="1d100"><i class="fa-solid fa-dice"></i>{{total}}</div>
+      {{#if target}}
+        <div class="target" data-only-owner-visible-uuid="{{speakerUuid}}"><i class="fa-solid fa-bullseye"></i> {{target}}%</div>
+      {{/if}}
+    </div>
+  </div>
+  {{{tooltip}}}
+</div>

--- a/src/rolls/resistance-roll/resistance-roll.ts
+++ b/src/rolls/resistance-roll/resistance-roll.ts
@@ -1,0 +1,106 @@
+import { activateChatTab, isTruthy, localize, toSignedString } from "../../system/util";
+import { templatePaths } from "../../system/load-handlebars-templates";
+import { calculateAbilitySuccessLevel } from "../ability-roll/calculate-ability-success-level";
+import { AbilitySuccessLevelEnum } from "../ability-roll/ability-roll.defs";
+import type { ResistanceRollOptions } from "./resistance-roll.types.ts";
+import { buildResistanceRollFlavor } from "./resistance-roll-flavor.ts";
+import { computeResistanceTargetChance } from "./resistance-roll-formula.ts";
+import type { AnyObject, EmptyObject } from "fvtt-types/utils";
+
+import Roll = foundry.dice.Roll;
+
+/**
+ * A roll on the Resistance Table (RQG core rulebook p.145-147): active vs passive characteristic
+ * (or sum of characteristics) folded into a single d100 target%, resolved with the same
+ * success-band mechanic as skill/characteristic rolls.
+ */
+export class ResistanceRoll<D extends AnyObject = EmptyObject> extends Roll<D> {
+  declare options: ResistanceRollOptions;
+
+  public static async rollAndShow(options: ResistanceRollOptions) {
+    const roll = new ResistanceRoll(undefined, {}, options);
+    await roll.evaluate();
+    activateChatTab();
+    const msg = await roll.toMessage({ flavor: roll.flavor, speaker: options.speaker }, {
+      messageMode: options.rollMode,
+      create: true,
+    } as unknown as Record<string, unknown>);
+
+    if (msg?.id != null) {
+      await game.dice3d?.waitFor3DAnimationByMessageID(msg.id);
+    }
+    return roll;
+  }
+
+  constructor(formula: string = "1d100", data?: D, options?: ResistanceRollOptions) {
+    super(formula, data, options);
+  }
+
+  get isEvaluated(): boolean {
+    return this._evaluated;
+  }
+
+  get targetChance(): number {
+    const modifierValues = this.options?.modifiers?.map((mod) => mod?.value) ?? [];
+    return computeResistanceTargetChance(
+      this.options.activeValue,
+      this.options.passiveValue,
+      modifierValues,
+    );
+  }
+
+  get successLevel(): AbilitySuccessLevelEnum | undefined {
+    if (!this._evaluated || this.total == null) {
+      return undefined;
+    }
+    return calculateAbilitySuccessLevel(this.targetChance, this.total);
+  }
+
+  // Html for the "content" of the chat-message
+  override async render({ flavor = this.flavor, isPrivate = false } = {}) {
+    if (!this._evaluated) {
+      await this.evaluate();
+    }
+    const chatData = {
+      formula: isPrivate ? "???" : this._formula,
+      flavor: isPrivate ? null : flavor,
+      user: game.user!.id,
+      tooltip: isPrivate ? "" : await this.getTooltip(),
+      total: isPrivate ? "??" : Math.round(this.total! * 100) / 100,
+      target: isPrivate ? undefined : this.targetChance,
+      successLevel: isPrivate ? "private" : this.successLevel,
+      successLevelText: isPrivate
+        ? undefined
+        : localize(`RQG.Game.AbilityResultEnum.${this.successLevel}`),
+      speakerUuid: ChatMessage.getSpeakerActor(this.options.speaker)?.uuid, // Used for hiding parts
+    };
+    return foundry.applications.handlebars.renderTemplate(templatePaths.resistanceRoll, chatData);
+  }
+
+  // Html for what modifiers are applied
+  override async getTooltip(): Promise<string> {
+    const modifiers = this.options.modifiers ?? [];
+    const nonzeroSignedModifiers = modifiers
+      .filter((m) => isTruthy(m.value))
+      .map((m) => ({ ...m, value: toSignedString(Number(m.value)) }));
+    return foundry.applications.handlebars.renderTemplate(templatePaths.resistanceRollTooltip, {
+      activeLabel: this.options.activeLabel,
+      activeValue: this.options.activeValue,
+      passiveLabel: this.options.passiveLabel,
+      passiveValue: this.options.passiveValue,
+      modifiers: nonzeroSignedModifiers,
+      speakerUuid: ChatMessage.getSpeakerActor(this.options.speaker)?.uuid, // Used for hiding parts
+    });
+  }
+
+  // Html for what the roll is about. A small "opposes <name>" line (mirroring the attack chat
+  // card's "attacks <name>") comes first when the passive side came from a targeted actor, then
+  // the bold "active vs passive" header naming the characteristic(s) rolled.
+  get flavor(): string {
+    return buildResistanceRollFlavor(
+      this.options.activeLabel,
+      this.options.passiveLabel,
+      this.options.passiveActorName,
+    );
+  }
+}

--- a/src/rolls/resistance-roll/resistance-roll.types.ts
+++ b/src/rolls/resistance-roll/resistance-roll.types.ts
@@ -1,0 +1,13 @@
+export type Modifier = { description: string; value: number };
+
+export type ResistanceRollOptions = Partial<foundry.dice.terms.DiceTerm.EvaluationOptions> & {
+  activeValue: number;
+  activeLabel: string;
+  passiveValue: number;
+  passiveLabel: string;
+  /** Name of the actor the passive value was drawn from, if any (not set for a manual value). */
+  passiveActorName?: string;
+  modifiers?: Modifier[];
+  speaker?: ChatMessage.SpeakerData;
+  rollMode?: foundry.dice.Roll.Mode;
+};

--- a/src/rqg.css
+++ b/src/rqg.css
@@ -910,6 +910,11 @@
         & .context-icon-img {
           height: 16pt;
         }
+
+        & .context-icon-fa {
+          font-size: 16pt;
+          color: white;
+        }
       }
     }
 
@@ -972,6 +977,10 @@
       & button:disabled {
         color: var(--color-text-dark-inactive);
         cursor: progress;
+      }
+
+      & button.resistance-request-roll {
+        width: 100%;
       }
     }
 
@@ -1936,6 +1945,12 @@
       color: var(--color-level-error);
       border: 1px solid var(--color-level-error);
       background-color: transparent;
+    }
+  }
+
+  .rqg.form.roll-dialog.resistance-request-dialog {
+    & .scrollable > * + * {
+      margin-top: 0.6rem;
     }
   }
 

--- a/src/rqg.ts
+++ b/src/rqg.ts
@@ -15,6 +15,8 @@ import { nameGeneration } from "./system/api/name-generation.js";
 import { openDataModelRepairDialog } from "./system/api/data-model-repair";
 import { Rqid } from "./system/api/rqid-api.js";
 import { RqgHotbar } from "./foundry-ui/rqg-hotbar";
+import { RqgActorDirectory } from "./foundry-ui/rqg-actor-directory";
+import { RqgTokenHud } from "./foundry-ui/rqg-token-hud";
 import { TextEditorHooks } from "./foundry-ui/text-editor-hooks";
 import { RqgJournalEntry } from "./journals/rqg-journal-entry";
 import { getTokenStatusEffects } from "./system/token-status-effects";
@@ -31,6 +33,7 @@ import { SpiritMagicRoll } from "./rolls/spirit-magic-roll/spirit-magic-roll";
 import { RuneMagicRoll } from "./rolls/rune-magic-roll/rune-magic-roll";
 import { HitLocationRoll } from "./rolls/hit-location-roll/hit-location-roll";
 import { DamageRoll } from "./rolls/damage-roll/damage-roll";
+import { ResistanceRoll } from "./rolls/resistance-roll/resistance-roll";
 import { RqgRollTableSheet } from "./roll-tables/rqg-roll-table-sheet";
 import { RqgTokenRuler } from "./combat/rqg-token-ruler";
 import { ClickableScriptsRegionBehavior } from "./scene/clickable-scripts-region-behavior";
@@ -92,6 +95,7 @@ Hooks.once("init", () => {
     RuneMagicRoll,
     HitLocationRoll,
     DamageRoll,
+    ResistanceRoll,
   ];
 
   Rqid.init();
@@ -105,6 +109,8 @@ Hooks.once("init", () => {
   initCharacterPassiveRecovery();
   RqgItem.init();
   RqgHotbar.init();
+  RqgActorDirectory.init();
+  RqgTokenHud.init();
   RqgJournalEntry.init();
   TextEditorHooks.init();
   RqgSettings.init();

--- a/src/system/load-handlebars-templates.ts
+++ b/src/system/load-handlebars-templates.ts
@@ -81,6 +81,8 @@ export const templatePaths = {
   characteristicRollTooltip:
     "systems/rqg/rolls/characteristic-roll/characteristic-roll-tooltip.hbs",
   characteristicRoll: "systems/rqg/rolls/characteristic-roll/characteristic-roll.hbs",
+  resistanceRollTooltip: "systems/rqg/rolls/resistance-roll/resistance-roll-tooltip.hbs",
+  resistanceRoll: "systems/rqg/rolls/resistance-roll/resistance-roll.hbs",
   hitLocationRoll: "systems/rqg/rolls/hit-location-roll/hit-location-roll.hbs",
   hitLocationTooltip: "systems/rqg/rolls/hit-location-roll/hit-location-roll-tooltip.hbs",
   spiritMagicRollTooltip: "systems/rqg/rolls/spirit-magic-roll/spirit-magic-roll-tooltip.hbs",
@@ -96,6 +98,7 @@ export const templatePaths = {
   // Chat
   chatMessage: "systems/rqg/chat/chat-message.hbs",
   attackChatMessage: "systems/rqg/applications/attack-flow/attack-chat-template.hbs",
+  resistanceRequestChatMessage: "systems/rqg/chat/resistance-request-chat-template.hbs",
 
   rqidTooltip: "systems/rqg/documents/rqid-tooltip.hbs",
 
@@ -137,6 +140,14 @@ export const templatePaths = {
   abilityRollDialogV2: "systems/rqg/applications/ability-roll-dialog/ability-roll-dialog-v2.hbs",
   characteristicRollDialogV2:
     "systems/rqg/applications/characteristic-roll-dialog/characteristic-roll-dialog-v2.hbs",
+  resistanceRollDialogV2:
+    "systems/rqg/applications/resistance-roll-dialog/resistance-roll-dialog-v2.hbs",
+  resistanceRequestDialogV2:
+    "systems/rqg/applications/resistance-roll-dialog/resistance-request-dialog-v2.hbs",
+  resistanceRequestFooter:
+    "systems/rqg/applications/resistance-roll-dialog/resistance-request-footer.hbs",
+  respondToResistanceRequestDialogV2:
+    "systems/rqg/applications/resistance-roll-dialog/respond-to-resistance-request-dialog-v2.hbs",
   spiritMagicRollDialogV2:
     "systems/rqg/applications/spirit-magic-roll-dialog/spirit-magic-roll-dialog-v2.hbs",
   runeMagicRollDialogV2:

--- a/src/system/rqg-system-settings.ts
+++ b/src/system/rqg-system-settings.ts
@@ -157,6 +157,15 @@ export const registerRqgSystemSettings = function () {
     default: true,
   });
 
+  game.settings?.register(systemId, "showResistanceRequestTokenHudButton", {
+    name: "RQG.Settings.ShowResistanceRequestTokenHudButton.settingName",
+    hint: "RQG.Settings.ShowResistanceRequestTokenHudButton.settingHint",
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
+
   game.settings?.register(systemId, "actor-wizard-feature-flag", {
     name: "Feature Flag: Enable Actor Wizard",
     hint: "For RnD use only",

--- a/src/system/util.ts
+++ b/src/system/util.ts
@@ -974,3 +974,12 @@ export function getActorLinkDecoration(actor: RqgActor | Actor | null | undefine
     return "";
   }
 }
+
+/**
+ * Warn the user if more than one token is targeted where a dialog can only sensibly use one.
+ */
+export function warnIfMultipleTargets(): void {
+  if ((game.user?.targets.size ?? 0) > 1) {
+    ui.notifications?.info("Please target one token only");
+  }
+}

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -605,7 +605,8 @@
       },
       "ResistanceRequest": {
         "Title": "Request Resistance Roll",
-        "ModifierDefaults": "Modifier defaults (recipient may change)",
+        "SituationalModifier": "Situational modifier",
+        "SituationalModifierHint": "Sent to the roller as a starting Other modifier. They pick their own Augment and Meditate when they roll.",
         "SendRequest": "Send Request"
       },
       "SpiritMagicRoll": {

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -21,7 +21,8 @@
       "character": "Character"
     },
     "ChatMessage": {
-      "combat": "Combat"
+      "combat": "Combat",
+      "resistanceRequest": "Resistance Request"
     },
     "RegionBehavior": {
       "clickableScripts": "Click to Execute Script"
@@ -511,6 +512,9 @@
         "AttackerFumble": "Attacker Fumble",
         "DefenderFumble": "Defender Fumble",
         "ApplyNaturalWeaponDamageNotImplemented": "Automatically applying damage to natural weapons is not supported yet.<br>Please manually add {weaponDamage} damage to the appropriate hit location, AP is not subtracted from {weaponDamage}.<br>Then close this notification."
+      },
+      "ResistanceRequest": {
+        "Roll": "Roll"
       }
     },
     "Dialog": {
@@ -588,6 +592,22 @@
           "6": "Very simple action (*6)"
         }
       },
+      "ResistanceRoll": {
+        "Title": "Resistance Roll",
+        "Active": "Active",
+        "Passive": "Passive",
+        "TokenOrActor": "Token/Actor",
+        "SourceManual": "Manual value...",
+        "Characteristic": "Characteristic",
+        "ManualName": "Name",
+        "ManualLabel": "Label",
+        "ManualValue": "Value"
+      },
+      "ResistanceRequest": {
+        "Title": "Request Resistance Roll",
+        "ModifierDefaults": "Modifier defaults (recipient may change)",
+        "SendRequest": "Send Request"
+      },
       "SpiritMagicRoll": {
         "Title": "Cast Spirit Magic",
         "LevelUsed": "Level",
@@ -648,6 +668,7 @@
         "TargetedToken": "targeted token",
         "Tokens": "tokens",
         "Actors": "actors",
+        "Other": "other",
         "AugmentOptions": {
           "None": "None",
           "CriticalSuccess": "Critical Success +50%",
@@ -1098,6 +1119,11 @@
         "Points": "Points",
         "Ritual": "Ritual",
         "Enchantment": "Enchantment",
+        "ResistanceCheck": "Resistance Check",
+        "ResistanceCheckEnum": {
+          "none": "None",
+          "single": "Single target (POW vs POW)"
+        },
         "DurationEnum": {
           "undefined": "None",
           "instant": "Instant",
@@ -1218,6 +1244,11 @@
           "6": "very simple action"
         }
       },
+      "ResistanceRoll": {
+        "Title": "Resistance Roll",
+        "Vs": "vs",
+        "Opposes": "opposes {targetName}"
+      },
       "HitLocationRoll": {
         "FallbackHitLocationName": "Hit Location"
       },
@@ -1322,6 +1353,7 @@
       "RollCharacteristicQuick": "Direct Roll *5 (dbl click)",
       "RollTitle": "Roll via Dialog (click), Direct Roll (dbl click)",
       "InitiateCombat": "Initiate combat",
+      "RequestResistanceRoll": "Request Resistance Roll",
       "WeaponUsage": {
         "oneHand": "1H",
         "offHand": "offH",
@@ -1504,6 +1536,10 @@
       "ShowActorActiveEffectsTab": {
         "settingName": "Show Actor Active Effects Tab",
         "settingHint": "If enabled, a GM-only Active Effects debug tab is shown on the actor sheet."
+      },
+      "ShowResistanceRequestTokenHudButton": {
+        "settingName": "Resistance Request Button on Token HUD",
+        "settingHint": "If enabled, GMs get a 'Request Resistance Roll' button on the Token HUD to start a resistance request straight from a token on the canvas."
       },
       "TokenRulerSettings": {
         "dialogTitle": "Token Ruler Settings",

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -1120,10 +1120,14 @@
         "Points": "Points",
         "Ritual": "Ritual",
         "Enchantment": "Enchantment",
-        "ResistanceCheck": "Resistance Check",
-        "ResistanceCheckEnum": {
+        "ResistedBy": "Resisted By",
+        "ResistedByEnum": {
           "none": "None",
-          "single": "Single target (POW vs POW)"
+          "resistanceRoll": "Resistance roll (single target)",
+          "resistanceRollArea": "Resistance roll, whole area (not yet automated)",
+          "resistanceRollPerTarget": "Resistance roll, per target (not yet automated)",
+          "spiritCombatRound": "Spirit combat, one round (not yet automated)",
+          "spiritCombatDefeat": "Spirit combat, until defeated (not yet automated)"
         },
         "DurationEnum": {
           "undefined": "None",

--- a/static/system.json
+++ b/static/system.json
@@ -56,7 +56,8 @@
       "character": {}
     },
     "ChatMessage": {
-      "combat": {}
+      "combat": {},
+      "resistanceRequest": {}
     },
     "Item": {
       "armor": {},


### PR DESCRIPTION
Closes #1068. Stacked on `feat/758-resistance-rolls` (#1067) — retarget to `main` once that merges.

## Why

#1067 added a shared spell field for the POW-vs-POW resistance step as `resistanceCheck` (`SpellResistanceCheckEnum = { None, Single }`). Before more is built on it:

- the field now also has to describe **spirit-combat gates**, which aren't "resistance checks" in the RAW sense;
- `single` / `areaOneRoll` / `perTarget` mix three different framings;
- the area / per-target / spirit-combat modes should be **declared now** so pack content is authored once.

This is pure data-model + naming work, no behaviour change, no migration (nothing released). Splitting it out of #1066 keeps that issue focused on the targeting/agency refactor, and unblocks the 147-template content migration in `sun-dragon-cult/fvtt-module-wiki-rqg-private#18` (its `validate:schemas` fetches this enum live).

## What

**Rename** `resistanceCheck` → `resistedBy`, `SpellResistanceCheckEnum` → `SpellResistedByEnum`, helper file `spell-resistance-check.ts` → `spell-resisted-by.ts`, sheet context `resistanceCheckOptions` → `resistedByOptions`, i18n `RQG.Item.Spell.ResistanceCheck*` → `ResistedBy*`. Regenerated `runeMagic` / `spiritMagic` JSON schemas.

**Enum** — declare all six, implement two:

| value | status |
| --- | --- |
| `none` | implemented (default) |
| `resistanceRoll` | implemented (was `single`) |
| `resistanceRollArea` | declared, inert |
| `resistanceRollPerTarget` | declared, inert |
| `spiritCombatRound` | declared, inert |
| `spiritCombatDefeat` | declared, inert |

`maybePromptResistanceRollForCast` keeps its guard — acts only on `resistanceRoll`, returns for everything else — so the four new values are accepted by the schema and cause no cast-time behaviour. The spell sheet select shows all six; the unimplemented four are labelled `(not yet automated)`.

Two spirit-combat values because RQG has two mechanically distinct gates: one won round (target willing/weak, e.g. Bind Ghost) vs. driven to 0 MP (e.g. Spirit Binding, Control).

## Not in scope

- Implementing the area / per-target targeting and the `spiritCombat*` hooks.
- Turn Undead's POW-vs-magic-points — that's a future orthogonal `resistedWith: "pow" | "magicPoints"` field, to land with `resistanceRollPerTarget`, **not** another enum value.
- The challenge-to-target / `Accepted` / pre-cast target-resolution work in #1066.

## Checks

`pnpm lint`, `pnpm typecheck`, `pnpm test` (789), `pnpm i18n:audit:en` (0 unused / 0 missing), `pnpm check:schemas`, `pnpm build:verify` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
