### PR TITLE
refactor: rename spell `resistanceCheck` → `resistedBy` and settle the enum shape

### DIFF
--- a/buildScripts/i18n-dynamic-key-map.ts
+++ b/buildScripts/i18n-dynamic-key-map.ts
@@ -34,7 +34,7 @@ import {
   SpellRangeEnum,
   SpellDurationEnum,
   SpellConcentrationEnum,
-  SpellResistanceCheckEnum,
+  SpellResistedByEnum,
 } from "../src/data-model/item-data/spell";
 import { AbilitySuccessLevelEnum } from "../src/rolls/ability-roll/ability-roll.defs";
 
@@ -147,7 +147,7 @@ export const dynamicKeyMap: Record<string, readonly string[]> = {
     "undefined",
   ],
   "RQG.Item.Spell.RangeEnum.": [...Object.values(SpellRangeEnum).filter(Boolean), "undefined"],
-  "RQG.Item.Spell.ResistanceCheckEnum.": [...Object.values(SpellResistanceCheckEnum)],
+  "RQG.Item.Spell.ResistedByEnum.": [...Object.values(SpellResistedByEnum)],
 
   // Item - Weapon
   "RQG.Item.Weapon.combatManeuver.": [...combatManeuverNames],

--- a/src/data-model/item-data/rune-magic-data-model.ts
+++ b/src/data-model/item-data/rune-magic-data-model.ts
@@ -2,7 +2,7 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
-import { maybePromptResistanceRollForCast } from "../shared/spell-resistance-check";
+import { maybePromptResistanceRollForCast } from "../shared/spell-resisted-by";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { rqidLinkArraySchemaField } from "../shared/rqid-link-field";
@@ -353,7 +353,7 @@ export class RuneMagicDataModel extends RqgItemDataModel<RuneMagicSchema, { chan
     );
 
     await maybePromptResistanceRollForCast(
-      this.resistanceCheck,
+      this.resistedBy,
       runeMagicRoll.successLevel,
       casterActor,
       token,

--- a/src/data-model/item-data/spell.ts
+++ b/src/data-model/item-data/spell.ts
@@ -32,12 +32,23 @@ export const SpellConcentrationEnum = {
 export type SpellConcentrationEnum =
   (typeof SpellConcentrationEnum)[keyof typeof SpellConcentrationEnum];
 
-export const SpellResistanceCheckEnum = {
+// How an unwilling target can stop a spell taking effect. Only `None` and `ResistanceRoll` are
+// implemented; the rest are declared so content is authored once, and are inert (treated as "no
+// automated step") until their own issues wire them up - see #1068.
+export const SpellResistedByEnum = {
   None: "none",
-  Single: "single",
+  // one resistance roll, single target
+  ResistanceRoll: "resistanceRoll",
+  // caster rolls one d100; every target in the radius is checked against that one roll
+  ResistanceRollArea: "resistanceRollArea",
+  // a separate resistance roll per target in the area
+  ResistanceRollPerTarget: "resistanceRollPerTarget",
+  // gated on winning one round of spirit combat (target typically willing/weak - e.g. Bind Ghost)
+  SpiritCombatRound: "spiritCombatRound",
+  // gated on driving the target to 0 magic points in spirit combat (e.g. Spirit Binding, Control X)
+  SpiritCombatDefeat: "spiritCombatDefeat",
 } as const;
-export type SpellResistanceCheckEnum =
-  (typeof SpellResistanceCheckEnum)[keyof typeof SpellResistanceCheckEnum];
+export type SpellResistedByEnum = (typeof SpellResistedByEnum)[keyof typeof SpellResistedByEnum];
 
 // Se core book p247
 export interface Spell {
@@ -49,7 +60,7 @@ export interface Spell {
   isRitual: boolean;
   /** Requires POW sacrifice by caster (possibly from others see core book p249) */
   isEnchantment: boolean;
-  /** Whether a successful cast triggers a POW-vs-POW resistance roll by the target. */
-  resistanceCheck: SpellResistanceCheckEnum;
+  /** How an unwilling target can resist the spell after a successful cast (p.145-147, 254) */
+  resistedBy: SpellResistedByEnum;
   descriptionRqidLink: RqidLink | undefined;
 }

--- a/src/data-model/item-data/spirit-magic-data-model.ts
+++ b/src/data-model/item-data/spirit-magic-data-model.ts
@@ -2,7 +2,7 @@ import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
 import { RqgItemDataModel } from "./rqg-item-data-model";
 import { migrateSpellBooleanFields, spellSchemaFields } from "../shared/spell-schema-fields";
-import { maybePromptResistanceRollForCast } from "../shared/spell-resistance-check";
+import { maybePromptResistanceRollForCast } from "../shared/spell-resisted-by";
 import type { RqidLink } from "../shared/rqid-link";
 import type { RqidString } from "../../system/api/rqid-api";
 import { RqgError, localize, assertDocumentSubType } from "../../system/util";
@@ -170,7 +170,7 @@ export class SpiritMagicDataModel extends RqgItemDataModel<SpiritMagicSchema> {
     );
 
     await maybePromptResistanceRollForCast(
-      this.resistanceCheck,
+      this.resistedBy,
       spiritMagicRoll.successLevel,
       casterActor,
       token,

--- a/src/data-model/json-schemas/generated/item/runeMagic.schema.json
+++ b/src/data-model/json-schemas/generated/item/runeMagic.schema.json
@@ -50,11 +50,15 @@
       "type": "boolean",
       "default": false
     },
-    "resistanceCheck": {
+    "resistedBy": {
       "type": "string",
       "enum": [
         "none",
-        "single"
+        "resistanceRoll",
+        "resistanceRollArea",
+        "resistanceRollPerTarget",
+        "spiritCombatRound",
+        "spiritCombatDefeat"
       ],
       "minLength": 1,
       "default": "none"
@@ -134,7 +138,7 @@
     "concentration",
     "isRitual",
     "isEnchantment",
-    "resistanceCheck",
+    "resistedBy",
     "cultId",
     "runeRqidLinks",
     "isStackable",

--- a/src/data-model/json-schemas/generated/item/spiritMagic.schema.json
+++ b/src/data-model/json-schemas/generated/item/spiritMagic.schema.json
@@ -50,11 +50,15 @@
       "type": "boolean",
       "default": false
     },
-    "resistanceCheck": {
+    "resistedBy": {
       "type": "string",
       "enum": [
         "none",
-        "single"
+        "resistanceRoll",
+        "resistanceRollArea",
+        "resistanceRollPerTarget",
+        "spiritCombatRound",
+        "spiritCombatDefeat"
       ],
       "minLength": 1,
       "default": "none"
@@ -114,7 +118,7 @@
     "concentration",
     "isRitual",
     "isEnchantment",
-    "resistanceCheck",
+    "resistedBy",
     "isVariable",
     "incompatibleWith",
     "spellFocus",

--- a/src/data-model/shared/spell-resisted-by.ts
+++ b/src/data-model/shared/spell-resisted-by.ts
@@ -1,21 +1,23 @@
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import { warnIfMultipleTargets } from "../../system/util";
 import { AbilitySuccessLevelEnum } from "../../rolls/ability-roll/ability-roll.defs";
-import { SpellResistanceCheckEnum } from "../item-data/spell";
+import { SpellResistedByEnum } from "../item-data/spell";
 
 /**
  * Post-cast hook for Rune/Spirit Magic: on a successful cast of a resisted spell, open a
  * POW-vs-POW ResistanceRollDialogV2 caster-vs-target. No-op with no target; warns on multiple.
+ * Only `ResistanceRoll` is handled; the area / spirit-combat modes are inert until #1068's
+ * follow-ups wire them up.
  */
 export async function maybePromptResistanceRollForCast(
-  resistanceCheck: SpellResistanceCheckEnum,
+  resistedBy: SpellResistedByEnum,
   castSuccessLevel: AbilitySuccessLevelEnum,
   casterActor: RqgActor,
   token: TokenDocument | null | undefined,
   spellName: string | undefined,
 ): Promise<void> {
   if (
-    resistanceCheck !== SpellResistanceCheckEnum.Single ||
+    resistedBy !== SpellResistedByEnum.ResistanceRoll ||
     castSuccessLevel > AbilitySuccessLevelEnum.Success
   ) {
     return;

--- a/src/data-model/shared/spell-schema-fields.ts
+++ b/src/data-model/shared/spell-schema-fields.ts
@@ -3,7 +3,7 @@ import {
   SpellConcentrationEnum,
   SpellDurationEnum,
   SpellRangeEnum,
-  SpellResistanceCheckEnum,
+  SpellResistedByEnum,
 } from "../item-data/spell";
 import { enumChoices } from "./enum-choices";
 
@@ -36,11 +36,11 @@ export function spellSchemaFields() {
     }),
     isRitual: new BooleanField({ nullable: false, initial: false }),
     isEnchantment: new BooleanField({ nullable: false, initial: false }),
-    resistanceCheck: new StringField({
+    resistedBy: new StringField({
       blank: false,
       nullable: false,
-      initial: SpellResistanceCheckEnum.None,
-      choices: enumChoices(SpellResistanceCheckEnum, "RQG.Item.Spell.ResistanceCheckEnum."),
+      initial: SpellResistedByEnum.None,
+      choices: enumChoices(SpellResistedByEnum, "RQG.Item.Spell.ResistedByEnum."),
     }),
     descriptionRqidLink: rqidLinkSchemaField({ nullable: true }),
   } as const;

--- a/src/items/rune-magic-item/rune-magic-sheet-v2-rune-magic.hbs
+++ b/src/items/rune-magic-item/rune-magic-sheet-v2-rune-magic.hbs
@@ -18,9 +18,9 @@
     <input type="checkbox" id="is-enchantment-{{id}}" name="system.isEnchantment" {{checked
       system.isEnchantment}}>
 
-    <label for="resistance-check-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistanceCheck"}}</label>
-    <select id="resistance-check-{{id}}" name="system.resistanceCheck">
-      {{selectOptions resistanceCheckOptions selected=system.resistanceCheck localize=true}}
+    <label for="resisted-by-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistedBy"}}</label>
+    <select id="resisted-by-{{id}}" name="system.resistedBy">
+      {{selectOptions resistedByOptions selected=system.resistedBy localize=true}}
     </select>
 
     <label for="is-stackable-{{id}}">{{localize "RQG.Item.RuneMagic.Stackable"}}</label>

--- a/src/items/rune-magic-item/rune-magic-sheet-v2.ts
+++ b/src/items/rune-magic-item/rune-magic-sheet-v2.ts
@@ -1,7 +1,7 @@
 import { ItemTypeEnum } from "@item-model/item-types.ts";
 import { getSelectRuneOptions, isDocumentSubType } from "../../system/util";
 import { RqgItemSheetV2, type RqgItemSheetContext } from "../rqg-item-sheet-v2";
-import { SpellDurationEnum, SpellRangeEnum, SpellResistanceCheckEnum } from "@item-model/spell.ts";
+import { SpellDurationEnum, SpellRangeEnum, SpellResistedByEnum } from "@item-model/spell.ts";
 import { systemId } from "../../system/config";
 import { templatePaths } from "../../system/load-handlebars-templates";
 import type { CultItem } from "@item-model/cult-data-model.ts";
@@ -12,7 +12,7 @@ interface RuneMagicSheetContext extends RqgItemSheetContext {
   allRuneOptions: SelectOptionData<string>[];
   rangeOptions: SelectOptionData<SpellRangeEnum>[];
   durationOptions: SelectOptionData<SpellDurationEnum>[];
-  resistanceCheckOptions: SelectOptionData<SpellResistanceCheckEnum>[];
+  resistedByOptions: SelectOptionData<SpellResistedByEnum>[];
   actorCultOptions: SelectOptionData<string>[];
 }
 
@@ -59,9 +59,9 @@ export class RuneMagicSheetV2 extends RqgItemSheetV2 {
         value: range,
         label: "RQG.Item.Spell.DurationEnum." + (range || "undefined"),
       })),
-      resistanceCheckOptions: Object.values(SpellResistanceCheckEnum).map((value) => ({
+      resistedByOptions: Object.values(SpellResistedByEnum).map((value) => ({
         value: value,
-        label: "RQG.Item.Spell.ResistanceCheckEnum." + value,
+        label: "RQG.Item.Spell.ResistedByEnum." + value,
       })),
       actorCultOptions: this.getActorCultOptions(),
       allRuneOptions: getSelectRuneOptions("RQG.Item.RuneMagic.AddRuneMagicRunePlaceholder"),

--- a/src/items/spirit-magic-item/spirit-magic-sheet-v2-spirit-magic.hbs
+++ b/src/items/spirit-magic-item/spirit-magic-sheet-v2-spirit-magic.hbs
@@ -28,9 +28,9 @@
     <label for="is-enchantment-{{id}}">{{localize "RQG.Item.Spell.Enchantment"}}</label>
     <input type="checkbox" id="is-enchantment-{{id}}" name="system.isEnchantment" {{checked system.isEnchantment}}>
 
-    <label for="resistance-check-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistanceCheck"}}</label>
-    <select id="resistance-check-{{id}}" name="system.resistanceCheck">
-      {{selectOptions resistanceCheckOptions selected=system.resistanceCheck localize=true}}
+    <label for="resisted-by-{{id}}" class="mp">{{localize "RQG.Item.Spell.ResistedBy"}}</label>
+    <select id="resisted-by-{{id}}" name="system.resistedBy">
+      {{selectOptions resistedByOptions selected=system.resistedBy localize=true}}
     </select>
 
     <label for="is-matrix-{{id}}">{{localize "RQG.Item.SpiritMagic.MatrixQ"}}</label>

--- a/src/items/spirit-magic-item/spirit-magic-sheet-v2.ts
+++ b/src/items/spirit-magic-item/spirit-magic-sheet-v2.ts
@@ -3,7 +3,7 @@ import {
   SpellConcentrationEnum,
   SpellDurationEnum,
   SpellRangeEnum,
-  SpellResistanceCheckEnum,
+  SpellResistedByEnum,
 } from "@item-model/spell.ts";
 import { systemId } from "../../system/config";
 import { templatePaths } from "../../system/load-handlebars-templates";
@@ -13,7 +13,7 @@ interface SpiritMagicSheetContext extends RqgItemSheetContext {
   rangeOptions: SelectOptionData<SpellRangeEnum>[];
   durationOptions: SelectOptionData<SpellDurationEnum>[];
   concentrationOptions: SelectOptionData<SpellConcentrationEnum>[];
-  resistanceCheckOptions: SelectOptionData<SpellResistanceCheckEnum>[];
+  resistedByOptions: SelectOptionData<SpellResistedByEnum>[];
 }
 
 export class SpiritMagicSheetV2 extends RqgItemSheetV2 {
@@ -63,9 +63,9 @@ export class SpiritMagicSheetV2 extends RqgItemSheetV2 {
         value: range,
         label: "RQG.Item.Spell.ConcentrationEnum." + (range || "undefined"),
       })),
-      resistanceCheckOptions: Object.values(SpellResistanceCheckEnum).map((value) => ({
+      resistedByOptions: Object.values(SpellResistedByEnum).map((value) => ({
         value: value,
-        label: "RQG.Item.Spell.ResistanceCheckEnum." + value,
+        label: "RQG.Item.Spell.ResistedByEnum." + value,
       })),
     };
 

--- a/static/i18n/en/uiContent.json
+++ b/static/i18n/en/uiContent.json
@@ -1123,10 +1123,14 @@
         "Points": "Points",
         "Ritual": "Ritual",
         "Enchantment": "Enchantment",
-        "ResistanceCheck": "Resistance Check",
-        "ResistanceCheckEnum": {
+        "ResistedBy": "Resisted By",
+        "ResistedByEnum": {
           "none": "None",
-          "single": "Single target (POW vs POW)"
+          "resistanceRoll": "Resistance roll (single target)",
+          "resistanceRollArea": "Resistance roll, whole area (not yet automated)",
+          "resistanceRollPerTarget": "Resistance roll, per target (not yet automated)",
+          "spiritCombatRound": "Spirit combat, one round (not yet automated)",
+          "spiritCombatDefeat": "Spirit combat, until defeated (not yet automated)"
         },
         "DurationEnum": {
           "undefined": "None",


### PR DESCRIPTION
Closes #1068.

Pure data-model / naming work, no behavioural change and no migration (nothing released, no legacy `requiresResistanceRoll` left).

## Changes

- **Rename** `resistanceCheck` → `resistedBy` on both spell data models, `SpellResistanceCheckEnum` → `SpellResistedByEnum`, helper file `spell-resistance-check.ts` → `spell-resisted-by.ts`, sheet context `resistanceCheckOptions` → `resistedByOptions`, i18n `RQG.Item.Spell.ResistanceCheck*` → `ResistedBy*`, and the `i18n-dynamic-key-map` prefix.
- **Enum shape** — declare all six values, implement two:
  - `none`, `resistanceRoll` (was `single`) — implemented
  - `resistanceRollArea`, `resistanceRollPerTarget`, `spiritCombatRound`, `spiritCombatDefeat` — declared, inert until their own issues; sheet select labels them "(not yet automated)"
- `maybePromptResistanceRollForCast` keeps its guard (acts only on `resistanceRoll`).
- Regenerated `runeMagic` / `spiritMagic` JSON schemas.

Unblocks the 147-template content migration in `sun-dragon-cult/fvtt-module-wiki-rqg-private#18`.

## Checks

`typecheck`, `lint`, `test`, `i18n:audit:en`, `check:schemas` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)