### PR TITLE
fix: attack dialog follows the target when retargeting while open

### DIFF
--- a/src/applications/attack-flow/attack-dialog-v2.ts
+++ b/src/applications/attack-flow/attack-dialog-v2.ts
@@ -15,6 +15,7 @@ import {
   normalizeOtherModifierDescriptionForRoll,
   requireValue,
   toSignedString,
+  warnIfMultipleTargets,
 } from "../../system/util";
 import type { RqgActor } from "@actors/rqg-actor.ts";
 import type { RqgItem } from "@items/rqg-item.ts";
@@ -52,6 +53,11 @@ export class AttackDialogV2 extends RqgInteractiveRollApplicationBase {
   ): boolean {
     const damageFormula = weaponItem.system.usage[usageType]?.damage ?? "";
     return /db(\/2)?/i.test(damageFormula.replaceAll(" ", ""));
+  }
+
+  /** Aimed blow options come from the target's hit locations, so a select can't be patched in place. */
+  protected override onUserTargetsChanged(): void {
+    void this.render();
   }
 
   protected override getLivePreviewFormBehaviorConfig() {
@@ -293,9 +299,7 @@ export class AttackDialogV2 extends RqgInteractiveRollApplicationBase {
       ? -Math.floor(naturalAttackChance / 2)
       : 0;
 
-    if ((game.user?.targets.size ?? 0) > 1) {
-      ui.notifications?.info("Please target one token only");
-    }
+    warnIfMultipleTargets();
 
     const target = game.user?.targets.first();
 
@@ -317,6 +321,11 @@ export class AttackDialogV2 extends RqgInteractiveRollApplicationBase {
     formData.proneAttackerPrev = rawProneAttackerPrev === true || rawProneAttackerPrev === "true";
     formData.hitLocationFormulaBeforeProne ??= "1d20";
     formData.aimedBlow = formData.aimedBlow ? Number(formData.aimedBlow) : 0;
+
+    const aimedBlowOptions = AttackDialogV2.getAimedBlowOptions(target);
+    if (!aimedBlowOptions.some((option) => option.value === formData.aimedBlow)) {
+      formData.aimedBlow = 0;
+    }
 
     const proneAttacker = !!formData.proneAttacker;
 
@@ -358,7 +367,7 @@ export class AttackDialogV2 extends RqgInteractiveRollApplicationBase {
       augmentOptions: AttackDialogV2.augmentOptions,
       damageBonusSourceOptions: damageBonusSourceOptions,
       hitLocationFormulaOptions: AttackDialogV2.getHitLocationFormulaOptions(formData.aimedBlow),
-      aimedBlowOptions: AttackDialogV2.getAimedBlowOptions(target),
+      aimedBlowOptions: aimedBlowOptions,
       weaponIsNatural: this.weaponItem.system.isNatural,
       selectedWeaponUsageHasDamageBonus: selectedWeaponUsageHasDamageBonus,
       isSelectedWeaponBroken: !hasValidSkillForSelectedUsage,
@@ -655,9 +664,7 @@ export class AttackDialogV2 extends RqgInteractiveRollApplicationBase {
 
     const target = game.user?.targets.first();
 
-    if ((game.user?.targets.size ?? 0) > 1) {
-      ui.notifications?.info("Please target one token only");
-    }
+    warnIfMultipleTargets();
 
     const hitLocationRollOptions: HitLocationRollOptions = {
       hitLocationNames: [], // hitLocationNames are added in defenceDialog when the target definitely selected


### PR DESCRIPTION
Fixes #1072

## What

`AttackDialogV2` read the user's target once, in `_prepareContext`, and never again. Leaving the dialog open across repeated attacks and retargeting on the canvas left it showing the previous target's name, and — worse — that target's hit locations in the aimed blow list.

- **Re-render on retarget.** Override `onUserTargetsChanged()` from `RqgInteractiveRollApplicationBase` (added in #1071) with a full `render()` rather than an in-place patch, because the aimed blow options drive a `<select>`. The base class already registers the user-filtered `targetToken` hook and tears it down on close, so no extra plumbing was needed.
- **Drop a stale aimed blow.** Retargeting can strand `formData.aimedBlow` on a `dieFrom` the new target has no hit location for, so `_prepareContext` resets it to 0 when it is not among the new options. Untargeting takes the same path, since the options list is then empty.
- **Localize the multi-target warning.** Both hardcoded `"Please target one token only"` strings replaced with `warnIfMultipleTargets()`, which uses the existing `RQG.Notification.Warn.TargetOneTokenOnly` key (AGENTS.md rule 5). Behaviour is unchanged: still info-level, and the attack still proceeds. Whether a multi-target attack should be *blocked* is left as the separate question the issue raises.

## On the focus cost

The issue flagged that a re-render costs the focus of any field being typed into. Values typed into Ammo Quantity or the Other modifier do survive it, since `_prepareContext` reads the live form via `FormDataExtended` before rebuilding. Focus itself is lost, but retargeting requires a canvas interaction that has already taken focus out of the input, so there is no realistic mid-typing case. Foundry serializes renders through a semaphore, so the two hook fires of a retarget (untarget old, target new) cannot interleave.

## Validation

`pnpm lint:scripts`, `pnpm test` (841 passed), `pnpm typecheck` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)